### PR TITLE
auth: only listen on localhost

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,7 +57,7 @@ export const auth = async ({ oauthHost, clientId }: AuthProps) => {
   // Start HTTP server and wait till /callback is hit
   //
   const server = createServer();
-  server.listen(0, function (this: typeof server) {
+  server.listen(0, 'localhost', function (this: typeof server) {
     log.info(`Listening on port ${(this.address() as AddressInfo).port}`);
   });
   const listen_port = (server.address() as AddressInfo).port;


### PR DESCRIPTION
it does not seem necessary that we will need to listen on 0.0.0.0. First of all, users will get this popup on macOS

<img width="260" alt="image" src="https://github.com/neondatabase/neonctl/assets/4198311/7952d023-76be-45a0-9563-c3c91783261a">

secondly, it does not look safe if user approved it as we get some server exposed on local network?

I haven't tested it locally and just searched for how to pass localhost to `.listen`, so this might not compile. Waiting on CI... Thanks for reviews!