### PR TITLE
feat: --psql flag for providing psql connection to db

### DIFF
--- a/mocks/bin/psql
+++ b/mocks/bin/psql
@@ -1,0 +1,1 @@
+psql.cjs

--- a/mocks/bin/psql.cjs
+++ b/mocks/bin/psql.cjs
@@ -1,0 +1,9 @@
+#! /usr/bin/env node
+
+// A psql mock that just prints its arguments (as an array in an object) to stdout.
+// Node.js script should have an extension (otherwise ERR_UNKNOWN_FILE_EXTENSION is thrown), so we use a symlink psql -> psql.cjs
+if (require.main === module) {
+    process.stdout.write(
+        JSON.stringify({'psql-cli-args': process.argv.slice(2)})
+    );
+}

--- a/mocks/main/projects/test/branches/POST.js
+++ b/mocks/main/projects/test/branches/POST.js
@@ -64,6 +64,9 @@ export default function (req, res) {
         created_at: '2021-01-01T00:00:00.000Z',
         host: `${endpoint.name}.example.com`,
       }));
+      result.connection_uris = req.body.endpoints.map((endpoint) => ({
+        connection_uri: `postgres://ep-${endpoint.name}-123456.example.com:5432/test_project`,
+      }));
     }
     res.send(result);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neonctl",
-  "version": "1.18.0",
+  "version": "1.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neonctl",
-      "version": "1.18.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@neondatabase/api-client": "1.1.0",
@@ -18,6 +18,7 @@
         "inquirer": "^9.2.6",
         "open": "^8.4.0",
         "openid-client": "^5.1.9",
+        "which": "^3.0.1",
         "yaml": "^2.1.1",
         "yargs": "^17.7.2"
       },
@@ -39,6 +40,7 @@
         "@types/express": "^4.17.17",
         "@types/inquirer": "^9.0.3",
         "@types/node": "^18.7.13",
+        "@types/which": "^3.0.0",
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^5.34.0",
         "@typescript-eslint/parser": "^5.34.0",
@@ -3350,6 +3352,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/which": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -4739,6 +4747,21 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -6538,7 +6561,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -14677,17 +14699,17 @@
       }
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -17326,6 +17348,12 @@
         "@types/node": "*"
       }
     },
+    "@types/which": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -18260,6 +18288,17 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypto-random-string": {
@@ -19508,8 +19547,7 @@
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "issue-parser": {
       "version": "6.0.0",
@@ -25185,8 +25223,9 @@
       }
     },
     "which": {
-      "version": "2.0.2",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/express": "^4.17.17",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^18.7.13",
+    "@types/which": "^3.0.0",
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.34.0",
     "@typescript-eslint/parser": "^5.34.0",
@@ -60,6 +61,7 @@
     "inquirer": "^9.2.6",
     "open": "^8.4.0",
     "openid-client": "^5.1.9",
+    "which": "^3.0.1",
     "yaml": "^2.1.1",
     "yargs": "^17.7.2"
   },

--- a/snapshots/commands/branches.test.snap
+++ b/snapshots/commands/branches.test.snap
@@ -8,6 +8,10 @@ type: read_only
 "
 `;
 
+exports[`branches create branch and connect with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project","-c","SELECT 1"]}"`;
+
+exports[`branches create branch and connect with psql test 1`] = `"{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project"]}"`;
+
 exports[`branches create by default with r/w endpoint test 1`] = `
 "branch:
   id: br-new-branch-123456
@@ -18,6 +22,8 @@ endpoints:
     type: read_write
     created_at: 2021-01-01T00:00:00.000Z
     host: undefined.example.com
+connection_uris:
+  - connection_uri: postgres://ep-undefined-123456.example.com:5432/test_project
 "
 `;
 
@@ -55,6 +61,8 @@ endpoints:
     type: read_only
     created_at: 2021-01-01T00:00:00.000Z
     host: undefined.example.com
+connection_uris:
+  - connection_uri: postgres://ep-undefined-123456.example.com:5432/test_project
 "
 `;
 

--- a/snapshots/commands/branches.test.snap
+++ b/snapshots/commands/branches.test.snap
@@ -8,9 +8,35 @@ type: read_only
 "
 `;
 
-exports[`branches create branch and connect with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project","-c","SELECT 1"]}"`;
+exports[`branches create branch and connect with psql and psql args test 1`] = `
+"branch:
+  id: br-new-branch-123456
+  name: test_branch
+  created_at: 2021-01-01T00:00:00.000Z
+endpoints:
+  - id: ep-undefined-123456
+    type: read_write
+    created_at: 2021-01-01T00:00:00.000Z
+    host: undefined.example.com
+connection_uris:
+  - connection_uri: postgres://ep-undefined-123456.example.com:5432/test_project
+{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project","-c","SELECT 1"]}"
+`;
 
-exports[`branches create branch and connect with psql test 1`] = `"{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project"]}"`;
+exports[`branches create branch and connect with psql test 1`] = `
+"branch:
+  id: br-new-branch-123456
+  name: test_branch
+  created_at: 2021-01-01T00:00:00.000Z
+endpoints:
+  - id: ep-undefined-123456
+    type: read_write
+    created_at: 2021-01-01T00:00:00.000Z
+    host: undefined.example.com
+connection_uris:
+  - connection_uri: postgres://ep-undefined-123456.example.com:5432/test_project
+{"psql-cli-args":["postgres://ep-undefined-123456.example.com:5432/test_project"]}"
+`;
 
 exports[`branches create by default with r/w endpoint test 1`] = `
 "branch:

--- a/snapshots/commands/connection_string.test.snap
+++ b/snapshots/commands/connection_string.test.snap
@@ -40,6 +40,10 @@ exports[`connection_string connection_string test 1`] = `
 "
 `;
 
+exports[`connection_string connection_string with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db","-c","SELECT 1"]}"`;
+
+exports[`connection_string connection_string with psql test 1`] = `"{"psql-cli-args":["postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db"]}"`;
+
 exports[`connection_string connection_string without any args should pass test 1`] = `
 "postgres://test_role:password@undefined/db1
 "

--- a/snapshots/commands/projects.test.snap
+++ b/snapshots/commands/projects.test.snap
@@ -1,8 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`projects create and connect with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://localhost:5432/test_project","-c","SELECT 1"]}"`;
+exports[`projects create and connect with psql and psql args test 1`] = `
+"project:
+  id: new-project-123456
+  name: test_project
+  created_at: 2021-01-01T00:00:00.000Z
+connection_uris:
+  - connection_uri: postgres://localhost:5432/test_project
+{"psql-cli-args":["postgres://localhost:5432/test_project","-c","SELECT 1"]}"
+`;
 
-exports[`projects create and connect with psql test 1`] = `"{"psql-cli-args":["postgres://localhost:5432/test_project"]}"`;
+exports[`projects create and connect with psql test 1`] = `
+"project:
+  id: new-project-123456
+  name: test_project
+  created_at: 2021-01-01T00:00:00.000Z
+connection_uris:
+  - connection_uri: postgres://localhost:5432/test_project
+{"psql-cli-args":["postgres://localhost:5432/test_project"]}"
+`;
 
 exports[`projects create test 1`] = `
 "project:

--- a/snapshots/commands/projects.test.snap
+++ b/snapshots/commands/projects.test.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`projects create and connect with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://localhost:5432/test_project","-c","SELECT 1"]}"`;
+
+exports[`projects create and connect with psql test 1`] = `"{"psql-cli-args":["postgres://localhost:5432/test_project"]}"`;
+
 exports[`projects create test 1`] = `
 "project:
   id: new-project-123456

--- a/src/commands/branches.test.ts
+++ b/src/commands/branches.test.ts
@@ -27,6 +27,47 @@ describe('branches', () => {
   });
 
   testCliCommand({
+    name: 'create branch and connect with psql',
+    args: [
+      'branches',
+      'create',
+      '--project-id',
+      'test',
+      '--name',
+      'test_branch',
+      '--psql',
+    ],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'create branch and connect with psql and psql args',
+    args: [
+      'branches',
+      'create',
+      '--project-id',
+      'test',
+      '--name',
+      'test_branch',
+      '--psql',
+      '--',
+      '-c',
+      'SELECT 1',
+    ],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
     name: 'create with readonly endpoint',
     args: [
       'branches',

--- a/src/commands/branches.test.ts
+++ b/src/commands/branches.test.ts
@@ -37,9 +37,6 @@ describe('branches', () => {
       'test_branch',
       '--psql',
     ],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },
@@ -59,9 +56,6 @@ describe('branches', () => {
       '-c',
       'SELECT 1',
     ],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -185,6 +185,26 @@ const create = async (
     })
   );
 
+  const out = writer(props);
+  out.write(data.branch, {
+    fields: BRANCH_FIELDS,
+    title: 'branch',
+  });
+
+  if (data.endpoints?.length > 0) {
+    out.write(data.endpoints, {
+      fields: ['id', 'created_at'],
+      title: 'endpoints',
+    });
+  }
+  if (data.connection_uris && data.connection_uris?.length > 0) {
+    out.write(data.connection_uris, {
+      fields: ['connection_uri'],
+      title: 'connection_uris',
+    });
+  }
+  out.end();
+
   if (props.psql) {
     if (!data.connection_uris || !data.connection_uris?.length) {
       throw new Error(`Branch ${data.branch.id} doesn't have a connection uri`);
@@ -192,26 +212,6 @@ const create = async (
     const connection_uri = data.connection_uris[0].connection_uri;
     const psqlArgs = props['--'];
     await psql(connection_uri, psqlArgs);
-  } else {
-    const out = writer(props);
-    out.write(data.branch, {
-      fields: BRANCH_FIELDS,
-      title: 'branch',
-    });
-
-    if (data.endpoints?.length > 0) {
-      out.write(data.endpoints, {
-        fields: ['id', 'created_at'],
-        title: 'endpoints',
-      });
-    }
-    if (data.connection_uris && data.connection_uris?.length > 0) {
-      out.write(data.connection_uris, {
-        fields: ['connection_uri'],
-        title: 'connection_uris',
-      });
-    }
-    out.end();
   }
 };
 

--- a/src/commands/connection_string.test.ts
+++ b/src/commands/connection_string.test.ts
@@ -150,9 +150,6 @@ describe('connection_string', () => {
       'test_role',
       '--psql',
     ],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },
@@ -174,9 +171,6 @@ describe('connection_string', () => {
       '-c',
       'SELECT 1',
     ],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },

--- a/src/commands/connection_string.test.ts
+++ b/src/commands/connection_string.test.ts
@@ -136,4 +136,49 @@ describe('connection_string', () => {
       snapshot: true,
     },
   });
+
+  testCliCommand({
+    name: 'connection_string with psql',
+    args: [
+      'connection-string',
+      'test_branch',
+      '--project-id',
+      'test',
+      '--database-name',
+      'test_db',
+      '--role-name',
+      'test_role',
+      '--psql',
+    ],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'connection_string with psql and psql args',
+    args: [
+      'connection-string',
+      'test_branch',
+      '--project-id',
+      'test',
+      '--database-name',
+      'test_db',
+      '--role-name',
+      'test_role',
+      '--psql',
+      '--',
+      '-c',
+      'SELECT 1',
+    ],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
 });

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -4,7 +4,7 @@ import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 import { showHelpMiddleware } from '../help.js';
 import { writer } from '../writer.js';
-import { psql, psqlArgs } from '../utils/psql.js';
+import { psql } from '../utils/psql.js';
 
 export const command = 'connection-string [branch]';
 export const aliases = ['cs'];
@@ -68,6 +68,7 @@ export const handler = async (
     extended: boolean;
     endpointType?: EndpointType;
     psql: boolean;
+    '--'?: string[];
   }
 ) => {
   const projectId = props.projectId;
@@ -150,7 +151,8 @@ export const handler = async (
   }
 
   if (props.psql) {
-    await psql(connectionString.toString(), psqlArgs(process.argv));
+    const psqlArgs = props['--'];
+    await psql(connectionString.toString(), psqlArgs);
   } else if (props.extended) {
     writer(props).end(
       {
@@ -163,6 +165,8 @@ export const handler = async (
       },
       { fields: ['host', 'role', 'password', 'database'] }
     );
+    const psqlArgs = props['--'];
+    await psql(connectionString.toString(), psqlArgs);
   } else {
     process.stdout.write(connectionString.toString() + '\n');
   }

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -4,6 +4,7 @@ import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 import { showHelpMiddleware } from '../help.js';
 import { writer } from '../writer.js';
+import { psql } from '../utils/psql.js';
 
 export const command = 'connection-string [branch]';
 export const aliases = ['cs'];
@@ -47,6 +48,10 @@ export const builder = (argv: yargs.Argv) => {
       extended: {
         type: 'boolean',
         describe: 'Show extended information',
+      },
+      psql: {
+        type: 'boolean',
+        describe: 'Connect to a database via psql using connection string',
         default: false,
       },
     })
@@ -62,6 +67,7 @@ export const handler = async (
     prisma: boolean;
     extended: boolean;
     endpointType?: EndpointType;
+    psql: boolean;
   }
 ) => {
   const projectId = props.projectId;
@@ -143,7 +149,9 @@ export const handler = async (
     }
   }
 
-  if (props.extended) {
+  if (props.psql) {
+    psql(connectionString.toString());
+  } else if (props.extended) {
     writer(props).end(
       {
         connection_string: connectionString.toString(),

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -165,8 +165,6 @@ export const handler = async (
       },
       { fields: ['host', 'role', 'password', 'database'] }
     );
-    const psqlArgs = props['--'];
-    await psql(connectionString.toString(), psqlArgs);
   } else {
     process.stdout.write(connectionString.toString() + '\n');
   }

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -4,7 +4,7 @@ import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 import { showHelpMiddleware } from '../help.js';
 import { writer } from '../writer.js';
-import { psql } from '../utils/psql.js';
+import { psql, psqlArgs } from '../utils/psql.js';
 
 export const command = 'connection-string [branch]';
 export const aliases = ['cs'];
@@ -150,7 +150,7 @@ export const handler = async (
   }
 
   if (props.psql) {
-    psql(connectionString.toString());
+    await psql(connectionString.toString(), psqlArgs(process.argv));
   } else if (props.extended) {
     writer(props).end(
       {

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -21,9 +21,6 @@ describe('projects', () => {
   testCliCommand({
     name: 'create and connect with psql',
     args: ['projects', 'create', '--name', 'test_project', '--psql'],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },
@@ -32,9 +29,6 @@ describe('projects', () => {
   testCliCommand({
     name: 'create and connect with psql and psql args',
     args: ['projects', 'create', '--name', 'test_project', '--psql', '--', '-c', 'SELECT 1'],
-    env: {
-      PATH: `mocks/bin:${process.env.PATH}`,
-    },
     expected: {
       snapshot: true,
     },

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -19,6 +19,28 @@ describe('projects', () => {
   });
 
   testCliCommand({
+    name: 'create and connect with psql',
+    args: ['projects', 'create', '--name', 'test_project', '--psql'],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'create and connect with psql and psql args',
+    args: ['projects', 'create', '--name', 'test_project', '--psql', '--', '-c', 'SELECT 1'],
+    env: {
+      PATH: `mocks/bin:${process.env.PATH}`,
+    },
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
     name: 'delete',
     args: ['projects', 'delete', 'test'],
     expected: {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -9,7 +9,7 @@ import { log } from '../log.js';
 import { projectCreateRequest } from '../parameters.gen.js';
 import { CommonProps, IdOrNameProps } from '../types.js';
 import { writer } from '../writer.js';
-import { psql, psqlArgs } from '../utils/psql.js';
+import { psql } from '../utils/psql.js';
 
 const PROJECT_FIELDS = ['id', 'name', 'region_id', 'created_at'] as const;
 
@@ -120,6 +120,7 @@ const create = async (
     name?: string;
     regionId?: string;
     psql: boolean;
+    '--'?: string[];
   }
 ) => {
   const project: ProjectCreateRequest['project'] = {};
@@ -135,7 +136,8 @@ const create = async (
 
   if (props.psql) {
     const connection_uri = data.connection_uris[0].connection_uri;
-    await psql(connection_uri, psqlArgs(process.argv));
+    const psqlArgs = props['--'];
+    await psql(connection_uri, psqlArgs);
   } else {
     const out = writer(props);
     out.write(data.project, { fields: PROJECT_FIELDS, title: 'Project' });

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -9,7 +9,7 @@ import { log } from '../log.js';
 import { projectCreateRequest } from '../parameters.gen.js';
 import { CommonProps, IdOrNameProps } from '../types.js';
 import { writer } from '../writer.js';
-import { psql } from '../utils/psql.js';
+import { psql, psqlArgs } from '../utils/psql.js';
 
 const PROJECT_FIELDS = ['id', 'name', 'region_id', 'created_at'] as const;
 
@@ -135,7 +135,7 @@ const create = async (
 
   if (props.psql) {
     const connection_uri = data.connection_uris[0].connection_uri;
-    psql(connection_uri);
+    await psql(connection_uri, psqlArgs(process.argv));
   } else {
     const out = writer(props);
     out.write(data.project, { fields: PROJECT_FIELDS, title: 'Project' });

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -134,18 +134,18 @@ const create = async (
     project,
   });
 
+  const out = writer(props);
+  out.write(data.project, { fields: PROJECT_FIELDS, title: 'Project' });
+  out.write(data.connection_uris, {
+    fields: ['connection_uri'],
+    title: 'Connection URIs',
+  });
+  out.end();
+
   if (props.psql) {
     const connection_uri = data.connection_uris[0].connection_uri;
     const psqlArgs = props['--'];
     await psql(connection_uri, psqlArgs);
-  } else {
-    const out = writer(props);
-    out.write(data.project, { fields: PROJECT_FIELDS, title: 'Project' });
-    out.write(data.connection_uris, {
-      fields: ['connection_uri'],
-      title: 'Connection URIs',
-    });
-    out.end();
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,9 @@ let builder = yargs(hideBin(process.argv));
 builder = builder
   .scriptName(pkg.name)
   .usage('$0 <command> [options]')
+  .parserConfiguration({
+    'populate--': true,
+  })
   .help()
   .option('output', {
     alias: 'o',

--- a/src/test_utils/test_cli_command.ts
+++ b/src/test_utils/test_cli_command.ts
@@ -16,6 +16,7 @@ export type TestCliCommandOptions = {
     stdout?: string | ReturnType<typeof expect.stringMatching>;
     stderr?: string | ReturnType<typeof expect.stringMatching>;
   };
+  env?: Record<string, string>;
 };
 
 export const testCliCommand = ({
@@ -23,6 +24,7 @@ export const testCliCommand = ({
   name,
   expected,
   mockDir = 'main',
+  env = {},
 }: TestCliCommandOptions) => {
   let server: Server;
   describe(name, () => {
@@ -55,6 +57,7 @@ export const testCliCommand = ({
         ],
         {
           stdio: 'pipe',
+          env: env,
         }
       );
 

--- a/src/test_utils/test_cli_command.ts
+++ b/src/test_utils/test_cli_command.ts
@@ -16,7 +16,6 @@ export type TestCliCommandOptions = {
     stdout?: string | ReturnType<typeof expect.stringMatching>;
     stderr?: string | ReturnType<typeof expect.stringMatching>;
   };
-  env?: Record<string, string>;
 };
 
 export const testCliCommand = ({
@@ -24,7 +23,6 @@ export const testCliCommand = ({
   name,
   expected,
   mockDir = 'main',
-  env = {},
 }: TestCliCommandOptions) => {
   let server: Server;
   describe(name, () => {
@@ -57,7 +55,9 @@ export const testCliCommand = ({
         ],
         {
           stdio: 'pipe',
-          env: env,
+          env: {
+            PATH: `mocks/bin:${process.env.PATH}`,
+          },
         }
       );
 

--- a/src/utils/psql.ts
+++ b/src/utils/psql.ts
@@ -2,6 +2,7 @@ import { log } from '../log.js';
 
 export const psql = async (
   connection_uri: string,
+  args: string[] = [],
 ) => {
   const { execSync, spawnSync } = await import('child_process');
 
@@ -13,7 +14,14 @@ export const psql = async (
     process.exit(1);
   }
 
-  return spawnSync('psql', [connection_uri], {
+  return spawnSync('psql', [connection_uri, ...args], {
     stdio: 'inherit',
   });
 };
+
+export const psqlArgs = (
+  argv: string[]
+) => {
+    const doubleDashIndex = argv.indexOf('--');
+    return doubleDashIndex === -1 ? [] : argv.slice(doubleDashIndex + 1);
+}

--- a/src/utils/psql.ts
+++ b/src/utils/psql.ts
@@ -4,7 +4,7 @@ export const psql = async (
   connection_uri: string,
   args: string[] = [],
 ) => {
-  const { execSync, spawnSync } = await import('child_process');
+  const { execSync, spawn } = await import('child_process');
 
   const which = process.platform === 'win32' ? 'where' : 'which';
   try {
@@ -14,8 +14,12 @@ export const psql = async (
     process.exit(1);
   }
 
-  return spawnSync('psql', [connection_uri, ...args], {
+  const psql = spawn('psql', [connection_uri, ...args], {
     stdio: 'inherit',
+  });
+
+  psql.on('exit', (code) => {
+    process.exit(code === null ? 1 : code);
   });
 };
 

--- a/src/utils/psql.ts
+++ b/src/utils/psql.ts
@@ -1,0 +1,19 @@
+import { log } from '../log.js';
+
+export const psql = async (
+  connection_uri: string,
+) => {
+  const { execSync, spawnSync } = await import('child_process');
+
+  const which = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    execSync(`${which} psql`, { stdio: 'ignore' });
+  } catch (error) {
+    log.error(`psql is not available in the PATH`);
+    process.exit(1);
+  }
+
+  return spawnSync('psql', [connection_uri], {
+    stdio: 'inherit',
+  });
+};


### PR DESCRIPTION
This PR adds `--psql` flag to the following commands:
- `projects create` 
- `branches create` 
- `connection-string`

The flag makes neonctl launch psql session for a given project/branch/connection string.
For non-idempotent operations (`projects create` and `branches create`), it happens after the standard output (with new project/branch information).
For idempotent `connection-string`, it launches psql instead of the output. 

Additional psql arguments can be passed after `--`:

```bash
neonctl branches create --project-id orange-field-03303460 --psql -- -c "SHOW neon.timeline_id"  
branch
┌────────────────────────┬────────────────────────┬─────────┬──────────────────────┬──────────────────────┐
│ Id                     │ Name                   │ Primary │ Created At           │ Updated At           │
├────────────────────────┼────────────────────────┼─────────┼──────────────────────┼──────────────────────┤
│ br-dark-water-38911821 │ br-dark-water-38911821 │ false   │ 2023-08-14T09:50:41Z │ 2023-08-14T09:50:41Z │
└────────────────────────┴────────────────────────┴─────────┴──────────────────────┴──────────────────────┘
endpoints
┌────────────────────────────┬──────────────────────┐
│ Id                         │ Created At           │
├────────────────────────────┼──────────────────────┤
│ ep-soft-waterfall-20122714 │ 2023-08-14T09:50:41Z │
└────────────────────────────┴──────────────────────┘
connection_uris
┌────────────────────────────────────────────────────────────────────────────────────────────┐
│ Connection Uri                                                                             │
├────────────────────────────────────────────────────────────────────────────────────────────┤
│ postgres://bayandin:<redacted>@ep-soft-waterfall-20122714.us-east-2.aws.neon.tech/neondb │
└────────────────────────────────────────────────────────────────────────────────────────────┘
INFO: Connecting to the database using psql...
         neon.timeline_id         
----------------------------------
 89a6ed1fb7c8e6e27352b5ecbaa0dbeb
(1 row)
```