### PR TITLE
fix: signal handling with --psql (#101)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bundle/
 .eslintcache
 .vscode
 coverage
+tmp/

--- a/src/utils/psql.ts
+++ b/src/utils/psql.ts
@@ -18,6 +18,14 @@ export const psql = async (
     stdio: 'inherit',
   });
 
+  for (const signame of ['SIGINT', 'SIGTERM']) {
+    process.on(signame, (code) => {
+      if (!psql.killed && code !== null) {
+        psql.kill(code);
+      }
+    });
+  }
+
   psql.on('exit', (code: number|null) => {
     process.exit(code === null ? 1 : code);
   });


### PR DESCRIPTION
This PR improves signal handling for `--psql`, particularly Ctrl+C behaviour.

Before: 
```
bayandin@mpb % neonctl cs --project-id <project-id> --psql -- -c "SELECT pg_sleep(60)"
INFO: Connecting to the database using psql...
^C
bayandin@mpb % Cancel request sent
ERROR:  canceling statement due to user request
        
```

After:
```
bayandin@mpb % neonctl cs --project-id <project-id> --psql -- -c "SELECT pg_sleep(60)"
INFO: Connecting to the database using psql...
^CCancel request sent
Cancel request sent
ERROR:  canceling statement due to user request
bayandin@mpb neonctl % 
```