### PR TITLE
feat: add dark mode for callback page

### DIFF
--- a/src/callback.html
+++ b/src/callback.html
@@ -14,6 +14,8 @@ body, html {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background-color: #ffffff;
+  color: #2d374c;
 }
 @media (prefers-color-scheme: dark) {
   body, html {

--- a/src/callback.html
+++ b/src/callback.html
@@ -40,6 +40,6 @@ svg {
     </div>
     <h1>Thank you for using Neon</h1>
     <p>
-        You may close the page now
+        You may close this page now
     </p>
 </body>

--- a/src/callback.html
+++ b/src/callback.html
@@ -15,6 +15,12 @@ body, html {
   justify-content: center;
   align-items: center;
 }
+@media (prefers-color-scheme: dark) {
+  body, html {
+    background-color: #131313;
+    color: #ffffff;
+  }
+}
 .logo {
   display: inline-block;
   width: 100px;

--- a/src/callback.html
+++ b/src/callback.html
@@ -17,8 +17,8 @@ body, html {
 }
 @media (prefers-color-scheme: dark) {
   body, html {
-    background-color: #131313;
-    color: #ffffff;
+    background-color: #191919;
+    color: #bfbfbf;
   }
 }
 .logo {


### PR DESCRIPTION
Successful `neonctl auth` redirects you to a really bright callback page.
This PR adds a dark theme to make the page friendly for owls.

Old Light mode:
<img width="1616" alt="old light mode" src="https://github.com/neondatabase/neonctl/assets/864213/84574ac6-6570-498d-8632-aa9d46cd2ba0">

New Light mode:
<img width="1616" alt="new light mode" src="https://github.com/neondatabase/neonctl/assets/864213/a94b90f0-5f74-4048-a6ae-46b80abc286d">

New Dark mode:
<img width="1616" alt="new dark mode" src="https://github.com/neondatabase/neonctl/assets/864213/5360c7e8-5568-4cd9-90f3-65e55c85397d">
