### PR TITLE
Make semantic-release also commit `package-lock.json` when releasing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,7 +18,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": "package.json"
+        "assets": ["package.json", "package-lock.json"]
       }
     ],
     [


### PR DESCRIPTION
Seems after every release, running `npm install` modifies the lockfile due to the pending change.

This PR uses the default `assets` for `@semantic-release/git` which is:

```js
[
  'CHANGELOG.md',
  'package.json',
  'package-lock.json',
  'npm-shrinkwrap.json'
]
```

should suit our needs pretty good.