### PR TITLE
fix: fix husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "clean": "rm -rf dist",
     "generateParams": "node --loader ts-node/esm ./generateOptionsFromSpec.ts",
     "start": "node src/index.js",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest"
+    "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "*.ts": [


### PR DESCRIPTION
Apparently we lost the `prepare` npm script that makes husky work for anyone who installs the project locally, so I managed to overcome it 😅 