### PR TITLE
feat: ip allow configuration with project update command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ bundle/
 .neonctl
 .eslintcache
 .vscode
+.idea
 coverage
 tmp/

--- a/generateOptionsFromSpec.ts
+++ b/generateOptionsFromSpec.ts
@@ -6,6 +6,7 @@ import { OpenAPIV3 } from 'openapi-types';
 
 const EXTRACT_PROPERTIES = [
   'ProjectCreateRequest',
+  'ProjectUpdateRequest',
   'BranchCreateRequest',
   'BranchCreateRequestEndpointOptions',
   'BranchUpdateRequest',
@@ -16,6 +17,7 @@ const EXTRACT_PROPERTIES = [
 ];
 
 const typesMapping = {
+  array: 'array',
   integer: 'number',
   string: 'string',
   boolean: 'boolean',
@@ -44,7 +46,7 @@ const typesMapping = {
               type: ${JSON.stringify(
                 typesMapping[value.type as keyof typeof typesMapping],
               )},
-              description: ${JSON.stringify(value.description)},\n
+              description: ${JSON.stringify(value.description)},
               demandOption: ${
                 schema.required?.includes(key) ? 'true' : 'false'
               },\n`,

--- a/mocks/main/projects/test/GET.json
+++ b/mocks/main/projects/test/GET.json
@@ -2,6 +2,12 @@
   "project": {
     "id": "test",
     "name": "test_project",
-    "created_at": "2019-01-01T00:00:00Z"
+    "created_at": "2019-01-01T00:00:00Z",
+    "settings": {
+      "allowed_ips": {
+        "ips": ["192.168.1.1"],
+        "primary_branch_only": false
+      }
+    }
   }
 }

--- a/mocks/main/projects/test/PATCH.js
+++ b/mocks/main/projects/test/PATCH.js
@@ -1,3 +1,10 @@
+const defaultSettings = {
+  allowed_ips: {
+    ips: ["192.168.1.1"],
+    primary_branch_only: false
+  }
+}
+
 export default function (req, res) {
   const project = req.body.project ?? {}
   res.send({
@@ -5,7 +12,7 @@ export default function (req, res) {
       "id": "test",
       "name": project.name ?? "test_project",
       "created_at": "2019-01-01T00:00:00Z",
-      "settings": project.settings
+      "settings": {...defaultSettings, ...project.settings}
     }
   });
 }

--- a/mocks/main/projects/test/PATCH.js
+++ b/mocks/main/projects/test/PATCH.js
@@ -1,21 +1,18 @@
 const defaultSettings = {
   allowed_ips: {
-    ips: ["192.168.1.1"],
-    primary_branch_only: false
-  }
-}
+    ips: ['192.168.1.1'],
+    primary_branch_only: false,
+  },
+};
 
 export default function (req, res) {
-  const project = req.body.project ?? {}
+  const project = req.body.project ?? {};
   res.send({
-    "project": {
-      "id": "test",
-      "name": project.name ?? "test_project",
-      "created_at": "2019-01-01T00:00:00Z",
-      "settings": {...defaultSettings, ...project.settings}
-    }
+    project: {
+      id: 'test',
+      name: project.name ?? 'test_project',
+      created_at: '2019-01-01T00:00:00Z',
+      settings: { ...defaultSettings, ...project.settings },
+    },
   });
 }
-
-
-

--- a/mocks/main/projects/test/PATCH.js
+++ b/mocks/main/projects/test/PATCH.js
@@ -1,0 +1,14 @@
+export default function (req, res) {
+  const project = req.body.project ?? {}
+  res.send({
+    "project": {
+      "id": "test",
+      "name": project.name ?? "test_project",
+      "created_at": "2019-01-01T00:00:00Z",
+      "settings": project.settings
+    }
+  });
+}
+
+
+

--- a/mocks/main/projects/test/PATCH.json
+++ b/mocks/main/projects/test/PATCH.json
@@ -1,7 +1,0 @@
-{
-  "project": {
-    "id": 1,
-    "name": "test_project",
-    "created_at": "2019-01-01T00:00:00Z"
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neonctl",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neonctl",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
         "@neondatabase/api-client": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.24.2",
       "license": "MIT",
       "dependencies": {
-        "@neondatabase/api-client": "1.4.0",
+        "@neondatabase/api-client": "1.4.1",
         "@segment/analytics-node": "^1.0.0-beta.26",
         "axios": "^1.4.0",
         "axios-debug-log": "^1.0.0",
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/@neondatabase/api-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.4.0.tgz",
-      "integrity": "sha512-QKg3zR5yF9lCAK2y70F0WXNkLZlg4QdE8FqyycSZTcpMfCR9aV1wfwWgPcQPUzOdTbzTg0JeNIr1PCvyNz28yg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.4.1.tgz",
+      "integrity": "sha512-GMwww33TwOuR/aNRD0MDV6607sxdqqB9yKRF9NFHMNoyKBxBcP8W8JbXTSgt7Tw1VptPmObuFeO6a7xhngry4w==",
       "dependencies": {
         "axios": "^1.4.0"
       }
@@ -16670,9 +16670,9 @@
       }
     },
     "@neondatabase/api-client": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.4.0.tgz",
-      "integrity": "sha512-QKg3zR5yF9lCAK2y70F0WXNkLZlg4QdE8FqyycSZTcpMfCR9aV1wfwWgPcQPUzOdTbzTg0JeNIr1PCvyNz28yg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.4.1.tgz",
+      "integrity": "sha512-GMwww33TwOuR/aNRD0MDV6607sxdqqB9yKRF9NFHMNoyKBxBcP8W8JbXTSgt7Tw1VptPmObuFeO6a7xhngry4w==",
       "requires": {
         "axios": "^1.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@neondatabase/api-client": "1.4.0",
+    "@neondatabase/api-client": "1.4.1",
     "@segment/analytics-node": "^1.0.0-beta.26",
     "axios": "^1.4.0",
     "axios-debug-log": "^1.0.0",

--- a/snapshots/commands/projects.test.snap
+++ b/snapshots/commands/projects.test.snap
@@ -51,6 +51,11 @@ exports[`projects get test 1`] = `
 "id: test
 name: test_project
 created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 192.168.1.1
+    primary_branch_only: false
 "
 `;
 
@@ -67,6 +72,29 @@ exports[`projects list test 1`] = `
   name: Project_3
   created_at: 2019-01-01T00:00:00.000Z
   updated_at: 2019-01-01T00:00:00.000Z
+"
+`;
+
+exports[`projects update ip allow primary only flag test 1`] = `
+"id: test
+name: test_project
+created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 192.168.1.1
+    primary_branch_only: false
+"
+`;
+
+exports[`projects update ip allow remove test 1`] = `
+"id: test
+name: test_project
+created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips: []
+    primary_branch_only: false
 "
 `;
 
@@ -87,5 +115,10 @@ exports[`projects update name test 1`] = `
 "id: test
 name: test_project_new_name
 created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 192.168.1.1
+    primary_branch_only: false
 "
 `;

--- a/snapshots/commands/projects.test.snap
+++ b/snapshots/commands/projects.test.snap
@@ -70,9 +70,22 @@ exports[`projects list test 1`] = `
 "
 `;
 
-exports[`projects update test 1`] = `
-"id: 1
+exports[`projects update ip allow test 1`] = `
+"id: test
 name: test_project
+created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 127.0.0.1
+      - 192.168.1.2/22
+    primary_branch_only: true
+"
+`;
+
+exports[`projects update name test 1`] = `
+"id: test
+name: test_project_new_name
 created_at: 2019-01-01T00:00:00Z
 "
 `;

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -97,7 +97,7 @@ describe('projects', () => {
       '--ip-allow',
       '127.0.0.1',
       '192.168.1.2/22',
-      '--primary-only',
+      '--ip-primary-only',
     ],
     expected: {
       snapshot: true,
@@ -106,7 +106,7 @@ describe('projects', () => {
 
   testCliCommand({
     name: 'update ip allow primary only flag',
-    args: ['projects', 'update', 'test', '--primary-only', 'false'],
+    args: ['projects', 'update', 'test', '--ip-primary-only', 'false'],
     expected: {
       snapshot: true,
     },

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -81,8 +81,24 @@ describe('projects', () => {
   });
 
   testCliCommand({
-    name: 'update',
-    args: ['projects', 'update', 'test', '--name', 'test_project'],
+    name: 'update name',
+    args: ['projects', 'update', 'test', '--name', 'test_project_new_name'],
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'update ip allow',
+    args: [
+      'projects',
+      'update',
+      'test',
+      '--ip-allow-ips',
+      '127.0.0.1',
+      '192.168.1.2/22',
+      '--ip-allow-primary-branch-only',
+    ],
     expected: {
       snapshot: true,
     },

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -94,10 +94,10 @@ describe('projects', () => {
       'projects',
       'update',
       'test',
-      '--ip-allow-ips',
+      '--ip-allow',
       '127.0.0.1',
       '192.168.1.2/22',
-      '--ip-allow-primary-branch-only',
+      '--primary-only',
     ],
     expected: {
       snapshot: true,

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -105,6 +105,22 @@ describe('projects', () => {
   });
 
   testCliCommand({
+    name: 'update ip allow primary only flag',
+    args: ['projects', 'update', 'test', '--primary-only', 'false'],
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'update ip allow remove',
+    args: ['projects', 'update', 'test', '--ip-allow'],
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
     name: 'get',
     args: ['projects', 'get', 'test'],
     expected: {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -88,7 +88,7 @@ export const builder = (argv: yargs.Argv) => {
             array: true,
             group: 'IP Allow:',
           },
-          'primary-only': {
+          'ip-primary-only': {
             describe:
               projectUpdateRequest[
                 'project.settings.allowed_ips.primary_branch_only'
@@ -196,14 +196,14 @@ const update = async (
     IdOrNameProps & {
       name?: string;
       ipAllow?: string[];
-      primaryOnly?: boolean;
+      ipPrimaryOnly?: boolean;
     },
 ) => {
   const project: ProjectUpdateRequest['project'] = {};
   if (props.name) {
     project.name = props.name;
   }
-  if (props.ipAllow || props.primaryOnly != undefined) {
+  if (props.ipAllow || props.ipPrimaryOnly != undefined) {
     const { data } = await props.apiClient.getProject(props.id);
     const existingAllowedIps = data.project.settings?.allowed_ips;
 
@@ -211,7 +211,9 @@ const update = async (
       allowed_ips: {
         ips: props.ipAllow ?? existingAllowedIps?.ips ?? [],
         primary_branch_only:
-          props.primaryOnly ?? existingAllowedIps?.primary_branch_only ?? false,
+          props.ipPrimaryOnly ??
+          existingAllowedIps?.primary_branch_only ??
+          false,
       },
     };
   }

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -82,8 +82,7 @@ export const builder = (argv: yargs.Argv) => {
           'ip-allow': {
             describe:
               projectUpdateRequest['project.settings.allowed_ips.ips']
-                .description ??
-              'A list of IP addresses that are allowed to connect to the endpoint.',
+                .description,
             type: 'string',
             array: true,
             group: 'IP Allow:',
@@ -92,8 +91,7 @@ export const builder = (argv: yargs.Argv) => {
             describe:
               projectUpdateRequest[
                 'project.settings.allowed_ips.primary_branch_only'
-              ].description ??
-              'If set true, the list will be applied only to the primary branch.',
+              ].description,
             type: 'boolean',
             group: 'IP Allow:',
           },

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -85,7 +85,6 @@ export const builder = (argv: yargs.Argv) => {
                 .description,
             type: 'string',
             array: true,
-            group: 'IP Allow:',
           },
           'ip-primary-only': {
             describe:
@@ -93,7 +92,6 @@ export const builder = (argv: yargs.Argv) => {
                 'project.settings.allowed_ips.primary_branch_only'
               ].description,
             type: 'boolean',
-            group: 'IP Allow:',
           },
         }),
       async (args) => {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -203,18 +203,15 @@ const update = async (
   if (props.name) {
     project.name = props.name;
   }
-  if (props.ipAllow) {
+  if (props.ipAllow || props.primaryOnly != undefined) {
+    const { data } = await props.apiClient.getProject(props.id);
+    const existingAllowedIps = data.project.settings?.allowed_ips;
+
     project.settings = {
       allowed_ips: {
-        ips: props.ipAllow,
-        primary_branch_only: props.primaryOnly ?? false,
-      },
-    };
-  } else if (props.primaryOnly) {
-    project.settings = {
-      allowed_ips: {
-        ips: [],
-        primary_branch_only: props.primaryOnly ?? false,
+        ips: props.ipAllow ?? existingAllowedIps?.ips ?? [],
+        primary_branch_only:
+          props.primaryOnly ?? existingAllowedIps?.primary_branch_only ?? false,
       },
     };
   }
@@ -222,6 +219,7 @@ const update = async (
   const { data } = await props.apiClient.updateProject(props.id, {
     project,
   });
+
   writer(props).end(data.project, { fields: PROJECT_FIELDS });
 };
 

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -79,7 +79,7 @@ export const builder = (argv: yargs.Argv) => {
             describe: projectCreateRequest['project.name'].description,
             type: 'string',
           },
-          ipAllowIps: {
+          'ip-allow': {
             describe:
               projectUpdateRequest['project.settings.allowed_ips.ips']
                 .description ??
@@ -88,7 +88,7 @@ export const builder = (argv: yargs.Argv) => {
             array: true,
             group: 'IP Allow:',
           },
-          ipAllowPrimaryBranchOnly: {
+          'primary-only': {
             describe:
               projectUpdateRequest[
                 'project.settings.allowed_ips.primary_branch_only'
@@ -195,26 +195,26 @@ const update = async (
   props: CommonProps &
     IdOrNameProps & {
       name?: string;
-      ipAllowIps?: string[];
-      ipAllowPrimaryBranchOnly?: boolean;
+      ipAllow?: string[];
+      primaryOnly?: boolean;
     },
 ) => {
   const project: ProjectUpdateRequest['project'] = {};
   if (props.name) {
     project.name = props.name;
   }
-  if (props.ipAllowIps) {
+  if (props.ipAllow) {
     project.settings = {
       allowed_ips: {
-        ips: props.ipAllowIps,
-        primary_branch_only: props.ipAllowPrimaryBranchOnly ?? false,
+        ips: props.ipAllow,
+        primary_branch_only: props.primaryOnly ?? false,
       },
     };
-  } else if (props.ipAllowPrimaryBranchOnly) {
+  } else if (props.primaryOnly) {
     project.settings = {
       allowed_ips: {
         ips: [],
-        primary_branch_only: props.ipAllowPrimaryBranchOnly ?? false,
+        primary_branch_only: props.primaryOnly ?? false,
       },
     };
   }

--- a/src/parameters.gen.ts
+++ b/src/parameters.gen.ts
@@ -28,12 +28,12 @@ export const projectCreateRequest = {
   },
   'project.settings.allowed_ips.ips': {
               type: "array",
-              description: undefined,
+              description: "A list of IP addresses that are allowed to connect to the endpoint.",
               demandOption: true,
   },
   'project.settings.allowed_ips.primary_branch_only': {
               type: "boolean",
-              description: undefined,
+              description: "If true, the list will be applied only to the primary branch.",
               demandOption: true,
   },
   'project.name': {
@@ -117,12 +117,12 @@ export const projectUpdateRequest = {
   },
   'project.settings.allowed_ips.ips': {
               type: "array",
-              description: undefined,
+              description: "A list of IP addresses that are allowed to connect to the endpoint.",
               demandOption: true,
   },
   'project.settings.allowed_ips.primary_branch_only': {
               type: "boolean",
-              description: undefined,
+              description: "If true, the list will be applied only to the primary branch.",
               demandOption: true,
   },
   'project.name': {

--- a/src/parameters.gen.ts
+++ b/src/parameters.gen.ts
@@ -4,125 +4,168 @@ export const projectCreateRequest = {
   'project.settings.quota.active_time_seconds': {
               type: "number",
               description: "The total amount of wall-clock time allowed to be spent by the project's compute endpoints.\n",
-
               demandOption: false,
   },
   'project.settings.quota.compute_time_seconds': {
               type: "number",
               description: "The total amount of CPU seconds allowed to be spent by the project's compute endpoints.\n",
-
               demandOption: false,
   },
   'project.settings.quota.written_data_bytes': {
               type: "number",
               description: "Total amount of data written to all of a project's branches.\n",
-
               demandOption: false,
   },
   'project.settings.quota.data_transfer_bytes': {
               type: "number",
               description: "Total amount of data transferred from all of a project's branches using the proxy.\n",
-
               demandOption: false,
   },
   'project.settings.quota.logical_size_bytes': {
               type: "number",
               description: "Limit on the logical size of every project's branch.\n",
-
               demandOption: false,
+  },
+  'project.settings.allowed_ips.ips': {
+              type: "array",
+              description: undefined,
+              demandOption: true,
   },
   'project.settings.allowed_ips.primary_branch_only': {
               type: "boolean",
               description: undefined,
-
               demandOption: true,
   },
   'project.name': {
               type: "string",
               description: "The project name",
-
               demandOption: false,
   },
   'project.branch.name': {
               type: "string",
               description: "The branch name. If not specified, the default branch name will be used.\n",
-
               demandOption: false,
   },
   'project.branch.role_name': {
               type: "string",
               description: "The role name. If not specified, the default role name will be used.\n",
-
               demandOption: false,
   },
   'project.branch.database_name': {
               type: "string",
               description: "The database name. If not specified, the default database name will be used.\n",
-
               demandOption: false,
   },
   'project.provisioner': {
               type: "string",
               description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n",
-
               demandOption: false,
  choices: ["k8s-pod","k8s-neonvm"],
   },
   'project.region_id': {
               type: "string",
               description: "The region identifier. Refer to our [Regions](https://neon.tech/docs/introduction/regions) documentation for supported regions. Values are specified in this format: `aws-us-east-1`\n",
-
               demandOption: false,
   },
   'project.default_endpoint_settings.suspend_timeout_seconds': {
               type: "number",
               description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
-
               demandOption: false,
   },
   'project.pg_version': {
               type: "number",
               description: "The major PostgreSQL version number. Currently supported versions are `14`, `15` and `16`.",
-
               demandOption: false,
   },
   'project.store_passwords': {
               type: "boolean",
               description: "Whether or not passwords are stored for roles in the Neon project. Storing passwords facilitates access to Neon features that require authorization.\n",
-
               demandOption: false,
   },
   'project.history_retention_seconds': {
               type: "number",
               description: "The number of seconds to retain the point-in-time restore (PITR) backup history for this project.\nThe default is 604800 seconds (7 days).\n",
+              demandOption: false,
+  },
+} as const;
 
+export const projectUpdateRequest = {
+  'project.settings.quota.active_time_seconds': {
+              type: "number",
+              description: "The total amount of wall-clock time allowed to be spent by the project's compute endpoints.\n",
+              demandOption: false,
+  },
+  'project.settings.quota.compute_time_seconds': {
+              type: "number",
+              description: "The total amount of CPU seconds allowed to be spent by the project's compute endpoints.\n",
+              demandOption: false,
+  },
+  'project.settings.quota.written_data_bytes': {
+              type: "number",
+              description: "Total amount of data written to all of a project's branches.\n",
+              demandOption: false,
+  },
+  'project.settings.quota.data_transfer_bytes': {
+              type: "number",
+              description: "Total amount of data transferred from all of a project's branches using the proxy.\n",
+              demandOption: false,
+  },
+  'project.settings.quota.logical_size_bytes': {
+              type: "number",
+              description: "Limit on the logical size of every project's branch.\n",
+              demandOption: false,
+  },
+  'project.settings.allowed_ips.ips': {
+              type: "array",
+              description: undefined,
+              demandOption: true,
+  },
+  'project.settings.allowed_ips.primary_branch_only': {
+              type: "boolean",
+              description: undefined,
+              demandOption: true,
+  },
+  'project.name': {
+              type: "string",
+              description: "The project name",
+              demandOption: false,
+  },
+  'project.default_endpoint_settings.suspend_timeout_seconds': {
+              type: "number",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              demandOption: false,
+  },
+  'project.history_retention_seconds': {
+              type: "number",
+              description: "The number of seconds to retain the point-in-time restore (PITR) backup history for this project.\nThe default is 604800 seconds (7 days).\n",
               demandOption: false,
   },
 } as const;
 
 export const branchCreateRequest = {
+  'endpoints': {
+              type: "array",
+              description: undefined,
+              demandOption: false,
+  },
   'branch.parent_id': {
               type: "string",
               description: "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's primary branch.\n",
-
               demandOption: false,
   },
   'branch.name': {
               type: "string",
               description: "The branch name\n",
-
               demandOption: false,
   },
   'branch.parent_lsn': {
               type: "string",
               description: "A Log Sequence Number (LSN) on the parent branch. The branch will be created with data from this LSN.\n",
-
               demandOption: false,
   },
   'branch.parent_timestamp': {
               type: "string",
               description: "A timestamp identifying a point in time on the parent branch. The branch will be created with data starting from this point in time.\n",
-
               demandOption: false,
   },
 } as const;
@@ -131,21 +174,18 @@ export const branchCreateRequestEndpointOptions = {
   'type': {
               type: "string",
               description: "The compute endpoint type. Either `read_write` or `read_only`.\nThe `read_only` compute endpoint type is not yet supported.\n",
-
               demandOption: true,
  choices: ["read_only","read_write"],
   },
   'provisioner': {
               type: "string",
               description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n",
-
               demandOption: false,
  choices: ["k8s-pod","k8s-neonvm"],
   },
   'suspend_timeout_seconds': {
               type: "number",
               description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
-
               demandOption: false,
   },
 } as const;
@@ -154,7 +194,6 @@ export const branchUpdateRequest = {
   'branch.name': {
               type: "string",
               description: undefined,
-
               demandOption: false,
   },
 } as const;
@@ -163,58 +202,49 @@ export const endpointCreateRequest = {
   'endpoint.branch_id': {
               type: "string",
               description: "The ID of the branch the compute endpoint will be associated with\n",
-
               demandOption: true,
   },
   'endpoint.region_id': {
               type: "string",
               description: "The region where the compute endpoint will be created. Only the project's `region_id` is permitted.\n",
-
               demandOption: false,
   },
   'endpoint.type': {
               type: "string",
               description: "The compute endpoint type. Either `read_write` or `read_only`.\nThe `read_only` compute endpoint type is not yet supported.\n",
-
               demandOption: true,
  choices: ["read_only","read_write"],
   },
   'endpoint.provisioner': {
               type: "string",
               description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n",
-
               demandOption: false,
  choices: ["k8s-pod","k8s-neonvm"],
   },
   'endpoint.pooler_enabled': {
               type: "boolean",
               description: "Whether to enable connection pooling for the compute endpoint\n",
-
               demandOption: false,
   },
   'endpoint.pooler_mode': {
               type: "string",
               description: "The connection pooler mode. Neon supports PgBouncer in `transaction` mode only.\n",
-
               demandOption: false,
  choices: ["transaction"],
   },
   'endpoint.disabled': {
               type: "boolean",
               description: "Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action. However, the compute endpoint is periodically\nenabled by check_availability operations.\n",
-
               demandOption: false,
   },
   'endpoint.passwordless_access': {
               type: "boolean",
               description: "NOT YET IMPLEMENTED. Whether to permit passwordless access to the compute endpoint.\n",
-
               demandOption: false,
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
               description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
-
               demandOption: false,
   },
 } as const;
@@ -223,45 +253,38 @@ export const endpointUpdateRequest = {
   'endpoint.branch_id': {
               type: "string",
               description: "The destination branch ID. The destination branch must not have an exsiting read-write endpoint.\n",
-
               demandOption: false,
   },
   'endpoint.provisioner': {
               type: "string",
               description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n",
-
               demandOption: false,
  choices: ["k8s-pod","k8s-neonvm"],
   },
   'endpoint.pooler_enabled': {
               type: "boolean",
               description: "Whether to enable connection pooling for the compute endpoint\n",
-
               demandOption: false,
   },
   'endpoint.pooler_mode': {
               type: "string",
               description: "The connection pooler mode. Neon supports PgBouncer in `transaction` mode only.\n",
-
               demandOption: false,
  choices: ["transaction"],
   },
   'endpoint.disabled': {
               type: "boolean",
               description: "Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action. However, the compute endpoint is periodically\nenabled by check_availability operations.\n",
-
               demandOption: false,
   },
   'endpoint.passwordless_access': {
               type: "boolean",
               description: "NOT YET IMPLEMENTED. Whether to permit passwordless access to the compute endpoint.\n",
-
               demandOption: false,
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
               description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
-
               demandOption: false,
   },
 } as const;
@@ -270,13 +293,11 @@ export const databaseCreateRequest = {
   'database.name': {
               type: "string",
               description: "The name of the datbase\n",
-
               demandOption: true,
   },
   'database.owner_name': {
               type: "string",
               description: "The name of the role that owns the database\n",
-
               demandOption: true,
   },
 } as const;
@@ -285,7 +306,6 @@ export const roleCreateRequest = {
   'role.name': {
               type: "string",
               description: "The role name. Cannot exceed 63 bytes in length.\n",
-
               demandOption: true,
   },
 } as const;


### PR DESCRIPTION
Fixes: https://github.com/neondatabase/cloud/issues/8242

- [x] Update generated parameters with new API spec
- [x] `projects update <id> --ip-allow 127.0.0.1 192.168.2.1/24 --ip-primary-only` sets provided IPs to `ips` and sets `primary_branch_only` to `true`
- [x] `projects update <id> --ip-allow --ip-primary-only false` sets `ips` to `[]` and `primary_branch_only` to false
- [x] `projects update <id> --ip-primary-only false` sets `primary_branch_only` to `false`. `ips` is not changed. 

---


https://github.com/neondatabase/neonctl/assets/1949852/d1ef12c9-70d1-4dbd-8341-1fd4a1627337



Commands in video - 

1. Project GET command (local environment)
2. Project UPDATE command with IP Allow configuration (local environment)
