### PR TITLE
fix: increase timeout when calling Neon public API (#177)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,7 @@ export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) =>
   createApiClient({
     apiKey,
     baseURL: apiHost,
-    timeout: 10000,
+    timeout: 60000,
     headers: {
       'User-Agent': `neonctl v${pkg.version}`,
     },


### PR DESCRIPTION
We ask our customers to integrate branch creation into their (customers') github workflows.
We don't want our customers to suffer from flaky github workflows due to Neon timeouts.
So a good developer experience needs to make sure that our documentation, sample and blogs provide instructions that will work (even in case our internal network is unstable for a few seconds).

I suggest to increase the timeout to a value that is more resilient to occasional hiccups.
60 seconds was suggested by subject matter expert based on Neon internal testing.