### PR TITLE
fix: connection uri scheme to postgresql

### DIFF
--- a/snapshots/commands/connection_string.test.snap
+++ b/snapshots/commands/connection_string.test.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`connection_string connection_string branch id 8 digits test 1`] = `
-"postgres://test_role:test_pwd@ep-lame-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
+"postgresql://test_role:test_pwd@ep-lame-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
 "
 `;
 
 exports[`connection_string connection_string branch id test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
+"postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
 "
 `;
 
 exports[`connection_string connection_string pooled test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?sslmode=require
+"postgresql://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?sslmode=require
 "
 `;
 
 exports[`connection_string connection_string prisma pooled extended test 1`] = `
-"connection_string: postgres://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?connect_timeout=30&pool_timeout=30&pgbouncer=true&sslmode=require
+"connection_string: postgresql://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?connect_timeout=30&pool_timeout=30&pgbouncer=true&sslmode=require
 host: ep-cool-king-930914-pooler.us-east-2.aws.neon.tech
 role: test_role
 password: test_pwd
@@ -26,45 +26,45 @@ options: connect_timeout=30&pool_timeout=30&pgbouncer=true&sslmode=require
 `;
 
 exports[`connection_string connection_string prisma pooled test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?connect_timeout=30&pool_timeout=30&pgbouncer=true&sslmode=require
+"postgresql://test_role:test_pwd@ep-cool-king-930914-pooler.us-east-2.aws.neon.tech/test_db?connect_timeout=30&pool_timeout=30&pgbouncer=true&sslmode=require
 "
 `;
 
 exports[`connection_string connection_string prisma test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?connect_timeout=30&sslmode=require
+"postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?connect_timeout=30&sslmode=require
 "
 `;
 
 exports[`connection_string connection_string test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
+"postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require
 "
 `;
 
 exports[`connection_string connection_string with lsn test 1`] = `
-"postgres://test_role:test_pwd@br-sunny-branch-123456.us-east-2.aws.neon.tech/test_db?sslmode=require&options=neon_lsn%3A0%2F123456
+"postgresql://test_role:test_pwd@br-sunny-branch-123456.us-east-2.aws.neon.tech/test_db?sslmode=require&options=neon_lsn%3A0%2F123456
 "
 `;
 
-exports[`connection_string connection_string with psql and psql args test 1`] = `"{"psql-cli-args":["postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require","-c","SELECT 1"]}"`;
+exports[`connection_string connection_string with psql and psql args test 1`] = `"{"psql-cli-args":["postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require","-c","SELECT 1"]}"`;
 
-exports[`connection_string connection_string with psql test 1`] = `"{"psql-cli-args":["postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require"]}"`;
+exports[`connection_string connection_string with psql test 1`] = `"{"psql-cli-args":["postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=require"]}"`;
 
 exports[`connection_string connection_string with ssl verify full test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=verify-full
+"postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db?sslmode=verify-full
 "
 `;
 
 exports[`connection_string connection_string with timestamp test 1`] = `
-"postgres://test_role:test_pwd@br-sunny-branch-123456.us-east-2.aws.neon.tech/test_db?sslmode=require&options=neon_timestamp%3A2021-01-01T00%3A00%3A00Z
+"postgresql://test_role:test_pwd@br-sunny-branch-123456.us-east-2.aws.neon.tech/test_db?sslmode=require&options=neon_timestamp%3A2021-01-01T00%3A00%3A00Z
 "
 `;
 
 exports[`connection_string connection_string without any args should pass test 1`] = `
-"postgres://test_role:password@undefined/db1?sslmode=require
+"postgresql://test_role:password@undefined/db1?sslmode=require
 "
 `;
 
 exports[`connection_string connection_string without ssl test 1`] = `
-"postgres://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db
+"postgresql://test_role:test_pwd@ep-cool-king-930914.us-east-2.aws.neon.tech/test_db
 "
 `;

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -169,7 +169,7 @@ export const handler = async (
   if (parsedPIT.tag !== 'head') {
     host = endpoint.host.replace(endpoint.id, endpoint.branch_id);
   }
-  const connectionString = new URL(`postgres://${host}`);
+  const connectionString = new URL(`postgresql://${host}`);
   connectionString.pathname = database;
   connectionString.username = role;
   connectionString.password = password;


### PR DESCRIPTION
relates: https://github.com/neondatabase/cloud/issues/11987

A while back, we changed connection string examples in the Connection Details widget to use `postgresql://` due to the shorter version (`postgres://`) not working with some framework/driver. Update the connection_string (cs) command to use `postgresql://` scheme while generating the connection string. 