### PR TITLE
feat: Add support for Timestamp and LSN for schema diff

### DIFF
--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -18,7 +18,7 @@ import {
 import { psql } from '../utils/psql.js';
 import { parsePointInTime } from '../utils/point_in_time.js';
 import { log } from '../log.js';
-import { schemaDiff } from './schema_diff.js';
+import { parseSchemaDiffParams, schemaDiff } from './schema_diff.js';
 
 const BRANCH_FIELDS = [
   'id',
@@ -189,17 +189,20 @@ export const builder = (argv: yargs.Argv) =>
       async (args) => await get(args as any),
     )
     .command({
-      command: 'schema-diff [base-branch] <compare-branch>',
+      command: 'schema-diff [base-branch] [compare-branch]',
       aliases: ['sd'],
-      describe: 'Compare schemas from two branches',
-      builder: (yargs) =>
-        yargs.options({
+      describe:
+        'compare a branch schema to a specific point in time\n<compare-source> can be: ^self, ^parent, or <compare-branch-id|name>',
+      builder: (yargs) => {
+        return yargs.middleware(parseSchemaDiffParams as any).options({
           database: {
             type: 'string',
             description:
               'Name of the database for which the schema is retrieved',
           },
-        }),
+        });
+      },
+
       handler: async (args) => schemaDiff(args as any),
     });
 

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -192,8 +192,7 @@ export const builder = (argv: yargs.Argv) =>
       command: 'schema-diff [base-branch] [compare-source[@(timestamp|lsn)]]',
       aliases: ['sd'],
       describe:
-        'compare a branch schema to a specific point in time' +
-        '\n  [compare-source] can be: ^self, ^parent, or <compare-branch-id|name>',
+        "Compare the latest schemas of any two branches, or compare a branch to its own or another branch's history.",
       builder: (yargs) => {
         return yargs
           .middleware(
@@ -205,21 +204,21 @@ export const builder = (argv: yargs.Argv) =>
             database: {
               type: 'string',
               description:
-                'Name of the database for which the schema is compared',
+                'Name of the database for which the schema comparison is performed',
             },
           })
           .example([
             [
               '$0 branches schema-diff main br-compare-branch-123456',
-              'Compares main branch to the head of the branch with id br-compare-branch-123456',
+              'Compares the main branch to the head of the branch with ID br-compare-branch-123456',
             ],
             [
               '$0 branches schema-diff main compare@2024-06-01T00:00:00Z',
-              'Compares main branch to the timestamp of 2024-06-01T00:00:00.000Z of the compare branch',
+              'Compares the main branch to the state of the compare branch at timestamp 2024-06-01T00:00:00.000Z',
             ],
             [
               '$0 branches schema-diff my-branch ^self@0/123456',
-              'Compares my-branch to the LSN of 0/123456 from its own history',
+              'Compares my-branch to LSN 0/123456 from its own history',
             ],
             [
               '$0 branches schema-diff my-branch ^parent',
@@ -227,7 +226,7 @@ export const builder = (argv: yargs.Argv) =>
             ],
             [
               '$0 branches schema-diff',
-              'Compares the branch in context with its parent branch',
+              "If a branch is specified in 'set-context', compares this branch to its parent. Otherwise, compares the primary branch to its parent.",
             ],
           ]);
       },

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -189,7 +189,7 @@ export const builder = (argv: yargs.Argv) =>
       async (args) => await get(args as any),
     )
     .command({
-      command: 'schema-diff [base-branch] [compare-branch]',
+      command: 'schema-diff [base-branch] [compare-source]',
       aliases: ['sd'],
       describe:
         'compare a branch schema to a specific point in time\n<compare-source> can be: ^self, ^parent, or <compare-branch-id|name>',

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -192,13 +192,14 @@ export const builder = (argv: yargs.Argv) =>
       command: 'schema-diff [base-branch] [compare-source]',
       aliases: ['sd'],
       describe:
-        'compare a branch schema to a specific point in time\n<compare-source> can be: ^self, ^parent, or <compare-branch-id|name>',
+        'compare a branch schema to a specific point in time' +
+        '\n  [compare-source] can be: ^self, ^parent, or <compare-branch-id|name>',
       builder: (yargs) => {
         return yargs.middleware(parseSchemaDiffParams as any).options({
           database: {
             type: 'string',
             description:
-              'Name of the database for which the schema is retrieved',
+              'Name of the database for which the schema is compared',
           },
         });
       },

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -202,6 +202,7 @@ export const builder = (argv: yargs.Argv) =>
           .middleware(parseSchemaDiffParams as any)
           .options({
             database: {
+              alias: 'db',
               type: 'string',
               description:
                 'Name of the database for which the schema comparison is performed',

--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -13,7 +13,7 @@ import {
 type SchemaDiffProps = BranchScopeProps & {
   branch?: string;
   baseBranch?: string;
-  compareBranch: string;
+  compareSource: string;
   database: string;
 };
 
@@ -30,7 +30,7 @@ export const schemaDiff = async (props: SchemaDiffProps) => {
   props.branch = props.baseBranch || props.branch;
   const baseBranch = await branchIdFromProps(props);
   const pointInTime: PointInTimeBranchId = await parsePointInTime({
-    pointInTime: props.compareBranch,
+    pointInTime: props.compareSource,
     targetBranchId: baseBranch,
     projectId: props.projectId,
     api: props.apiClient,
@@ -159,9 +159,9 @@ const generateHeader = (pointInTime: PointInTimeBranchId) => {
     and `base-branch` will be either read from context or the primary branch of project.
 */
 export const parseSchemaDiffParams = (props: SchemaDiffProps) => {
-  if (!props.compareBranch) {
+  if (!props.compareSource) {
     if (props.baseBranch) {
-      props.compareBranch = props.baseBranch;
+      props.compareSource = props.baseBranch;
       props.baseBranch = props.branch;
     }
   }

--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -157,12 +157,15 @@ const generateHeader = (pointInTime: PointInTimeBranchId) => {
   The command has two positional optional arguments - [base-branch] and [compare-source]
   If only one argument is specified, we should consider it as `compare-source`
     and `base-branch` will be either read from context or the primary branch of project.
+  If no branches are specified, compare the context branch with its parent
 */
 export const parseSchemaDiffParams = (props: SchemaDiffProps) => {
   if (!props.compareSource) {
     if (props.baseBranch) {
       props.compareSource = props.baseBranch;
       props.baseBranch = props.branch;
+    } else {
+      props.compareSource = '^parent';
     }
   }
   return props;

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,11 @@ builder = builder
       type: 'string',
       default: currentContextFile,
     },
+    color: {
+      describe: 'Colorize the output. Example: --no-color, --color false',
+      type: 'boolean',
+      default: true,
+    },
   })
   .middleware((args) => fillInArgs(args), true)
   .help(false)

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ builder = builder
       default: currentContextFile,
     },
     color: {
+      group: 'Global options:',
       describe: 'Colorize the output. Example: --no-color, --color false',
       type: 'boolean',
       default: true,

--- a/src/utils/point_in_time.ts
+++ b/src/utils/point_in_time.ts
@@ -48,8 +48,18 @@ export const parsePITBranch = (input: string) => {
         ? { tag: 'lsn', lsn: exactPIT }
         : { tag: 'timestamp', timestamp: exactPIT }),
   } satisfies PointInTimeBranch;
-  if (result.tag === 'timestamp' && !looksLikeTimestamp(result.timestamp)) {
-    throw new PointInTimeParseError('Invalid source branch format');
+  if (result.tag === 'timestamp') {
+    const timestamp = result.timestamp;
+    if (!looksLikeTimestamp(timestamp)) {
+      throw new PointInTimeParseError(
+        `Invalid source branch format - ${input}`,
+      );
+    }
+    if (Date.parse(timestamp) > Date.now()) {
+      throw new PointInTimeParseError(
+        `Timestamp can not be in future - ${input}`,
+      );
+    }
   }
   return result;
 };

--- a/src/utils/point_in_time.ts
+++ b/src/utils/point_in_time.ts
@@ -59,7 +59,7 @@ export const parsePointInTime = async ({
   targetBranchId,
   projectId,
   api,
-}: PointInTimeProps) => {
+}: PointInTimeProps): Promise<PointInTimeBranchId> => {
   const parsedPIT = parsePITBranch(pointInTime);
 
   let branchId = '';


### PR DESCRIPTION
closes: https://github.com/neondatabase/cloud/issues/14004
closes: https://github.com/neondatabase/cloud/issues/14005
closes: https://github.com/neondatabase/cloud/issues/14006

```
$ neonctl branches schema-diff [base-branch] [compare-branch[@timestamp|lsn]] 
```

- [x] Compare the branch with Point in time with another branch
- [x] Compare the branch with LSN
- [x] Compare the branch with its parents or parent's history
- [x] Compare branch with self history
- [x] If no compare branch is provided, compare with parent by default
- [x] Compare timestamp if it is in the future 
- [x] Swap base and compare branches when comparing with parent
- [x] Add `--no-color` option to help section.  
- [x] Add `--db` alias for `--database` option



https://github.com/neondatabase/neonctl/assets/1949852/5962adb7-a736-4308-a8b1-ba767c95f7a4


https://github.com/neondatabase/neonctl/assets/1949852/e7593649-23a3-41cf-ab9f-2b0d29af6340



