### PR TITLE
fix: issue with command without any arguments throwing error (when no context)

### DIFF
--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -192,6 +192,11 @@ export const parseSchemaDiffParams = (props: SchemaDiffProps) => {
         `No branches specified. Comparing branch '${props.branch}' with its parent`,
       );
       props.compareSource = '^parent';
+    } else {
+      log.info(
+        `No branches specified. Comparing primary branch with its parent`,
+      );
+      props.compareSource = '^parent';
     }
   }
   return props;

--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -182,17 +182,41 @@ const generateHeader = (pointInTime: PointInTimeBranchId) => {
     and `base-branch` will be either read from context or the primary branch of project.
   If no branches are specified, compare the context branch with its parent
 */
-export const parseSchemaDiffParams = (props: SchemaDiffProps) => {
+export const parseSchemaDiffParams = async (props: SchemaDiffProps) => {
   if (!props.compareSource) {
     if (props.baseBranch) {
       props.compareSource = props.baseBranch;
       props.baseBranch = props.branch;
     } else if (props.branch) {
+      const { data } = await props.apiClient.listProjectBranches(
+        props.projectId,
+      );
+      const contextBranch = data.branches.find(
+        (b) => b.id === props.branch || b.name === props.branch,
+      );
+
+      if (contextBranch?.parent_id == undefined) {
+        throw new Error(
+          `No branch specified. Your context branch (${props.branch}) has no parent, so no comparison is possible.`,
+        );
+      }
+
       log.info(
-        `No branches specified. Comparing branch '${props.branch}' with its parent`,
+        `No branches specified. Comparing your context branch '${props.branch}' with its parent`,
       );
       props.compareSource = '^parent';
     } else {
+      const { data } = await props.apiClient.listProjectBranches(
+        props.projectId,
+      );
+      const primaryBranch = data.branches.find((b) => b.primary);
+
+      if (primaryBranch?.parent_id == undefined) {
+        throw new Error(
+          'No branch specified. Include a base branch or add a set-context branch to continue. Your primary branch has no parent, so no comparison is possible.',
+        );
+      }
+
       log.info(
         `No branches specified. Comparing primary branch with its parent`,
       );


### PR DESCRIPTION
relates: https://github.com/neondatabase/cloud/issues/11846


- [x] Throw error when no branch is specified, and the context branch has no parent
- [x] Throw error when no branch is specified, no context is configured, and primary branch has no parent 

```sh
➜ node dist branches sd 
ERROR: No branch specified. Your context branch (br-twilight-paper-w2yl38qc) has no parent, so no comparison is possible


➜ node dist branches sd --projectId white-wildflower-12758365
ERROR: No branch specified. Include a base branch or add a set-context branch to continue. Your primary branch has no parent, so no comparison is possible.
```

