### PR TITLE
fix: remove storing and enriching branch to/from context

### DIFF
--- a/mocks/main/projects/project-id-123/GET.json
+++ b/mocks/main/projects/project-id-123/GET.json
@@ -1,0 +1,13 @@
+{
+  "project": {
+    "id": "project-id-123",
+    "name": "project name 123",
+    "created_at": "2019-01-01T00:00:00Z",
+    "settings": {
+      "allowed_ips": {
+        "ips": ["192.168.1.1"],
+        "primary_branch_only": false
+      }
+    }
+  }
+}

--- a/snapshots/commands/set_context.test.snap
+++ b/snapshots/commands/set_context.test.snap
@@ -30,3 +30,15 @@ exports[`set_context should set the context list branches selecting project from
   updated_at: 2021-01-01T00:00:00.000Z
 "
 `;
+
+exports[`set_context should set the context set the branchId and projectId is from context test 1`] = `
+"- name: db1
+  owner_name: user1
+- name: db2
+  owner_name: user2
+- name: test_db
+  owner_name: test_user
+"
+`;
+
+exports[`set_context should set the context should not set branchId from context for non-context projectId test 1`] = `""`;

--- a/snapshots/commands/set_context.test.snap
+++ b/snapshots/commands/set_context.test.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`set_context should set the context get branch id overrides context set branch test 1`] = `
-"name: test_branch
-id: br-sunny-branch-123456
-primary: true
-parent_id: br-parent-branch-123456
+exports[`set_context should set the context get project id overrides context set project test 1`] = `
+"id: project-id-123
+name: project name 123
 created_at: 2019-01-01T00:00:00Z
-updated_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 192.168.1.1
+    primary_branch_only: false
 "
 `;
 

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -36,13 +36,12 @@ describe('set_context', () => {
       `neon_override_ctx_${Date.now()}`,
     );
     testCliCommand({
-      name: 'get branch id overrides context set branch',
+      name: 'get project id overrides context set project',
       before: async () => {
         writeFileSync(
           overrideContextFile,
           JSON.stringify({
-            projectId: 'test',
-            branchId: 'br-cloudy-branch-12345678',
+            projectId: 'new-project id',
           }),
         );
       },
@@ -50,9 +49,9 @@ describe('set_context', () => {
         rmSync(overrideContextFile);
       },
       args: [
-        'branches',
+        'project',
         'get',
-        'br-sunny-branch-123456',
+        'project-id-123',
         '--context-file',
         overrideContextFile,
       ],

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -35,6 +35,7 @@ describe('set_context', () => {
       tmpdir(),
       `neon_override_ctx_${Date.now()}`,
     );
+
     testCliCommand({
       name: 'get project id overrides context set project',
       before: async () => {
@@ -56,6 +57,55 @@ describe('set_context', () => {
         overrideContextFile,
       ],
       expected: {
+        snapshot: true,
+      },
+    });
+
+    testCliCommand({
+      name: 'set the branchId and projectId is from context',
+      before: async () => {
+        writeFileSync(
+          overrideContextFile,
+          JSON.stringify({
+            projectId: 'test',
+            branchId: 'test_branch',
+          }),
+        );
+      },
+      after: async () => {
+        rmSync(overrideContextFile);
+      },
+      args: ['databases', 'list', '--context-file', overrideContextFile],
+      expected: {
+        snapshot: true,
+      },
+    });
+
+    testCliCommand({
+      name: 'should not set branchId from context for non-context projectId',
+      before: async () => {
+        writeFileSync(
+          overrideContextFile,
+          JSON.stringify({
+            projectId: 'project-id-123',
+            branchId: 'test_branch',
+          }),
+        );
+      },
+      after: async () => {
+        rmSync(overrideContextFile);
+      },
+      args: [
+        'databases',
+        'list',
+        '--project-id',
+        'test',
+        '--context-file',
+        overrideContextFile,
+      ],
+      expected: {
+        code: 1,
+        stderr: 'ERROR: Not Found',
         snapshot: true,
       },
     });

--- a/src/commands/set_context.ts
+++ b/src/commands/set_context.ts
@@ -1,6 +1,5 @@
 import yargs from 'yargs';
 import { Context, updateContextFile } from '../context.js';
-import { branchIdFromProps } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 
 export const command = 'set-context';
@@ -11,17 +10,11 @@ export const builder = (argv: yargs.Argv) =>
       describe: 'Project ID',
       type: 'string',
     },
-    branch: {
-      describe: 'Branch ID or name',
-      type: 'string',
-    },
   });
 
 export const handler = async (props: BranchScopeProps) => {
-  const branchId = await branchIdFromProps(props);
   const context: Context = {
     projectId: props.projectId,
-    branchId,
   };
   updateContextFile(props.contextFile, context);
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -48,9 +48,6 @@ export const enrichFromContext = (
     return;
   }
   const context = readContextFile(args.contextFile);
-  if (!args.branch && !args.id && !args.name) {
-    args.branch = context.branchId;
-  }
   if (!args.projectId) {
     args.projectId = context.projectId;
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -51,6 +51,14 @@ export const enrichFromContext = (
   if (!args.projectId) {
     args.projectId = context.projectId;
   }
+  if (
+    !args.branch &&
+    !args.id &&
+    !args.name &&
+    context.projectId === args.projectId
+  ) {
+    args.branch = context.branchId;
+  }
 };
 
 export const updateContextFile = (file: string, context: Context) => {


### PR DESCRIPTION

- [x] Remove storing `branchId` to context on `set-context` command
- [x] Still enrich commands with `projectId` and `branchId` from context, for backward compatibility 
- [x] Enrich commands with `branchId` only if the `projectId` is from the context. 