### PR TITLE
feat: use default branch field

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 | [projects](https://neon.tech/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                               | Manage projects              |
 | [ip-allow](https://neon.tech/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                          | Manage IP Allow              |
 | [me](https://neon.tech/docs/reference/cli-me)                               |                                                                           | Show current user            |
-| [branches](https://neon.tech/docs/reference/cli-branches)                   | `list`, `create`, `rename`, `add-compute`, `set-primary`, `delete`, `get` | Manage branches              |
+| [branches](https://neon.tech/docs/reference/cli-branches)                   | `list`, `create`, `rename`, `add-compute`, `set-default`, `delete`, `get` | Manage branches              |
 | [databases](https://neon.tech/docs/reference/cli-databases)                 | `list`, `create`, `delete`                                                | Manage databases             |
 | [roles](https://neon.tech/docs/reference/cli-roles)                         | `list`, `create`, `delete`                                                | Manage roles                 |
 | [operations](https://neon.tech/docs/reference/cli-operations)               | `list`                                                                    | Manage operations            |

--- a/mocks/main/projects/test/branches/GET.json
+++ b/mocks/main/projects/test/branches/GET.json
@@ -3,7 +3,7 @@
     {
       "id": "br-main-branch-123456",
       "name": "main",
-      "primary": true,
+      "default": true,
       "created_at": "2021-01-01T00:00:00.000Z",
       "updated_at": "2021-01-01T00:00:00.000Z"
     },

--- a/mocks/main/projects/test/branches/br-cloudy-branch-12345678/GET.json
+++ b/mocks/main/projects/test/branches/br-cloudy-branch-12345678/GET.json
@@ -2,7 +2,7 @@
   "branch": {
     "name": "test-branch-cloudy",
     "id": "br-cloudy-branch-12345678",
-    "primary": true,
+    "default": true,
     "created_at": "2019-01-01T00:00:00Z",
     "updated_at": "2019-01-01T00:00:00Z"
   }

--- a/mocks/main/projects/test/branches/br-numbered-branch-123456/GET.json
+++ b/mocks/main/projects/test/branches/br-numbered-branch-123456/GET.json
@@ -2,7 +2,7 @@
   "branch": {
     "name": "123",
     "id": "br-numbered-branch-123456",
-    "primary": false,
+    "default": false,
     "parent_id": "br-parent-branch-123456",
     "created_at": "2019-01-01T00:00:00Z",
     "updated_at": "2019-01-01T00:00:00Z"

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/GET.json
@@ -2,7 +2,7 @@
   "branch": {
     "name": "test_branch",
     "id": "br-sunny-branch-123456",
-    "primary": true,
+    "default": true,
     "parent_id": "br-parent-branch-123456",
     "created_at": "2019-01-01T00:00:00Z",
     "updated_at": "2019-01-01T00:00:00Z"

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/set_as_default/POST.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/set_as_default/POST.json
@@ -1,8 +1,8 @@
 {
   "branch": {
-    "name": "test-branch-cloudy",
-    "id": "br-cloudy-branch-12345678",
-    "primary": true,
+    "name": "test-branch-sunny",
+    "id": "br-sunny-branch-123456",
+    "default": true,
     "created_at": "2019-01-01T00:00:00Z",
     "updated_at": "2019-01-01T00:00:00Z"
   }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/set_as_primary/POST.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/set_as_primary/POST.json
@@ -1,9 +1,0 @@
-{
-  "branch": {
-    "name": "test-branch-sunny",
-    "id": "br-sunny-branch-123456",
-    "primary": true,
-    "created_at": "2019-01-01T00:00:00Z",
-    "updated_at": "2019-01-01T00:00:00Z"
-  }
-}

--- a/mocks/single_project/projects/test-project-123456/branches/GET.json
+++ b/mocks/single_project/projects/test-project-123456/branches/GET.json
@@ -3,7 +3,7 @@
     {
       "id": "br-main-branch-123456",
       "name": "main",
-      "primary": true,
+      "default": true,
       "created_at": "2021-01-01T00:00:00.000Z",
       "updated_at": "2021-01-01T00:00:00.000Z"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
-        "@neondatabase/api-client": "1.8.0",
+        "@neondatabase/api-client": "1.9.0",
         "@segment/analytics-node": "^1.0.0-beta.26",
         "axios": "^1.4.0",
         "axios-debug-log": "^1.0.0",
@@ -2080,9 +2080,9 @@
       }
     },
     "node_modules/@neondatabase/api-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.8.0.tgz",
-      "integrity": "sha512-NzVeu/4uXnQBTT7c/UUy7j4I4UVsoXSINZYyCht8C6Pdo5keNLa0cQlTdCykVEkydaZg1XOnedyoQEg9ofWVDw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.9.0.tgz",
+      "integrity": "sha512-BKU4KtPTc7onh7B5wytg4hTT5RjT6Ln6SH7gQs+warTi0j0YFo0pTwckBG6njDLIvquQXxGBfvI8WiXmAW0Yww==",
       "dependencies": {
         "axios": "^1.4.0"
       }
@@ -17134,9 +17134,9 @@
       }
     },
     "@neondatabase/api-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.8.0.tgz",
-      "integrity": "sha512-NzVeu/4uXnQBTT7c/UUy7j4I4UVsoXSINZYyCht8C6Pdo5keNLa0cQlTdCykVEkydaZg1XOnedyoQEg9ofWVDw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.9.0.tgz",
+      "integrity": "sha512-BKU4KtPTc7onh7B5wytg4hTT5RjT6Ln6SH7gQs+warTi0j0YFo0pTwckBG6njDLIvquQXxGBfvI8WiXmAW0Yww==",
       "requires": {
         "axios": "^1.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@neondatabase/api-client": "1.8.0",
+    "@neondatabase/api-client": "1.9.0",
     "@segment/analytics-node": "^1.0.0-beta.26",
     "axios": "^1.4.0",
     "axios-debug-log": "^1.0.0",

--- a/snapshots/commands/branches.test.snap
+++ b/snapshots/commands/branches.test.snap
@@ -118,7 +118,7 @@ created_at: 2021-01-01T00:00:00.000Z
 exports[`branches get by id test 1`] = `
 "name: test_branch
 id: br-sunny-branch-123456
-primary: true
+default: true
 parent_id: br-parent-branch-123456
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
@@ -128,7 +128,7 @@ updated_at: 2019-01-01T00:00:00Z
 exports[`branches get by id test 2`] = `
 "name: test-branch-cloudy
 id: br-cloudy-branch-12345678
-primary: true
+default: true
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
 "
@@ -137,7 +137,7 @@ updated_at: 2019-01-01T00:00:00Z
 exports[`branches get by name test 1`] = `
 "name: test_branch
 id: br-sunny-branch-123456
-primary: true
+default: true
 parent_id: br-parent-branch-123456
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
@@ -147,7 +147,7 @@ updated_at: 2019-01-01T00:00:00Z
 exports[`branches get by name with numeric name test 1`] = `
 "name: "123"
 id: br-numbered-branch-123456
-primary: false
+default: false
 parent_id: br-parent-branch-123456
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
@@ -157,7 +157,7 @@ updated_at: 2019-01-01T00:00:00Z
 exports[`branches list test 1`] = `
 "- id: br-main-branch-123456
   name: main
-  primary: true
+  default: true
   created_at: 2021-01-01T00:00:00.000Z
   updated_at: 2021-01-01T00:00:00.000Z
 - id: br-sunny-branch-123456
@@ -214,7 +214,16 @@ last_reset_at: 2021-01-01T00:00:00Z
 exports[`branches set primary by id test 1`] = `
 "name: test-branch-sunny
 id: br-sunny-branch-123456
-primary: true
+default: true
+created_at: 2019-01-01T00:00:00Z
+updated_at: 2019-01-01T00:00:00Z
+"
+`;
+
+exports[`branches set default by id test 1`] = `
+"name: test-branch-sunny
+id: br-sunny-branch-123456
+default: true
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
 "

--- a/snapshots/commands/set_context.test.snap
+++ b/snapshots/commands/set_context.test.snap
@@ -3,7 +3,7 @@
 exports[`set_context should set the context get branch id overrides context set branch test 1`] = `
 "name: test_branch
 id: br-sunny-branch-123456
-primary: true
+default: true
 parent_id: br-parent-branch-123456
 created_at: 2019-01-01T00:00:00Z
 updated_at: 2019-01-01T00:00:00Z
@@ -13,7 +13,7 @@ updated_at: 2019-01-01T00:00:00Z
 exports[`set_context should set the context list branches selecting project from the context test 1`] = `
 "- id: br-main-branch-123456
   name: main
-  primary: true
+  default: true
   created_at: 2021-01-01T00:00:00.000Z
   updated_at: 2021-01-01T00:00:00.000Z
 - id: br-sunny-branch-123456

--- a/src/commands/branches.test.ts
+++ b/src/commands/branches.test.ts
@@ -215,6 +215,22 @@ describe('branches', () => {
     },
   });
 
+  /* set default */
+
+  testCliCommand({
+    name: 'set default by id',
+    args: [
+      'branches',
+      'set-default',
+      'br-sunny-branch-123456',
+      '--project-id',
+      'test',
+    ],
+    expected: {
+      snapshot: true,
+    },
+  });
+
   /* get */
 
   testCliCommand({

--- a/src/commands/connection_string.ts
+++ b/src/commands/connection_string.ts
@@ -24,7 +24,7 @@ export const builder = (argv: yargs.Argv) => {
       'Get connection string for the main branch at a specific LSN',
     )
     .positional('branch', {
-      describe: `Branch name or id. Defaults to the primary branch if omitted. Can be written in the point-in-time format: "branch@timestamp" or "branch@lsn"`,
+      describe: `Branch name or id. Defaults to the default branch if omitted. Can be written in the point-in-time format: "branch@timestamp" or "branch@lsn"`,
       type: 'string',
     })
     .options({

--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -179,7 +179,7 @@ const generateHeader = (pointInTime: PointInTimeBranchId) => {
 /*
   The command has two positional optional arguments - [base-branch] and [compare-source]
   If only one argument is specified, we should consider it as `compare-source`
-    and `base-branch` will be either read from context or the primary branch of project.
+    and `base-branch` will be either read from context or the default branch of project.
   If no branches are specified, compare the context branch with its parent
 */
 export const parseSchemaDiffParams = async (props: SchemaDiffProps) => {
@@ -209,16 +209,16 @@ export const parseSchemaDiffParams = async (props: SchemaDiffProps) => {
       const { data } = await props.apiClient.listProjectBranches(
         props.projectId,
       );
-      const primaryBranch = data.branches.find((b) => b.primary);
+      const defaultBranch = data.branches.find((b) => b.default);
 
-      if (primaryBranch?.parent_id == undefined) {
+      if (defaultBranch?.parent_id == undefined) {
         throw new Error(
-          'No branch specified. Include a base branch or add a set-context branch to continue. Your primary branch has no parent, so no comparison is possible.',
+          'No branch specified. Include a base branch or add a set-context branch to continue. Your default branch has no parent, so no comparison is possible.',
         );
       }
 
       log.info(
-        `No branches specified. Comparing primary branch with its parent`,
+        `No branches specified. Comparing default branch with its parent`,
       );
       props.compareSource = '^parent';
     }

--- a/src/parameters.gen.ts
+++ b/src/parameters.gen.ts
@@ -38,7 +38,7 @@ export const projectCreateRequest = {
   },
   'project.settings.allowed_ips.primary_branch_only': {
               type: "boolean",
-              description: "If true, the list will be applied only to the primary branch.",
+              description: "If true, the list will be applied only to the default branch.",
               demandOption: false,
   },
   'project.settings.enable_logical_replication': {
@@ -142,7 +142,7 @@ export const projectUpdateRequest = {
   },
   'project.settings.allowed_ips.primary_branch_only': {
               type: "boolean",
-              description: "If true, the list will be applied only to the primary branch.",
+              description: "If true, the list will be applied only to the default branch.",
               demandOption: false,
   },
   'project.settings.enable_logical_replication': {
@@ -175,7 +175,7 @@ export const branchCreateRequest = {
   },
   'branch.parent_id': {
               type: "string",
-              description: "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's primary branch.\n",
+              description: "The `branch_id` of the parent branch. If omitted or empty, the branch will be created from the project's default branch.\n",
               demandOption: false,
   },
   'branch.name': {

--- a/src/utils/enrichers.ts
+++ b/src/utils/enrichers.ts
@@ -42,13 +42,13 @@ export const branchIdFromProps = async (props: BranchScopeProps) => {
   }
 
   const { data } = await props.apiClient.listProjectBranches(props.projectId);
-  const primaryBranch = data.branches.find((b) => b.primary);
+  const defaultBranch = data.branches.find((b) => b.default);
 
-  if (primaryBranch) {
-    return primaryBranch.id;
+  if (defaultBranch) {
+    return defaultBranch.id;
   }
 
-  throw new Error('No primary branch found');
+  throw new Error('No default branch found');
 };
 
 export const fillSingleProject = async (


### PR DESCRIPTION
Closes https://github.com/neondatabase/neonctl/issues/230 and https://github.com/neondatabase/cloud/issues/9951

* Use default branch field instead of primary
* Use set_as_default API endpoint
* Deprecate set-primary CLI command