### PR TITLE
fix: do not store branchid in context (#237)

### DIFF
--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -209,7 +209,6 @@ const create = async (
   if (props.setContext) {
     updateContextFile(props.contextFile, {
       projectId: data.project.id,
-      branchId: data.branch.id,
     });
   }
 


### PR DESCRIPTION
as part of https://github.com/neondatabase/neonctl/pull/231 missed to remove the setting `branchId` in context from project create with `--set-context` option.