### PR TITLE
feat: add protected-only option to IP allow, deprecate primary-only

### DIFF
--- a/mocks/single_project/projects/GET.json
+++ b/mocks/single_project/projects/GET.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "id": "test-project-123456",
-      "name": "",
+      "name": "test-project-123456",
       "created_at": "2019-01-01T00:00:00.000Z",
       "updated_at": "2019-01-01T00:00:00.000Z"
     }

--- a/mocks/single_project/projects/test-project-123456/GET.json
+++ b/mocks/single_project/projects/test-project-123456/GET.json
@@ -1,13 +1,14 @@
 {
   "project": {
     "id": "test-project-123456",
-    "name": "",
+    "name": "test-project-123456",
     "created_at": "2019-01-01T00:00:00.000Z",
     "updated_at": "2019-01-01T00:00:00.000Z",
     "settings": {
       "allowed_ips": {
         "ips": ["192.168.1.1"],
-        "primary_branch_only": false
+        "primary_branch_only": false,
+        "protected_branch_only": false
       }
     }
   }

--- a/src/commands/__snapshots__/ip_allow.test.ts.snap
+++ b/src/commands/__snapshots__/ip_allow.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ip-allow > Add IP allow > test 1`] = `
+exports[`ip-allow > Add IP allow - Primary > test 1`] = `
 "id: test
 name: test_project
 IP_addresses:
@@ -8,6 +8,17 @@ IP_addresses:
   - 192.168.10.1-192.168.10.15
   - 192.168.1.1
 primary_branch_only: true
+"
+`;
+
+exports[`ip-allow > Add IP allow - Protected > test 1`] = `
+"id: test
+name: test_project
+IP_addresses:
+  - 127.0.0.1
+  - 192.168.10.1-192.168.10.15
+  - 192.168.1.1
+protected_branches_only: true
 "
 `;
 

--- a/src/commands/__snapshots__/ip_allow.test.ts.snap
+++ b/src/commands/__snapshots__/ip_allow.test.ts.snap
@@ -8,6 +8,7 @@ IP_addresses:
   - 192.168.10.1-192.168.10.15
   - 192.168.1.1
 primary_branch_only: true
+protected_branches_only: false
 "
 `;
 
@@ -18,6 +19,7 @@ IP_addresses:
   - 127.0.0.1
   - 192.168.10.1-192.168.10.15
   - 192.168.1.1
+primary_branch_only: false
 protected_branches_only: true
 "
 `;
@@ -27,6 +29,7 @@ exports[`ip-allow > Remove IP allow > test 1`] = `
 name: test_project
 IP_addresses: []
 primary_branch_only: false
+protected_branches_only: false
 "
 `;
 
@@ -35,6 +38,7 @@ exports[`ip-allow > Reset IP allow > test 1`] = `
 name: test_project
 IP_addresses: []
 primary_branch_only: false
+protected_branches_only: false
 "
 `;
 
@@ -44,15 +48,17 @@ name: test_project
 IP_addresses:
   - 192.168.2.2
 primary_branch_only: false
+protected_branches_only: false
 "
 `;
 
 exports[`ip-allow > list IP Allow with single-project > test 1`] = `
 "id: test-project-123456
-name: ""
+name: test-project-123456
 IP_addresses:
   - 192.168.1.1
 primary_branch_only: false
+protected_branches_only: false
 "
 `;
 
@@ -62,5 +68,6 @@ name: test_project
 IP_addresses:
   - 192.168.1.1
 primary_branch_only: false
+protected_branches_only: false
 "
 `;

--- a/src/commands/ip_allow.test.ts
+++ b/src/commands/ip_allow.test.ts
@@ -30,13 +30,29 @@ describe('ip-allow', () => {
   });
 
   testCliCommand({
-    name: 'Add IP allow',
+    name: 'Add IP allow - Primary',
     args: [
       'ip-allow',
       'add',
       '127.0.0.1',
       '192.168.10.1-192.168.10.15',
       '--primary-only',
+      '--project-id',
+      'test',
+    ],
+    expected: {
+      snapshot: true,
+    },
+  });
+
+  testCliCommand({
+    name: 'Add IP allow - Protected',
+    args: [
+      'ip-allow',
+      'add',
+      '127.0.0.1',
+      '192.168.10.1-192.168.10.15',
+      '--protected-only',
       '--project-id',
       'test',
     ],

--- a/src/commands/ip_allow.test.ts
+++ b/src/commands/ip_allow.test.ts
@@ -87,6 +87,7 @@ describe('ip-allow', () => {
 name: test_project
 IP_addresses: []
 primary_branch_only: false
+protected_branches_only: false
 `,
       stderr: `INFO: The IP allowlist has been reset. All databases on project "test_project" are now exposed to the internet`,
     },

--- a/src/commands/ip_allow.ts
+++ b/src/commands/ip_allow.ts
@@ -10,7 +10,7 @@ const IP_ALLOW_FIELDS = [
   'id',
   'name',
   'IP_addresses',
-  'primary_branch_only',
+  'protected_branches_only',
 ] as const;
 
 export const command = 'ip-allow';
@@ -166,6 +166,8 @@ const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
       ips:
         existingAllowedIps?.ips?.filter((ip) => !props.ips.includes(ip)) ?? [],
       primary_branch_only: existingAllowedIps?.primary_branch_only ?? false,
+      protected_branches_only:
+        existingAllowedIps?.protected_branches_only ?? false,
     },
   };
 
@@ -188,6 +190,7 @@ const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
     allowed_ips: {
       ips: props.ips,
       primary_branch_only: false,
+      protected_branches_only: false,
     },
   };
 
@@ -215,5 +218,7 @@ const parse = (project: Project) => {
     IP_addresses: ips,
     primary_branch_only:
       project.settings?.allowed_ips?.primary_branch_only ?? false,
+    protected_branches_only:
+      project.settings?.allowed_ips?.protected_branches_only ?? false,
   };
 };

--- a/src/commands/ip_allow.ts
+++ b/src/commands/ip_allow.ts
@@ -46,6 +46,15 @@ export const builder = (argv: yargs.Argv) => {
             array: true,
           })
           .options({
+            'protected-only': {
+              describe:
+                projectUpdateRequest[
+                  'project.settings.allowed_ips.protected_branches_only'
+                ].description,
+              type: 'boolean',
+            },
+          })
+          .options({
             'primary-only': {
               describe:
                 projectUpdateRequest[
@@ -104,6 +113,7 @@ const add = async (
     ProjectScopeProps & {
       ips: string[];
       primaryOnly?: boolean;
+      protectedOnly?: boolean;
     },
 ) => {
   if (props.ips.length <= 0) {
@@ -120,6 +130,10 @@ const add = async (
       ips: [...new Set(props.ips.concat(existingAllowedIps?.ips ?? []))],
       primary_branch_only:
         props.primaryOnly ?? existingAllowedIps?.primary_branch_only ?? false,
+      protected_branches_only:
+        props.protectedOnly ??
+        existingAllowedIps?.protected_branches_only ??
+        false,
     },
   };
 
@@ -133,6 +147,7 @@ const add = async (
   writer(props).end(parse(response.project), {
     fields: IP_ALLOW_FIELDS,
   });
+  // TODO: also modify this
 };
 
 const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
@@ -164,6 +179,7 @@ const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
   writer(props).end(parse(response.project), {
     fields: IP_ALLOW_FIELDS,
   });
+  // TODO: also modify this
 };
 
 const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
@@ -188,6 +204,7 @@ const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
       `The IP allowlist has been reset. All databases on project "${data.project.name}" are now exposed to the internet`,
     );
   }
+  // TODO: also modify this
 };
 
 const parse = (project: Project) => {

--- a/src/commands/ip_allow.ts
+++ b/src/commands/ip_allow.ts
@@ -61,6 +61,7 @@ export const builder = (argv: yargs.Argv) => {
                   'project.settings.allowed_ips.primary_branch_only'
                 ].description,
               type: 'boolean',
+              deprecated: 'See --protected-only',
             },
           }),
       async (args) => {
@@ -147,7 +148,6 @@ const add = async (
   writer(props).end(parse(response.project), {
     fields: IP_ALLOW_FIELDS,
   });
-  // TODO: also modify this
 };
 
 const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
@@ -181,7 +181,6 @@ const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
   writer(props).end(parse(response.project), {
     fields: IP_ALLOW_FIELDS,
   });
-  // TODO: also modify this
 };
 
 const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
@@ -207,7 +206,6 @@ const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
       `The IP allowlist has been reset. All databases on project "${data.project.name}" are now exposed to the internet`,
     );
   }
-  // TODO: also modify this
 };
 
 const parse = (project: Project) => {


### PR DESCRIPTION
Closes https://github.com/neondatabase/cloud/issues/9951

- [x] Display `protected-only` flag for `ip-allow list` command (in table format, JSON and YAML will display both `primary-only` and `protected-only` flags
- [x] Add `protected-only` flag support for `ip-allow add` command
- [x] Deprecate `primary-only` flag from `ip-allow add` command   