### PR TITLE
refactor: add typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,9 @@
   },
   "scripts": {
     "watch": "tsc --watch",
-    "lint": "tsc --noEmit && eslint src --ext .ts && prettier --check .",
-    "lint:fix": "tsc --noEmit && eslint src --ext .ts --fix && prettier --w .",
+    "typecheck": "tsc --noEmit",
+    "lint": "npm run typecheck && eslint src --ext .ts && prettier --check .",
+    "lint:fix": "npm run typecheck && eslint src --ext .ts --fix && prettier --w .",
     "build": "bun generateParams && bun clean && tsc && cp src/*.html package*.json README.md ./dist",
     "clean": "rm -rf dist",
     "generateParams": "bun generateOptionsFromSpec.ts",


### PR DESCRIPTION
Added `npm run typecheck` script for ease of usage as I needed to run it a lot to make sure my refactor didn't break anything.