### PR TITLE
refactor: ignore .history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bundle/
 .neon
 coverage
 tmp/
+.history


### PR DESCRIPTION
I use [local history](https://marketplace.visualstudio.com/items?itemName=xyz.local-history) VSCode extension to backup accidentally removed code. It is done by storing all the version of files locally in `.history` directory.

Unfortunately, prettier does try to format files in this directory sometimes stumbling upon merge markers.
Fortunately, prettier does include `.gitignore` to its own ignore list
Unfortunately, it does not include `~/.gitignore` where I keep ignoring my `.history` dir for every git repo

I decided to add `.history` to local `.gitignore` so it is ignored both by git and prettier.