### PR TITLE
feat: add org oauth scopes #cloud/13076

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,6 +23,11 @@ const NEONCTL_SCOPES = [
   'urn:neoncloud:projects:read',
   'urn:neoncloud:projects:update',
   'urn:neoncloud:projects:delete',
+  'urn:neoncloud:orgs:create',
+  'urn:neoncloud:orgs:read',
+  'urn:neoncloud:orgs:update',
+  'urn:neoncloud:orgs:delete',
+  'urn:neoncloud:orgs:permission',
 ] as const;
 
 const AUTH_TIMEOUT_SECONDS = 60;


### PR DESCRIPTION
Related to https://github.com/neondatabase/cloud/issues/13076

Back-end changes in https://github.com/neondatabase/cloud/pull/15724

**Test**

After deploying back-end change to staging, I tested this change locally `npm start auth -- --oauth-host=https://oauth2-stage.neon.build`

Tested on prod too, worked correctly. `npm start auth -- --oauth-host=https://oauth2.neon.tech`