### PR TITLE
feat: ability to set org context

### DIFF
--- a/mocks/main/projects/GET.js
+++ b/mocks/main/projects/GET.js
@@ -6,33 +6,49 @@ export default function (req, res) {
   });
 
   if (req.query.org_id) {
-    expect(req.query.org_id).toBe('org-2');
+    expect(['org-2', 'org-3']).toContain(req.query.org_id);
 
-    return res.json({
-      projects: [
-        {
-          id: 4,
-          name: 'Project_4',
-          created_at: '2019-01-01T00:00:00.000Z',
-          updated_at: '2019-01-01T00:00:00.000Z',
-          org_id: 'org-2',
-        },
-        {
-          id: 5,
-          name: 'Project_5',
-          created_at: '2019-01-01T00:00:00.000Z',
-          updated_at: '2019-01-01T00:00:00.000Z',
-          org_id: 'org-2',
-        },
-        {
-          id: 6,
-          name: 'Project_6',
-          created_at: '2019-01-01T00:00:00.000Z',
-          updated_at: '2019-01-01T00:00:00.000Z',
-          org_id: 'org-2',
-        },
-      ],
-    });
+    if (req.query.org_id === 'org-2') {
+      return res.json({
+        projects: [
+          {
+            id: 4,
+            name: 'Project_4',
+            created_at: '2019-01-01T00:00:00.000Z',
+            updated_at: '2019-01-01T00:00:00.000Z',
+            org_id: 'org-2',
+          },
+          {
+            id: 5,
+            name: 'Project_5',
+            created_at: '2019-01-01T00:00:00.000Z',
+            updated_at: '2019-01-01T00:00:00.000Z',
+            org_id: 'org-2',
+          },
+          {
+            id: 6,
+            name: 'Project_6',
+            created_at: '2019-01-01T00:00:00.000Z',
+            updated_at: '2019-01-01T00:00:00.000Z',
+            org_id: 'org-2',
+          },
+        ],
+      });
+    }
+
+    if (req.query.org_id === 'org-3') {
+      return res.json({
+        projects: [
+          {
+            id: 7,
+            name: 'Project_7',
+            created_at: '2019-01-01T00:00:00.000Z',
+            updated_at: '2019-01-01T00:00:00.000Z',
+            org_id: 'org-3',
+          },
+        ],
+      });
+    }
   }
 
   res.json({

--- a/src/commands/__snapshots__/set_context.test.ts.snap
+++ b/src/commands/__snapshots__/set_context.test.ts.snap
@@ -1,6 +1,53 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`set_context > should set the context > get project id overrides context set project 1`] = `
+exports[`set_context > should set the context to organization > create projects selecting organization from the context 1`] = `
+"project:
+  id: new-project-789012
+  name: test_project
+  created_at: 2022-01-01T00:00:00.000Z
+  org_id: org-2
+connection_uris:
+  - connection_uri: postgres://localhost:5432/test_project
+"
+`;
+
+exports[`set_context > should set the context to organization > list projects selecting organization from the context 1`] = `
+"- id: 4
+  name: Project_4
+  created_at: 2019-01-01T00:00:00.000Z
+  updated_at: 2019-01-01T00:00:00.000Z
+  org_id: org-2
+- id: 5
+  name: Project_5
+  created_at: 2019-01-01T00:00:00.000Z
+  updated_at: 2019-01-01T00:00:00.000Z
+  org_id: org-2
+- id: 6
+  name: Project_6
+  created_at: 2019-01-01T00:00:00.000Z
+  updated_at: 2019-01-01T00:00:00.000Z
+  org_id: org-2
+"
+`;
+
+exports[`set_context > should set the context to organization > list projects with explicit org id overrides context 1`] = `
+"- id: 7
+  name: Project_7
+  created_at: 2019-01-01T00:00:00.000Z
+  updated_at: 2019-01-01T00:00:00.000Z
+  org_id: org-3
+"
+`;
+
+exports[`set_context > should set the context to organization > set-context 1`] = `""`;
+
+exports[`set_context > should set the context to organization > set-context 2`] = `
+"{
+  "orgId": "org-2"
+}"
+`;
+
+exports[`set_context > should set the context to project > get project id overrides context set project 1`] = `
 "id: project-id-123
 name: project name 123
 created_at: 2019-01-01T00:00:00Z
@@ -12,7 +59,7 @@ settings:
 "
 `;
 
-exports[`set_context > should set the context > list branches selecting project from the context 1`] = `
+exports[`set_context > should set the context to project > list branches selecting project from the context 1`] = `
 "- id: br-main-branch-123456
   name: main
   default: true
@@ -41,7 +88,7 @@ exports[`set_context > should set the context > list branches selecting project 
 "
 `;
 
-exports[`set_context > should set the context > set the branchId and projectId is from context 1`] = `
+exports[`set_context > should set the context to project > set the branchId and projectId is from context 1`] = `
 "- name: db1
   owner_name: user1
 - name: db2
@@ -51,11 +98,11 @@ exports[`set_context > should set the context > set the branchId and projectId i
 "
 `;
 
-exports[`set_context > should set the context > set the branchId and projectId is from context 2`] = `""`;
+exports[`set_context > should set the context to project > set the branchId and projectId is from context 2`] = `""`;
 
-exports[`set_context > should set the context > set-context 1`] = `""`;
+exports[`set_context > should set the context to project > set-context 1`] = `""`;
 
-exports[`set_context > should set the context > set-context 2`] = `
+exports[`set_context > should set the context to project > set-context 2`] = `
 "{
   "projectId": "test"
 }"

--- a/src/commands/__snapshots__/set_context.test.ts.snap
+++ b/src/commands/__snapshots__/set_context.test.ts.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`set_context > can set the context to project and organization at the same time > set-context 1`] = `""`;
+
+exports[`set_context > can set the context to project and organization at the same time > set-context 2`] = `
+"{
+  "projectId": "test_project",
+  "orgId": "org-2"
+}"
+`;
+
 exports[`set_context > should set the context to organization > create projects selecting organization from the context 1`] = `
 "project:
   id: new-project-789012

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -186,4 +186,19 @@ describe('set_context', () => {
       ]);
     });
   });
+
+  describe('can set the context to project and organization at the same time', () => {
+    test('set-context', async ({ testCliCommand, readFile }) => {
+      await testCliCommand([
+        'set-context',
+        '--project-id',
+        'test_project',
+        '--org-id',
+        'org-2',
+        '--context-file',
+        CONTEXT_FILE,
+      ]);
+      expect(readFile(CONTEXT_FILE)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -36,7 +36,7 @@ const test = originalTest.extend<{
 });
 
 describe('set_context', () => {
-  describe('should set the context', () => {
+  describe('should set the context to project', () => {
     test('set-context', async ({ testCliCommand, readFile }) => {
       await testCliCommand([
         'set-context',
@@ -122,6 +122,68 @@ describe('set_context', () => {
           stderr: 'ERROR: Not Found',
         },
       );
+    });
+  });
+
+  describe('should set the context to organization', () => {
+    test('set-context', async ({ testCliCommand, readFile }) => {
+      await testCliCommand([
+        'set-context',
+        '--org-id',
+        'org-2',
+        '--context-file',
+        CONTEXT_FILE,
+      ]);
+      expect(readFile(CONTEXT_FILE)).toMatchSnapshot();
+    });
+
+    test('list projects selecting organization from the context', async ({
+      testCliCommand,
+      writeFile,
+    }) => {
+      writeFile(CONTEXT_FILE, {
+        orgId: 'org-2',
+      });
+      await testCliCommand([
+        'projects',
+        'list',
+        '--context-file',
+        CONTEXT_FILE,
+      ]);
+    });
+
+    test('list projects with explicit org id overrides context', async ({
+      testCliCommand,
+      writeFile,
+    }) => {
+      writeFile(CONTEXT_FILE, {
+        orgId: 'org-2',
+      });
+      await testCliCommand([
+        'project',
+        'list',
+        '--org-id',
+        'org-3',
+        '--context-file',
+        CONTEXT_FILE,
+      ]);
+    });
+
+    test('create projects selecting organization from the context', async ({
+      testCliCommand,
+      writeFile,
+    }) => {
+      writeFile(CONTEXT_FILE, {
+        orgId: 'org-2',
+      });
+      await testCliCommand([
+        'projects',
+        'create',
+        '--name',
+        'test_project',
+        '--context-file',
+        CONTEXT_FILE,
+      ]);
     });
   });
 });

--- a/src/commands/set_context.ts
+++ b/src/commands/set_context.ts
@@ -1,6 +1,11 @@
 import yargs from 'yargs';
 import { Context, updateContextFile } from '../context.js';
-import { BranchScopeProps } from '../types.js';
+import { CommonProps } from '../types.js';
+
+type SetContextProps = {
+  projectId?: string;
+  orgId?: string;
+};
 
 export const command = 'set-context';
 export const describe = 'Set the current context';
@@ -10,11 +15,16 @@ export const builder = (argv: yargs.Argv) =>
       describe: 'Project ID',
       type: 'string',
     },
+    'org-id': {
+      describe: 'Organization ID',
+      type: 'string',
+    },
   });
 
-export const handler = (props: BranchScopeProps) => {
+export const handler = (props: CommonProps & SetContextProps) => {
   const context: Context = {
     projectId: props.projectId,
+    orgId: props.orgId,
   };
   updateContextFile(props.contextFile, context);
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,6 +4,7 @@ import { normalize, resolve } from 'node:path';
 import yargs from 'yargs';
 
 export type Context = {
+  orgId?: string;
   projectId?: string;
   branchId?: string;
 };
@@ -48,6 +49,9 @@ export const enrichFromContext = (
     return;
   }
   const context = readContextFile(args.contextFile);
+  if (!args.orgId) {
+    args.orgId = context.orgId;
+  }
   if (!args.projectId) {
     args.projectId = context.projectId;
   }


### PR DESCRIPTION
Related to https://github.com/neondatabase/cloud/issues/13076

Changes
* You can now set org context `neonctl set-context --org-id org-round-art-46961103`
* This will set the context for `neonctl projects list` and `neonctl projects create`

**Testing**
![Screenshot 2024-08-12 at 19 44 01](https://github.com/user-attachments/assets/da67acef-8717-4c6d-9219-3b63b2cc731e)

You can also reset the context by calling `neonctl set-context` without any params
![Screenshot 2024-08-12 at 19 46 10](https://github.com/user-attachments/assets/ee742e8d-5f98-47d8-a6eb-cde4a747d449)
