### PR TITLE
feat: Add `azure-eastus2` and `aws-ap-southeast-2` regions

### DIFF
--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -29,6 +29,7 @@ const REGIONS = [
   'aws-eu-central-1',
   'aws-us-east-2',
   'aws-us-east-1',
+  'azure-eastus2',
 ];
 
 const PROJECTS_LIST_LIMIT = 100;

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -26,6 +26,7 @@ export const PROJECT_FIELDS = [
 const REGIONS = [
   'aws-us-west-2',
   'aws-ap-southeast-1',
+  'aws-ap-southeast-2',
   'aws-eu-central-1',
   'aws-us-east-2',
   'aws-us-east-1',


### PR DESCRIPTION
The initial goal was to add `azure` region. However, while adding it, I noticed that `aws-ap-southeast-2` is also missing.