### PR TITLE
chore: remove deprecated set-primary command

### DIFF
--- a/mocks/main/projects/project-id-123/GET.json
+++ b/mocks/main/projects/project-id-123/GET.json
@@ -6,7 +6,7 @@
     "settings": {
       "allowed_ips": {
         "ips": ["192.168.1.1"],
-        "primary_branch_only": false
+        "protected_branches_only": false
       }
     }
   }

--- a/mocks/main/projects/test/GET.json
+++ b/mocks/main/projects/test/GET.json
@@ -6,7 +6,7 @@
     "settings": {
       "allowed_ips": {
         "ips": ["192.168.1.1"],
-        "primary_branch_only": false
+        "protected_branches_only": false
       }
     }
   }

--- a/mocks/main/projects/test/PATCH.js
+++ b/mocks/main/projects/test/PATCH.js
@@ -1,7 +1,7 @@
 const defaultSettings = {
   allowed_ips: {
     ips: ['192.168.1.1'],
-    primary_branch_only: false,
+    protected_branches_only: false,
   },
 };
 

--- a/mocks/main/projects/test_project_with_autoscaling/PATCH.js
+++ b/mocks/main/projects/test_project_with_autoscaling/PATCH.js
@@ -1,7 +1,7 @@
 const defaultSettings = {
   allowed_ips: {
     ips: ['192.168.1.1'],
-    primary_branch_only: false,
+    protected_branches_only: false,
   },
 };
 

--- a/mocks/main/projects/test_project_with_fixed_cu/PATCH.js
+++ b/mocks/main/projects/test_project_with_fixed_cu/PATCH.js
@@ -1,7 +1,7 @@
 const defaultSettings = {
   allowed_ips: {
     ips: ['192.168.1.1'],
-    primary_branch_only: false,
+    protected_branches_only: false,
   },
 };
 

--- a/mocks/single_project/projects/test-project-123456/GET.json
+++ b/mocks/single_project/projects/test-project-123456/GET.json
@@ -7,8 +7,7 @@
     "settings": {
       "allowed_ips": {
         "ips": ["192.168.1.1"],
-        "primary_branch_only": false,
-        "protected_branch_only": false
+        "protected_branches_only": false
       }
     }
   }

--- a/src/commands/__snapshots__/branches.test.ts.snap
+++ b/src/commands/__snapshots__/branches.test.ts.snap
@@ -264,11 +264,3 @@ updated_at: 2019-01-01T00:00:00Z
 "
 `;
 
-exports[`branches > set primary by id 1`] = `
-"name: test-branch-sunny
-id: br-sunny-branch-123456
-default: true
-created_at: 2019-01-01T00:00:00Z
-updated_at: 2019-01-01T00:00:00Z
-"
-`;

--- a/src/commands/__snapshots__/ip_allow.test.ts.snap
+++ b/src/commands/__snapshots__/ip_allow.test.ts.snap
@@ -2,18 +2,6 @@
 
 exports[`ip-allow > Add IP allow - Error 1`] = `""`;
 
-exports[`ip-allow > Add IP allow - Primary 1`] = `
-"id: test
-name: test_project
-IP_addresses:
-  - 127.0.0.1
-  - 192.168.10.1-192.168.10.15
-  - 192.168.1.1
-primary_branch_only: true
-protected_branches_only: false
-"
-`;
-
 exports[`ip-allow > Add IP allow - Protected 1`] = `
 "id: test
 name: test_project
@@ -21,7 +9,6 @@ IP_addresses:
   - 127.0.0.1
   - 192.168.10.1-192.168.10.15
   - 192.168.1.1
-primary_branch_only: false
 protected_branches_only: true
 "
 `;
@@ -32,7 +19,6 @@ exports[`ip-allow > Remove IP allow 1`] = `
 "id: test
 name: test_project
 IP_addresses: []
-primary_branch_only: false
 protected_branches_only: false
 "
 `;
@@ -41,7 +27,6 @@ exports[`ip-allow > Reset IP allow 1`] = `
 "id: test
 name: test_project
 IP_addresses: []
-primary_branch_only: false
 protected_branches_only: false
 "
 `;
@@ -51,7 +36,6 @@ exports[`ip-allow > Reset IP allow to new list 1`] = `
 name: test_project
 IP_addresses:
   - 192.168.2.2
-primary_branch_only: false
 protected_branches_only: false
 "
 `;
@@ -61,7 +45,6 @@ exports[`ip-allow > list IP Allow with single-project 1`] = `
 name: test-project-123456
 IP_addresses:
   - 192.168.1.1
-primary_branch_only: false
 protected_branches_only: false
 "
 `;
@@ -71,7 +54,6 @@ exports[`ip-allow > list IP allow 1`] = `
 name: test_project
 IP_addresses:
   - 192.168.1.1
-primary_branch_only: false
 protected_branches_only: false
 "
 `;

--- a/src/commands/__snapshots__/projects.test.ts.snap
+++ b/src/commands/__snapshots__/projects.test.ts.snap
@@ -96,7 +96,7 @@ settings:
   allowed_ips:
     ips:
       - 192.168.1.1
-    primary_branch_only: false
+    protected_branches_only: false
 "
 `;
 
@@ -142,42 +142,6 @@ exports[`projects > list with org id 1`] = `
 "
 `;
 
-exports[`projects > update ip allow 1`] = `
-"id: test
-name: test_project
-created_at: 2019-01-01T00:00:00Z
-settings:
-  allowed_ips:
-    ips:
-      - 127.0.0.1
-      - 192.168.1.2/22
-    primary_branch_only: true
-"
-`;
-
-exports[`projects > update ip allow primary only flag 1`] = `
-"id: test
-name: test_project
-created_at: 2019-01-01T00:00:00Z
-settings:
-  allowed_ips:
-    ips:
-      - 192.168.1.1
-    primary_branch_only: false
-"
-`;
-
-exports[`projects > update ip allow remove 1`] = `
-"id: test
-name: test_project
-created_at: 2019-01-01T00:00:00Z
-settings:
-  allowed_ips:
-    ips: []
-    primary_branch_only: false
-"
-`;
-
 exports[`projects > update name 1`] = `
 "id: test
 name: test_project_new_name
@@ -186,7 +150,7 @@ settings:
   allowed_ips:
     ips:
       - 192.168.1.1
-    primary_branch_only: false
+    protected_branches_only: false
 "
 `;
 
@@ -198,7 +162,7 @@ settings:
   allowed_ips:
     ips:
       - 192.168.1.1
-    primary_branch_only: false
+    protected_branches_only: false
 "
 `;
 
@@ -210,6 +174,6 @@ settings:
   allowed_ips:
     ips:
       - 192.168.1.1
-    primary_branch_only: false
+    protected_branches_only: false
 "
 `;

--- a/src/commands/__snapshots__/set_context.test.ts.snap
+++ b/src/commands/__snapshots__/set_context.test.ts.snap
@@ -64,7 +64,7 @@ settings:
   allowed_ips:
     ips:
       - 192.168.1.1
-    primary_branch_only: false
+    protected_branches_only: false
 "
 `;
 

--- a/src/commands/branches.test.ts
+++ b/src/commands/branches.test.ts
@@ -179,18 +179,6 @@ describe('branches', () => {
     ]);
   });
 
-  /* set primary */
-
-  test('set primary by id', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'branches',
-      'set-primary',
-      'br-sunny-branch-123456',
-      '--project-id',
-      'test',
-    ]);
-  });
-
   /* set default */
 
   test('set default by id', async ({ testCliCommand }) => {

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -24,7 +24,6 @@ import { getComputeUnits } from '../utils/compute_units.js';
 export const BRANCH_FIELDS = [
   'id',
   'name',
-  'primary',
   'default',
   'created_at',
   'updated_at',
@@ -33,7 +32,6 @@ export const BRANCH_FIELDS = [
 const BRANCH_FIELDS_RESET = [
   'id',
   'name',
-  'primary',
   'default',
   'created_at',
   'last_reset_at',

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -171,12 +171,6 @@ export const builder = (argv: yargs.Argv) =>
       (args) => rename(args as any),
     )
     .command(
-      'set-primary <id|name>',
-      'DEPRECATED: Use set-default. Set a branch as primary',
-      (yargs) => yargs,
-      (args) => setDefault(args as any),
-    )
-    .command(
       'set-default <id|name>',
       'Set a branch as default',
       (yargs) => yargs,

--- a/src/commands/ip_allow.test.ts
+++ b/src/commands/ip_allow.test.ts
@@ -20,18 +20,6 @@ describe('ip-allow', () => {
     });
   });
 
-  test('Add IP allow - Primary', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'ip-allow',
-      'add',
-      '127.0.0.1',
-      '192.168.10.1-192.168.10.15',
-      '--primary-only',
-      '--project-id',
-      'test',
-    ]);
-  });
-
   test('Add IP allow - Protected', async ({ testCliCommand }) => {
     await testCliCommand([
       'ip-allow',

--- a/src/commands/ip_allow.ts
+++ b/src/commands/ip_allow.ts
@@ -53,16 +53,6 @@ export const builder = (argv: yargs.Argv) => {
                 ].description,
               type: 'boolean',
             },
-          })
-          .options({
-            'primary-only': {
-              describe:
-                projectUpdateRequest[
-                  'project.settings.allowed_ips.primary_branch_only'
-                ].description,
-              type: 'boolean',
-              deprecated: 'See --protected-only',
-            },
           }),
       async (args) => {
         await add(args as any);
@@ -113,7 +103,6 @@ const add = async (
   props: CommonProps &
     ProjectScopeProps & {
       ips: string[];
-      primaryOnly?: boolean;
       protectedOnly?: boolean;
     },
 ) => {
@@ -129,8 +118,6 @@ const add = async (
   project.settings = {
     allowed_ips: {
       ips: [...new Set(props.ips.concat(existingAllowedIps?.ips ?? []))],
-      primary_branch_only:
-        props.primaryOnly ?? existingAllowedIps?.primary_branch_only ?? false,
       protected_branches_only:
         props.protectedOnly ??
         existingAllowedIps?.protected_branches_only ??
@@ -165,7 +152,6 @@ const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
     allowed_ips: {
       ips:
         existingAllowedIps?.ips?.filter((ip) => !props.ips.includes(ip)) ?? [],
-      primary_branch_only: existingAllowedIps?.primary_branch_only ?? false,
       protected_branches_only:
         existingAllowedIps?.protected_branches_only ?? false,
     },
@@ -188,7 +174,6 @@ const reset = async (props: ProjectScopeProps & { ips: string[] }) => {
   project.settings = {
     allowed_ips: {
       ips: props.ips,
-      primary_branch_only: false,
       protected_branches_only: false,
     },
   };
@@ -214,8 +199,6 @@ const parse = (project: Project) => {
     id: project.id,
     name: project.name,
     IP_addresses: ips,
-    primary_branch_only:
-      project.settings?.allowed_ips?.primary_branch_only ?? false,
     protected_branches_only:
       project.settings?.allowed_ips?.protected_branches_only ?? false,
   };

--- a/src/commands/projects.test.ts
+++ b/src/commands/projects.test.ts
@@ -127,32 +127,6 @@ describe('projects', () => {
     ]);
   });
 
-  test('update ip allow', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'projects',
-      'update',
-      'test',
-      '--ip-allow',
-      '127.0.0.1',
-      '192.168.1.2/22',
-      '--ip-primary-only',
-    ]);
-  });
-
-  test('update ip allow primary only flag', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'projects',
-      'update',
-      'test',
-      '--ip-primary-only',
-      'false',
-    ]);
-  });
-
-  test('update ip allow remove', async ({ testCliCommand }) => {
-    await testCliCommand(['projects', 'update', 'test', '--ip-allow']);
-  });
-
   test('update project with default fixed size CU', async ({
     testCliCommand,
   }) => {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -6,10 +6,7 @@ import {
 import yargs from 'yargs';
 
 import { log } from '../log.js';
-import {
-  projectCreateRequest,
-  projectUpdateRequest,
-} from '../parameters.gen.js';
+import { projectCreateRequest } from '../parameters.gen.js';
 import { CommonProps, IdOrNameProps } from '../types.js';
 import { writer } from '../writer.js';
 import { psql } from '../utils/psql.js';
@@ -110,22 +107,6 @@ export const builder = (argv: yargs.Argv) => {
           name: {
             describe: projectCreateRequest['project.name'].description,
             type: 'string',
-          },
-          'ip-allow': {
-            describe:
-              projectUpdateRequest['project.settings.allowed_ips.ips']
-                .description,
-            type: 'string',
-            array: true,
-            deprecated: "Deprecated. Use 'ip-allow' command",
-          },
-          'ip-primary-only': {
-            describe:
-              projectUpdateRequest[
-                'project.settings.allowed_ips.primary_branch_only'
-              ].description,
-            type: 'boolean',
-            deprecated: "Deprecated. Use 'ip-allow' command",
           },
           cu: {
             describe:
@@ -282,27 +263,11 @@ const update = async (
     IdOrNameProps & {
       name?: string;
       cu?: string;
-      ipAllow?: string[];
-      ipPrimaryOnly?: boolean;
     },
 ) => {
   const project: ProjectUpdateRequest['project'] = {};
   if (props.name) {
     project.name = props.name;
-  }
-  if (props.ipAllow || props.ipPrimaryOnly != undefined) {
-    const { data } = await props.apiClient.getProject(props.id);
-    const existingAllowedIps = data.project.settings?.allowed_ips;
-
-    project.settings = {
-      allowed_ips: {
-        ips: props.ipAllow ?? existingAllowedIps?.ips ?? [],
-        primary_branch_only:
-          props.ipPrimaryOnly ??
-          existingAllowedIps?.primary_branch_only ??
-          false,
-      },
-    };
   }
   if (props.cu) {
     project.default_endpoint_settings = props.cu


### PR DESCRIPTION
This PR:
- removes deprecated set-primary branch command
- removes deprecated --allow-list and --ip-primary-only flags from project update
- removes deprecated --primary-only flag from ip-allow command
- stops displaying the primary field and drops primary-only

It is a continuation of https://github.com/neondatabase/neonctl/pull/232 and closes https://github.com/neondatabase/cloud/issues/18110. 

BREAKING CHANGE: The deprecated set-primary branch command has been removed, deprecated --allow-list and --ip-primary-only project update flags have been removed, --primary-only flag from the ip-allow command has been removed