### PR TITLE
docs: add a changelog file for the neon cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# The Neon CLI Changelog
+
+This changelog documents updates and fixes for the Neon CLI, starting at v2.0.0.
+
+## 2.0.0
+
+- Removed the deprecated `set-primary` branch command
+- Removed the deprecated `--allow-list` and `--ip-primary-only` flags from the `project update` command
+- Removed the deprecated `--primary-only` flag from the `ip-allow` command
+- Added empty state messages for the `projects list` command


### PR DESCRIPTION
I'd like to propose that we start keeping a changelog file for the Neon CLI. It will be helpful to reference this from the Docs and elsewhere. Ideally, we'll automate this as a next step, but I'd like to find an automated approach that we can use for all repos.