### PR TITLE
ci: gh-workflow-stats-action: bump version and move action repo

### DIFF
--- a/.github/workflows/report-workflow-stats.yml
+++ b/.github/workflows/report-workflow-stats.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read
     steps:
       - name: Export GH Workflow Stats
-        uses: fedordikarev/gh-workflow-stats-action@v0.1.3
+        uses: neondatabase/gh-workflow-stats-action@v0.1.4
         with:
           DB_URI: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
           DB_TABLE: 'gh_workflow_stats_neonctl'


### PR DESCRIPTION
Move action repo from personal account to org, and bump to last version.