### PR TITLE
feat: segment track IPs

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -74,6 +74,9 @@ export const analyticsMiddleware = async (args: {
       ci: isCi(),
       githubEnvVars: getGithubEnvVars(process.env),
     },
+    context: {
+      direct: true,
+    },
   });
 };
 


### PR DESCRIPTION
resolves https://github.com/neondatabase/cloud/issues/17309
IP address is collected by Segment itself with `context: {direct: true}`, confirmed in Segment debugger.