### PR TITLE
Release 2024-11-24

### DIFF
--- a/.github/workflows/report-workflow-stats.yml
+++ b/.github/workflows/report-workflow-stats.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read
     steps:
       - name: Export GH Workflow Stats
-        uses: fedordikarev/gh-workflow-stats-action@v0.1.3
+        uses: neondatabase/gh-workflow-stats-action@v0.1.4
         with:
           DB_URI: ${{ secrets.GH_REPORT_STATS_DB_RW_CONNSTR }}
           DB_TABLE: 'gh_workflow_stats_neonctl'

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -74,6 +74,9 @@ export const analyticsMiddleware = async (args: {
       ci: isCi(),
       githubEnvVars: getGithubEnvVars(process.env),
     },
+    context: {
+      direct: true,
+    },
   });
 };
 


### PR DESCRIPTION
- ci: gh-workflow-stats-action: bump version and move action repo (https://github.com/neondatabase/neonctl/commit/51fe65f6d0cc02096f3829127faa0386ef02f7b8)
- feat: segment track IPs (https://github.com/neondatabase/neonctl/commit/2b2092e459922f2b5f8dabdf6c0ded2550e5d67d)