### PR TITLE
feat: send projectId and branchId to Segment

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -65,15 +65,7 @@ export const analyticsMiddleware = async (args: {
   client.track({
     userId: userId ?? 'anonymous',
     event: 'CLI Started',
-    properties: {
-      version: pkg.version,
-      command: args._.join(' '),
-      flags: {
-        output: args.output,
-      },
-      ci: isCi(),
-      githubEnvVars: getGithubEnvVars(process.env),
-    },
+    properties: getAnalyticsEventProperties(args),
     context: {
       direct: true,
     },
@@ -120,3 +112,13 @@ export const trackEvent = (
   });
   log.debug('Sent CLI event: %s', event);
 };
+
+export const getAnalyticsEventProperties = (args: any) => ({
+  version: pkg.version,
+  command: args._.join(' '),
+  flags: {
+    output: args.output,
+  },
+  ci: isCi(),
+  githubEnvVars: getGithubEnvVars(process.env),
+});

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -51,6 +51,10 @@ export const builder = (argv: yargs.Argv) =>
       },
     })
     .middleware(fillSingleProject as any)
+    .middleware((args: any) => {
+      // Provide alias for analytics
+      args.branchId ??= args.id;
+    })
     .command(
       'list',
       'List branches',
@@ -134,6 +138,7 @@ export const builder = (argv: yargs.Argv) =>
           .middleware((args: any) => {
             args.id = args.targetId;
             args.pointInTime = args['source@(timestamp'];
+            args.branchId = args.id; // for analytics
           })
           .usage(
             '$0 branches restore <target-id|name> <source>[@(timestamp|lsn)]',
@@ -375,12 +380,11 @@ const create = async (
 };
 
 const rename = async (
-  props: ProjectScopeProps &
-    IdOrNameProps & { newName: string; branchId: string },
+  props: ProjectScopeProps & IdOrNameProps & { newName: string },
 ) => {
-  props.branchId = await branchIdFromProps(props);
+  const branchId = await branchIdFromProps(props);
   const { data } = await retryOnLock(() =>
-    props.apiClient.updateProjectBranch(props.projectId, props.branchId, {
+    props.apiClient.updateProjectBranch(props.projectId, branchId, {
       branch: {
         name: props.newName,
       },
@@ -391,37 +395,31 @@ const rename = async (
   });
 };
 
-const setDefault = async (
-  props: ProjectScopeProps & IdOrNameProps & { branchId: string },
-) => {
-  props.branchId = await branchIdFromProps(props);
+const setDefault = async (props: ProjectScopeProps & IdOrNameProps) => {
+  const branchId = await branchIdFromProps(props);
   const { data } = await retryOnLock(() =>
-    props.apiClient.setDefaultProjectBranch(props.projectId, props.branchId),
+    props.apiClient.setDefaultProjectBranch(props.projectId, branchId),
   );
   writer(props).end(data.branch, {
     fields: BRANCH_FIELDS,
   });
 };
 
-const deleteBranch = async (
-  props: ProjectScopeProps & IdOrNameProps & { branchId: string },
-) => {
-  props.branchId = await branchIdFromProps(props);
+const deleteBranch = async (props: ProjectScopeProps & IdOrNameProps) => {
+  const branchId = await branchIdFromProps(props);
   const { data } = await retryOnLock(() =>
-    props.apiClient.deleteProjectBranch(props.projectId, props.branchId),
+    props.apiClient.deleteProjectBranch(props.projectId, branchId),
   );
   writer(props).end(data.branch, {
     fields: BRANCH_FIELDS,
   });
 };
 
-const get = async (
-  props: ProjectScopeProps & IdOrNameProps & { branchId: string },
-) => {
-  props.branchId = await branchIdFromProps(props);
+const get = async (props: ProjectScopeProps & IdOrNameProps) => {
+  const branchId = await branchIdFromProps(props);
   const { data } = await props.apiClient.getProjectBranch(
     props.projectId,
-    props.branchId,
+    branchId,
   );
   writer(props).end(data.branch, {
     fields: BRANCH_FIELDS,
@@ -433,13 +431,13 @@ const addCompute = async (
     IdOrNameProps & {
       type: EndpointType;
       cu?: string;
-    } & { branchId: string },
+    },
 ) => {
-  props.branchId = await branchIdFromProps(props);
+  const branchId = await branchIdFromProps(props);
   const { data } = await retryOnLock(() =>
     props.apiClient.createProjectEndpoint(props.projectId, {
       endpoint: {
-        branch_id: props.branchId,
+        branch_id: branchId,
         type: props.type,
         ...(props.cu ? getComputeUnits(props.cu) : undefined),
       },
@@ -455,22 +453,22 @@ const reset = async (
     IdOrNameProps & {
       parent: boolean;
       preserveUnderName?: string;
-    } & { branchId: string },
+    },
 ) => {
   if (!props.parent) {
     throw new Error('Only resetting to parent is supported for now');
   }
-  props.branchId = await branchIdFromProps(props);
+  const branchId = await branchIdFromProps(props);
   const {
     data: {
       branch: { parent_id },
     },
-  } = await props.apiClient.getProjectBranch(props.projectId, props.branchId);
+  } = await props.apiClient.getProjectBranch(props.projectId, branchId);
   if (!parent_id) {
     throw new Error('Branch has no parent');
   }
   const { data } = await retryOnLock(() =>
-    props.apiClient.restoreProjectBranch(props.projectId, props.branchId, {
+    props.apiClient.restoreProjectBranch(props.projectId, branchId, {
       source_branch_id: parent_id,
       preserve_under_name: props.preserveUnderName || undefined,
     }),

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -38,6 +38,10 @@ export const aliases = ['project'];
 export const builder = (argv: yargs.Argv) => {
   return argv
     .usage('$0 projects <sub-command> [options]')
+    .middleware((args: any) => {
+      // Provide alias for analytics
+      args.projectId = args.id;
+    })
     .command(
       'list',
       'List projects',

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,13 @@ import { defaultClientID } from './auth.js';
 import { fillInArgs } from './utils/middlewares.js';
 import pkg from './pkg.js';
 import commands from './commands/index.js';
-import { analyticsMiddleware, closeAnalytics, sendError } from './analytics.js';
+import {
+  analyticsMiddleware,
+  closeAnalytics,
+  getAnalyticsEventProperties,
+  sendError,
+  trackEvent,
+} from './analytics.js';
 import { isAxiosError } from 'axios';
 import { matchErrorCode } from './errors.js';
 import { showHelp } from './help.js';
@@ -195,6 +201,11 @@ builder = builder
 void (async () => {
   try {
     const args = await builder.argv;
+    trackEvent('cli_command_success', {
+      ...getAnalyticsEventProperties(args),
+      projectId: args.projectId,
+      branchId: args.branchId,
+    });
     if (args._.length === 0 || args.help) {
       await showHelp(builder);
       process.exit(0);

--- a/src/utils/enrichers.ts
+++ b/src/utils/enrichers.ts
@@ -34,7 +34,7 @@ export const branchIdResolve = async ({
   return branchData.id;
 };
 
-export const branchIdFromProps = async (props: BranchScopeProps) => {
+const getBranchIdFromProps = async (props: BranchScopeProps) => {
   const branch =
     'branch' in props && typeof props.branch === 'string'
       ? props.branch
@@ -58,6 +58,11 @@ export const branchIdFromProps = async (props: BranchScopeProps) => {
   }
 
   throw new Error('No default branch found');
+};
+
+export const branchIdFromProps = async (props: BranchScopeProps) => {
+  (props as any).branchId = await getBranchIdFromProps(props);
+  return (props as any).branchId;
 };
 
 export const fillSingleProject = async (props: ProjectScopeProps) => {


### PR DESCRIPTION
Relates to https://github.com/neondatabase/cloud/issues/20941

Because the `cli_started` event is sent at the beginning we can't know the resource ids.

So I added a `cli_command_success` event after the command runs when we have the final context.

These will not be sent on error because I couldn't find a way to get the context on error.

### **Examples**

`neon branches list` will send `projectId`

`neon branches get someid` will send `projectId` and `branchId`

`neon branches get main` will send `projectId` and correct `branchId`

`branches restore A B` will send `projectId` and `branchId=A`

`neon me` will send both as `undefined`