### PR TITLE
feat(project-update): add project update options and refactor code (#main)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7466,6 +7466,7 @@
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
       "dev": true,
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7751,7 +7752,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
+      "version": "10.4.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7765,6 +7766,9 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -8222,15 +8226,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/npm/node_modules/minipass": {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -111,16 +111,18 @@ export const builder = (argv: yargs.Argv) => {
       'Update a project',
       (yargs) =>
         yargs.options({
-          block_vpc_connections: {
+          'block-vpc-connections': {
             describe:
               projectUpdateRequest['project.settings.block_vpc_connections']
-                .description,
+                .description +
+              ' Use --block-vpc-connections=false to set the value to false.',
             type: 'boolean',
           },
-          block_public_connections: {
+          'block-public-connections': {
             describe:
               projectUpdateRequest['project.settings.block_public_connections']
-                .description,
+                .description +
+              ' Use --block-public-connections=false to set the value to false.',
             type: 'boolean',
           },
           cu: {
@@ -285,22 +287,22 @@ const update = async (
     IdOrNameProps & {
       name?: string;
       cu?: string;
-      block_vpc_connections?: boolean;
-      block_public_connections?: boolean;
+      blockVpcConnections?: boolean;
+      blockPublicConnections?: boolean;
     },
 ) => {
   const project: ProjectUpdateRequest['project'] = {};
-  if (props.block_public_connections !== undefined) {
+  if (props.blockPublicConnections !== undefined) {
     if (!project.settings) {
       project.settings = {};
     }
-    project.settings.block_public_connections = props.block_public_connections;
+    project.settings.block_public_connections = props.blockPublicConnections;
   }
-  if (props.block_vpc_connections !== undefined) {
+  if (props.blockVpcConnections !== undefined) {
     if (!project.settings) {
       project.settings = {};
     }
-    project.settings.block_vpc_connections = props.block_vpc_connections;
+    project.settings.block_vpc_connections = props.blockVpcConnections;
   }
   if (props.name) {
     project.name = props.name;

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -6,7 +6,10 @@ import {
 import yargs from 'yargs';
 
 import { log } from '../log.js';
-import { projectCreateRequest } from '../parameters.gen.js';
+import {
+  projectCreateRequest,
+  projectUpdateRequest,
+} from '../parameters.gen.js';
 import { CommonProps, IdOrNameProps } from '../types.js';
 import { writer } from '../writer.js';
 import { psql } from '../utils/psql.js';
@@ -108,13 +111,25 @@ export const builder = (argv: yargs.Argv) => {
       'Update a project',
       (yargs) =>
         yargs.options({
-          name: {
-            describe: projectCreateRequest['project.name'].description,
-            type: 'string',
+          block_vpc_connections: {
+            describe:
+              projectUpdateRequest['project.settings.block_vpc_connections']
+                .description,
+            type: 'boolean',
+          },
+          block_public_connections: {
+            describe:
+              projectUpdateRequest['project.settings.block_public_connections']
+                .description,
+            type: 'boolean',
           },
           cu: {
             describe:
               'The number of Compute Units. Could be a fixed size (e.g. "2") or a range delimited by a dash (e.g. "0.5-3").',
+            type: 'string',
+          },
+          name: {
+            describe: projectUpdateRequest['project.name'].description,
             type: 'string',
           },
         }),
@@ -270,9 +285,23 @@ const update = async (
     IdOrNameProps & {
       name?: string;
       cu?: string;
+      block_vpc_connections?: boolean;
+      block_public_connections?: boolean;
     },
 ) => {
   const project: ProjectUpdateRequest['project'] = {};
+  if (props.block_public_connections !== undefined) {
+    if (!project.settings) {
+      project.settings = {};
+    }
+    project.settings.block_public_connections = props.block_public_connections;
+  }
+  if (props.block_vpc_connections !== undefined) {
+    if (!project.settings) {
+      project.settings = {};
+    }
+    project.settings.block_vpc_connections = props.block_vpc_connections;
+  }
   if (props.name) {
     project.name = props.name;
   }

--- a/src/parameters.gen.ts
+++ b/src/parameters.gen.ts
@@ -98,7 +98,7 @@ export const projectCreateRequest = {
   },
   'project.default_endpoint_settings.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'project.pg_version': {
@@ -196,7 +196,7 @@ export const projectUpdateRequest = {
   },
   'project.default_endpoint_settings.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'project.history_retention_seconds': {
@@ -242,11 +242,10 @@ export const branchCreateRequest = {
               description: "Whether to create the branch as archived\n",
               demandOption: false,
   },
-  'branch.schema_initialization_type': {
+  'branch.init_source': {
               type: "string",
-              description: "The type of schema initialization. Defines how the schema is initialized, currently only empty is supported. This parameter is under\nactive development and may change its semantics in the future.\n",
+              description: "The initialization source type for the branch. Valid values are `import`, `empty`, `schema` and `parent-data`.\nThis parameter is under active development and may change its semantics in the future.\n",
               demandOption: false,
- choices: ["empty"],
   },
 } as const;
 
@@ -264,7 +263,7 @@ export const branchCreateRequestEndpointOptions = {
   },
   'suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
 } as const;
@@ -327,7 +326,7 @@ export const endpointCreateRequest = {
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
 } as const;
@@ -366,7 +365,7 @@ export const endpointUpdateRequest = {
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the global default.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Auto-suspend configuration](https://neon.tech/docs/manage/endpoints#auto-suspend-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
 } as const;


### PR DESCRIPTION
This commit introduces new options for project updates, including
`block_vpc_connections` and `block_public_connections`. It also refactors
the existing code for improved readability and maintainability by alphabetically sorting the parameters for the `project update` command.

Use `--block-vpc-connections=false` to set the value to false.
Use `--block-public-connections=false` to set the value to false.


https://github.com/neondatabase/cloud/issues/21903