### PR TITLE
fix: issues with refresh token and auth

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -142,7 +142,7 @@ const handleExistingToken = async (
       return { apiKey, apiClient };
     } catch (err: unknown) {
       const typedErr = err instanceof Error ? err : new Error('Unknown error');
-      log.error('Failed to refresh token: %s', typedErr.message);
+      log.debug('Failed to refresh token: %s', typedErr.message);
       throw new Error('AUTH_REFRESH_FAILED');
     }
   }
@@ -207,9 +207,10 @@ export const ensureAuth = async (
     } catch (e) {
       if (
         !(e instanceof Error && e.message === 'AUTH_REFRESH_FAILED') &&
-        (e as { code: string }).code !== 'ENOENT'
+        (e as { code: string }).code !== 'ENOENT' &&
+        !(e instanceof SyntaxError)
       ) {
-        // Throw for any errors except auth refresh failure and missing file
+        // Throw for any errors except auth refresh failure, missing file, or invalid credentials file
         throw e;
       }
       // Fall through to new auth flow for auth failures


### PR DESCRIPTION
Handle Auth issues
- Missing credentials file - reauth (added tests)
- Invalid credentials file - reauth
- Incomplete token set  - reauth
- Missing access_token - refresh token


Problem:
We had a lot of auth and refresh token-related issues
- https://github.com/neondatabase/neonctl/issues/282 
- https://github.com/neondatabase/neonctl/issues/253
- https://github.com/neondatabase/neonctl/issues/321

Most of these issues were happening while refreshing tokens.  When a refresh token is missing or API fails to renew the token, it leaves the user in an abrupt state needing to explicitly run `neonctl auth`. 


Solution: 

This change handles different states of the `credentials` file as listed above. Also added unit tests for all these scenarios. 