### PR TITLE
feat: enable strict mode for command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Global options are supported with any Neon CLI command.
 To run the CLI locally, execute the build command after making changes:
 
 ```shell
+npm install
 npm run build
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ const NO_SUBCOMMANDS_VERBS = [
 
 let builder = yargs(hideBin(process.argv));
 builder = builder
+  .strict()
   .scriptName(pkg.name)
   .locale('en')
   .usage('$0 <command> [options]')


### PR DESCRIPTION
According to the docs:

> Any command-line argument given that is not demanded, or does not have a corresponding description, will be reported as an error.
>  Unrecognized commands will also be reported as errors.

This solves the use-cases when a user passes an non-existent parameter and neonctl, continuing to work,

Example:
```
node dist project update --project-id super-base-59043008 --name "Chaporgin-Chaporgin-Chaporgin1" --block-public-connections 1
ERROR: Unknown arguments: project-id, projectId
node dist project update --project-id super-base-59043008 --name "Chaporgin-Chaporgin-Chaporgin1" --block-public-connections 1
ERROR: Unknown arguments: project-id, projectId
neonctl project update --project-id super-base-59043008 --name "Chaporgin-Chaporgin-Chaporgin1" --block-public-connections 1
```
Expected:
```
Error: parameter project-id does not exist
```

Actual:
```
ERROR: The request could not be authorized due to an internal error
```

This fixes that with the following examples:
```
node dist project update super-base-59043008 --name "Chaporgin-Chaporgin-Chaporgin1" --block-public-connections yes
ERROR: Unknown command: yes
node dist project update super-base-59043008 --name "Chaporgin-Chaporgin-Chaporgin1" --block-public-connections true
┌─────────────────────┬────────────────────────────────┬──────────────────┬──────────────────────┐
│ Id                  │ Name                           │ Region Id        │ Created At           │
├─────────────────────┼────────────────────────────────┼──────────────────┼──────────────────────┤
│ super-base-59043008 │ Chaporgin-Chaporgin-Chaporgin1 │ aws-eu-central-1 │ 2025-01-22T15:30:36Z │
└─────────────────────┴────────────────────────────────┴──────────────────┴──────────────────────┘
```
As you can see, still not perfect, see the first line:
ERROR: Unknown arguments: project-id, projectId

they do provide you with a hint, `project-id` is indeed missing, but for a complex misconfigured commands it will be hard to fix them by looking at the error message `ERROR: Unknown arguments: project-id, projectId`.

This, being a backward incompatible change might break workflows for the people.

I have no good idea how to solve it.