### PR TITLE
fix: add binaries creation to semantic-release `prepareCmd` hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - run: node pkg.js
       - run: git fetch origin
       - run: git checkout main
       - run: git rebase origin/release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,7 +12,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "cp dist/package*.json ./"
+        "prepareCmd": "cp dist/package*.json ./ && node pkg.js"
       }
     ],
     "@semantic-release/git",


### PR DESCRIPTION
closes #351

a regression was introduced when I tried to sync binary and NPM package versions.
if the binary is generated before release, it's outdated
if it's generated after the release, it's not uploaded

this PR moves the bundle creation to the semantic-release `prepareCmd` hook.
It should run between version bumping and publishing the release.
