### PR TITLE
feat: track account_id in analytics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -220,11 +220,15 @@ const MAX_ATTEMPTS = 2;
 while (attempts < MAX_ATTEMPTS) {
   try {
     const args = await builder.argv;
+
     // Send analytics for a successful attempt
     trackEvent('cli_command_success', {
       ...getAnalyticsEventProperties(args),
       projectId: args.projectId,
       branchId: args.branchId,
+      accountId: args.accountId,
+      authMethod: args.authMethod,
+      authData: args.authData,
     });
     if (args._.length === 0 || args.help) {
       await showHelp(builder);


### PR DESCRIPTION
Related to https://github.com/neondatabase/cloud/issues/20941

We track more data to know who the caller is when using an API key.

```
  accountId: "org-bold-frost-90980959",
  authMethod: "api_key_org",
  authData: "13", // this is the API key id
```
