### PR TITLE
feat: add `name` param to add-compute command

### DIFF
--- a/src/commands/__snapshots__/branches.test.ts.snap
+++ b/src/commands/__snapshots__/branches.test.ts.snap
@@ -8,6 +8,14 @@ type: read_only
 "
 `;
 
+exports[`branches > add compute with a name 1`] = `
+"id: test_endpoint_id
+branch_id: br-numbered-branch-123456
+created_at: 2019-01-01T00:00:00Z
+type: read_only
+"
+`;
+
 exports[`branches > add compute with autoscaled CU 1`] = `
 "id: test_endpoint_id
 branch_id: br-numbered-branch-123456

--- a/src/commands/branches.test.ts
+++ b/src/commands/branches.test.ts
@@ -321,6 +321,20 @@ describe('branches', () => {
     ]);
   });
 
+  test('add compute with a name', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'branches',
+      'add-compute',
+      'test_branch_with_autoscaling',
+      '--project-id',
+      'test',
+      '--cu',
+      '0.5-2',
+      '--name',
+      'My fancy new compute',
+    ]);
+  });
+
   /* reset */
 
   test('reset branch to parent', async ({ testCliCommand }) => {

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -202,6 +202,10 @@ export const builder = (argv: yargs.Argv) =>
               'The number of Compute Units. Could be a fixed size (e.g. "2") or a range delimited by a dash (e.g. "0.5-3").',
             type: 'string',
           },
+          name: {
+            type: 'string',
+            describe: 'Optional name of the compute',
+          },
         }),
       (args) => addCompute(args as any),
     )
@@ -451,15 +455,18 @@ const addCompute = async (
     IdOrNameProps & {
       type: EndpointType;
       cu?: string;
+      name?: string;
     },
 ) => {
   const branchId = await branchIdFromProps(props);
+  const computeName = props.name ? { name: props.name } : null;
   const { data } = await retryOnLock(() =>
     props.apiClient.createProjectEndpoint(props.projectId, {
       endpoint: {
         branch_id: branchId,
         type: props.type,
         ...(props.cu ? getComputeUnits(props.cu) : undefined),
+        ...computeName,
       },
     }),
   );


### PR DESCRIPTION
Resolves https://github.com/neondatabase/cloud/issues/24662. 

There is no functionality to show/list endpoints at the moment, so it was scoped to only adding the `name` parameter to `add-compute` sub-command.