### PR TITLE
feat: show `set-expiration` command in the help output

### DIFF
--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -118,7 +118,7 @@ export const builder = (argv: yargs.Argv) =>
 
           'expires-at': {
             describe:
-              '[PRIVATE-PREVIEW] Set an expiration date for the branch. Accepts a date string (e.g., 2024-12-31T23:59:59Z).',
+              'Set an expiration date for the branch. Accepts a date string (e.g., 2024-12-31T23:59:59Z).',
             type: 'string',
             requiresArg: true,
           },

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -196,10 +196,7 @@ export const builder = (argv: yargs.Argv) =>
     )
     .command({
       command: 'set-expiration <id|name>',
-      /**
-       * @info setting `describe` to `false` hides from the `help` command
-       */
-      describe: false, //'Set a expiration date for the branch',
+      describe: '[Early Access Program] Set an expiration date for the branch',
       builder: (yargs: yargs.Argv) =>
         yargs.options({
           'expires-at': {

--- a/src/commands/branches.ts
+++ b/src/commands/branches.ts
@@ -196,7 +196,7 @@ export const builder = (argv: yargs.Argv) =>
     )
     .command({
       command: 'set-expiration <id|name>',
-      describe: '[Early Access Program] Set an expiration date for the branch',
+      describe: 'Set an expiration date for the branch',
       builder: (yargs: yargs.Argv) =>
         yargs.options({
           'expires-at': {


### PR DESCRIPTION
Expiring Branches have entered in GA, the command was already available to anyone who had access, but now we show it in the `--help` output.
