### PR TITLE
fix: send a user id for anonymous users

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -77,7 +77,7 @@ export const analyticsMiddleware = async (args: {
   });
 
   client.track({
-    userId: userId ?? 'anonymous',
+    userId: userId || 'anonymous',
     event: 'CLI Started',
     properties: getAnalyticsEventProperties(args),
     context: {
@@ -105,7 +105,7 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
   }
   client.track({
     event: 'CLI Error',
-    userId: userId ?? 'anonymous',
+    userId: userId || 'anonymous',
     properties: {
       message: err.message,
       stack: err.stack,
@@ -126,7 +126,7 @@ export const trackEvent = (
   }
   client.track({
     event,
-    userId: userId ?? 'anonymous',
+    userId: userId || 'anonymous',
     properties,
   });
   log.debug('Sent CLI event: %s', event);


### PR DESCRIPTION
**Context**
On Segment, I noticed a large number of events being dropped because of no user ID or anonymous ID specified: https://app.segment.com/neondatabase/sources/cli/overview?startTime=1762167431852&endTime=1762253831852&selectedStep=successfully-received&showMetricsAs=absolute&isLive=false&selectedTabId=eventType

**What changes are proposed in this pull request?**
This PR adds a user ID when the command doesn't include one. Previously, we only added the `anonymous` user ID if the user ID was null or undefined; however, what we want is to add a value even if the user ID is an empty string.

#[LKB-4026](https://databricks.atlassian.net/browse/LKB-5291)