### PR TITLE
ci: replace default CI runner with protected runner group

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   main:
     name: Semantic PR title
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/report-workflow-stats-batch.yml
+++ b/.github/workflows/report-workflow-stats-batch.yml
@@ -13,7 +13,9 @@ jobs:
   gh-workflow-stats-batch-2h:
     name: GitHub Workflow Stats Batch 2 hours
     if: github.event.schedule == '*/15 * * * *'
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       actions: read
     steps:
@@ -33,7 +35,9 @@ jobs:
   gh-workflow-stats-batch-48h:
     name: GitHub Workflow Stats Batch 48 hours
     if: github.event.schedule == '25 0 * * *'
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       actions: read
     steps:
@@ -53,7 +57,9 @@ jobs:
   gh-workflow-stats-batch-30d:
     name: GitHub Workflow Stats Batch 30 days
     if: github.event.schedule == '25 1 * * 6'
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       actions: read
     steps:


### PR DESCRIPTION
## Problem

The workflows are currently using default GitHub runners (ubuntu-latest and ubuntu-22.04), which need to be replaced with the protected runner group for security and compliance purposes.

## Summary of changes

Replaces all instances of ubuntu-latest and ubuntu-22.04 runners with neondatabase-protected-runner-group across all GitHub workflow files (commitlint.yml, pr.yml, release.yml, and report-workflow-stats-batch.yml).