### PR TITLE
chore: fix bun.lock dependency version format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "neonctl",
       "dependencies": {
-        "@neondatabase/api-client": "^2.6.0",
+        "@neondatabase/api-client": "2.6.0",
         "@segment/analytics-node": "^1.0.0-beta.26",
         "@yao-pkg/pkg": "^6.10.0",
         "axios": "^1.4.0",


### PR DESCRIPTION
## Problem

The `bun.lock` file contained a caret range (`^2.6.0`) for the `@neondatabase/api-client` dependency instead of an exact version, which could lead to inconsistent dependency resolution across different installations.

## Summary of changes

Updates the `@neondatabase/api-client` dependency in `bun.lock` from caret range (`^2.6.0`) to exact version (`2.6.0`) to ensure consistent dependency resolution across all installations.