### PR TITLE
ci: use frozen lockfile in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
         with:
           bun-version-file: .bun-version
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - run: bun run build
       - run: bun run test
       - run: bunx semantic-release


### PR DESCRIPTION
## Problem

During the release workflow, running `bun install` without the `--frozen-lockfile` flag could potentially modify the lockfile if there are any discrepancies between the lockfile and package.json. This can lead to inconsistent builds and unexpected dependency updates during releases.

## Summary of changes

- Add `--frozen-lockfile` flag to `bun install` command in the release workflow
- Ensure that the release process uses the exact dependencies specified in the lockfile
- Prevent accidental lockfile modifications during release builds