### PR TITLE
feat: bump neon-init version to incorporate extension

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "neonctl",
       "dependencies": {
-        "@neondatabase/api-client": "^2.6.0",
+        "@neondatabase/api-client": "2.6.0",
         "@segment/analytics-node": "^1.0.0-beta.26",
         "@yao-pkg/pkg": "^6.10.0",
         "axios": "^1.4.0",
@@ -13,7 +14,7 @@
         "cli-table": "^0.3.11",
         "crypto-random-string": "^5.0.0",
         "diff": "^5.2.0",
-        "neon-init": "^0.10.0",
+        "neon-init": "^0.11.0",
         "open": "^10.1.0",
         "openid-client": "^6.8.1",
         "prompts": "2.4.2",
@@ -1207,7 +1208,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "neon-init": ["neon-init@0.10.1", "", { "dependencies": { "@clack/prompts": "0.10.1", "execa": "^9.5.2", "yoctocolors": "^2.1.2" }, "bin": { "neon-init": "dist/cli.js" } }, "sha512-SZogrTAZ97s1XJMxm7JmdK652z98xNHVanYcJpaGRWGry/bvxPWJypNdu8aevmEFupuw9sj1uMVHgS7QFJXWbg=="],
+    "neon-init": ["neon-init@0.11.0", "", { "dependencies": { "@clack/prompts": "0.10.1", "execa": "^9.5.2", "yoctocolors": "^2.1.2" }, "bin": { "neon-init": "dist/cli.js" } }, "sha512-JJAgOuVSjyQpWqOxC7uTG78HV0t7qsHyIAAcvUc7Ln+hbM5s6JR/wvIcpsSBDP044yzu5a2/78KUn716BXFofg=="],
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cli-table": "^0.3.11",
     "crypto-random-string": "^5.0.0",
     "diff": "^5.2.0",
-    "neon-init": "^0.10.0",
+    "neon-init": "^0.11.0",
     "open": "^10.1.0",
     "openid-client": "^6.8.1",
     "prompts": "2.4.2",


### PR DESCRIPTION
**Context**
We are now installing the VS Code/ VSX extension as part of `init` for Cursor and VS Code IDEs. These changes have already been published to `neon-init` but have not yet been published as part of `neonctl`
.
**What changes are proposed in this pull request?**
Update the package version of `neon-init` to account for the latest changes

**How did we test this?**
Tested locally

#[LKB-6294](https://databricks.atlassian.net/browse/LKB-7949)