### PR TITLE
feat: add skills command for discovering and installing agent skills

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -163,6 +163,11 @@ export const ensureAuth = async (
     return;
   }
 
+  // Skills command doesn't need Neon API auth
+  if (props._[0] === 'skills' || props._[0] === 'skill') {
+    return;
+  }
+
   // Use existing API key or handle auth command
   if (props.apiKey || props._[0] === 'auth') {
     if (props.apiKey) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,6 +11,7 @@ import * as operations from './operations.js';
 import * as cs from './connection_string.js';
 import * as setContext from './set_context.js';
 import * as init from './init.js';
+import * as skills from './skills.js';
 
 export default [
   auth,
@@ -26,4 +27,5 @@ export default [
   cs,
   setContext,
   init,
+  skills,
 ];

--- a/src/commands/skills.test.ts
+++ b/src/commands/skills.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseFrontmatter, parseBody, validateName } from './skills.js';
+
+describe('skills', () => {
+  describe('validateName', () => {
+    it('accepts valid skill names', () => {
+      expect(validateName('neon-postgres')).toBe('neon-postgres');
+      expect(validateName('my_skill')).toBe('my_skill');
+      expect(validateName('skill.v2')).toBe('skill.v2');
+      expect(validateName('a')).toBe('a');
+      expect(validateName('123')).toBe('123');
+    });
+
+    it('rejects path traversal attempts', () => {
+      expect(() => validateName('../../etc')).toThrow('Invalid skill name');
+      expect(() => validateName('../.ssh')).toThrow('Invalid skill name');
+      expect(() => validateName('foo/../bar')).toThrow('Invalid skill name');
+    });
+
+    it('rejects names starting with special characters', () => {
+      expect(() => validateName('.hidden')).toThrow('Invalid skill name');
+      expect(() => validateName('-flag')).toThrow('Invalid skill name');
+      expect(() => validateName('_private')).toThrow('Invalid skill name');
+    });
+
+    it('rejects names with invalid characters', () => {
+      expect(() => validateName('skill/name')).toThrow('Invalid skill name');
+      expect(() => validateName('skill name')).toThrow('Invalid skill name');
+      expect(() => validateName('UPPERCASE')).toThrow('Invalid skill name');
+      expect(() => validateName('')).toThrow('Invalid skill name');
+    });
+  });
+
+  describe('parseFrontmatter', () => {
+    it('parses all frontmatter fields', () => {
+      const content = [
+        '---',
+        'name: my-skill',
+        'description: A test skill',
+        'compatibility: node >= 18',
+        'license: MIT',
+        '---',
+        'Body content here',
+      ].join('\n');
+
+      expect(parseFrontmatter(content)).toEqual({
+        name: 'my-skill',
+        description: 'A test skill',
+        compatibility: 'node >= 18',
+        license: 'MIT',
+      });
+    });
+
+    it('handles quoted values', () => {
+      const content = [
+        '---',
+        'name: "quoted-skill"',
+        "description: 'single quoted'",
+        '---',
+      ].join('\n');
+
+      expect(parseFrontmatter(content)).toEqual({
+        name: 'quoted-skill',
+        description: 'single quoted',
+        compatibility: undefined,
+        license: undefined,
+      });
+    });
+
+    it('returns defaults when no frontmatter present', () => {
+      expect(parseFrontmatter('Just some content')).toEqual({
+        name: '',
+        description: '',
+        compatibility: undefined,
+        license: undefined,
+      });
+    });
+
+    it('returns defaults for empty frontmatter', () => {
+      const content = '---\n---\nBody';
+      expect(parseFrontmatter(content)).toEqual({
+        name: '',
+        description: '',
+        compatibility: undefined,
+        license: undefined,
+      });
+    });
+
+    it('handles colons in values', () => {
+      const content = [
+        '---',
+        'name: my-skill',
+        'description: A skill: with colons: in it',
+        '---',
+      ].join('\n');
+
+      expect(parseFrontmatter(content)).toEqual({
+        name: 'my-skill',
+        description: 'A skill: with colons: in it',
+        compatibility: undefined,
+        license: undefined,
+      });
+    });
+
+    it('ignores lines without colons', () => {
+      const content = ['---', 'name: my-skill', 'not a key value', '---'].join(
+        '\n',
+      );
+
+      expect(parseFrontmatter(content).name).toBe('my-skill');
+    });
+
+    it('handles \\r\\n line endings', () => {
+      const content =
+        '---\r\nname: my-skill\r\ndescription: A test\r\n---\r\nBody';
+      expect(parseFrontmatter(content)).toEqual({
+        name: 'my-skill',
+        description: 'A test',
+        compatibility: undefined,
+        license: undefined,
+      });
+    });
+  });
+
+  describe('parseBody', () => {
+    it('extracts body after frontmatter', () => {
+      const content = '---\nname: test\n---\nBody content here';
+      expect(parseBody(content)).toBe('Body content here');
+    });
+
+    it('trims whitespace from body', () => {
+      const content = '---\nname: test\n---\n\n  Body  \n\n';
+      expect(parseBody(content)).toBe('Body');
+    });
+
+    it('returns full content when no frontmatter', () => {
+      expect(parseBody('Just content')).toBe('Just content');
+    });
+
+    it('handles multiline body', () => {
+      const content = '---\nname: test\n---\nLine 1\nLine 2\nLine 3';
+      expect(parseBody(content)).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    it('handles empty body after frontmatter', () => {
+      const content = '---\nname: test\n---\n';
+      expect(parseBody(content)).toBe('');
+    });
+
+    it('handles \\r\\n line endings', () => {
+      const content = '---\r\nname: test\r\n---\r\nBody content here';
+      expect(parseBody(content)).toBe('Body content here');
+    });
+  });
+});

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -1,0 +1,258 @@
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import yargs from 'yargs';
+
+import { writer } from '../writer.js';
+import { log } from '../log.js';
+
+const SKILLS_REPO = 'neondatabase/agent-skills';
+const SKILLS_PATH = 'skills';
+const GITHUB_API = `https://api.github.com/repos/${SKILLS_REPO}/contents/${SKILLS_PATH}`;
+const GITHUB_RAW = `https://raw.githubusercontent.com/${SKILLS_REPO}/main/${SKILLS_PATH}`;
+
+type SkillMeta = {
+  name: string;
+  description: string;
+  compatibility?: string;
+  license?: string;
+};
+
+type OutputProps = {
+  output: 'json' | 'yaml' | 'table';
+};
+
+const SKILL_FIELDS = ['name', 'description'] as const;
+
+const VALID_NAME = /^[a-z0-9][a-z0-9._-]*$/;
+
+export function validateName(name: string): string {
+  if (!VALID_NAME.test(name) || name.includes('..')) {
+    throw new Error(
+      `Invalid skill name "${name}". Names must be lowercase alphanumeric with hyphens, dots, or underscores.`,
+    );
+  }
+  return name;
+}
+
+function safePath(baseDir: string, name: string): string {
+  const target = resolve(join(baseDir, name));
+  const base = resolve(baseDir);
+  if (!target.startsWith(base + sep)) {
+    throw new Error(`Path traversal detected in "${name}"`);
+  }
+  return target;
+}
+
+export function parseFrontmatter(content: string): SkillMeta {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = /^---\n([\s\S]*?)\n---/.exec(normalized);
+  if (!match) {
+    return {
+      name: '',
+      description: '',
+      compatibility: undefined,
+      license: undefined,
+    };
+  }
+
+  const frontmatter = match[1];
+  const meta: Record<string, string> = {};
+  for (const line of frontmatter.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line
+      .slice(colonIdx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, '');
+    meta[key] = value;
+  }
+
+  return {
+    name: meta.name ?? '',
+    description: meta.description ?? '',
+    compatibility: meta.compatibility,
+    license: meta.license,
+  };
+}
+
+export function parseBody(content: string): string {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = /^---\n[\s\S]*?\n---\n([\s\S]*)$/.exec(normalized);
+  return match ? match[1].trim() : content;
+}
+
+async function fetchSkillDirs(): Promise<string[]> {
+  const response = await fetch(GITHUB_API, {
+    headers: { Accept: 'application/vnd.github.v3+json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch skills: ${response.statusText}`);
+  }
+  const items = (await response.json()) as { name: string; type: string }[];
+  return items.filter((item) => item.type === 'dir').map((item) => item.name);
+}
+
+async function fetchSkillMd(skillName: string): Promise<string> {
+  const url = `${GITHUB_RAW}/${skillName}/SKILL.md`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Skill "${skillName}" not found`);
+  }
+  return response.text();
+}
+
+async function fetchDirContents(
+  dirPath: string,
+): Promise<{ name: string; type: string; download_url: string | null }[]> {
+  const url = `https://api.github.com/repos/${SKILLS_REPO}/contents/${dirPath}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/vnd.github.v3+json' },
+  });
+  if (!response.ok) return [];
+  return response.json() as Promise<
+    { name: string; type: string; download_url: string | null }[]
+  >;
+}
+
+async function downloadDir(remotePath: string, localPath: string) {
+  const items = await fetchDirContents(remotePath);
+  mkdirSync(localPath, { recursive: true });
+
+  for (const item of items) {
+    const localItemPath = safePath(localPath, item.name);
+    if (item.type === 'dir') {
+      await downloadDir(`${remotePath}/${item.name}`, localItemPath);
+    } else if (item.type === 'file' && item.download_url) {
+      const res = await fetch(item.download_url);
+      if (res.ok) {
+        writeFileSync(localItemPath, await res.text(), 'utf-8');
+      }
+    }
+  }
+}
+
+// --- Subcommand handlers ---
+
+const list = async (props: OutputProps) => {
+  const dirs = await fetchSkillDirs();
+  const skills: SkillMeta[] = await Promise.all(
+    dirs.map(async (name) => {
+      try {
+        const content = await fetchSkillMd(name);
+        return parseFrontmatter(content);
+      } catch {
+        return {
+          name,
+          description: '(unable to fetch)',
+          compatibility: undefined,
+          license: undefined,
+        };
+      }
+    }),
+  );
+
+  writer(props).end(skills, {
+    fields: SKILL_FIELDS,
+    title: 'Available Skills',
+    emptyMessage: 'No skills found',
+  });
+};
+
+const get = async (props: OutputProps & { name: string }) => {
+  validateName(props.name);
+  const content = await fetchSkillMd(props.name);
+  const meta = parseFrontmatter(content);
+  const body = parseBody(content);
+
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(
+      { ...meta, body },
+      {
+        fields: [
+          'name',
+          'description',
+          'compatibility',
+          'license',
+          'body',
+        ] as any,
+      },
+    );
+  } else {
+    process.stdout.write(content);
+    process.stdout.write('\n');
+  }
+};
+
+const install = async (
+  props: OutputProps & { name: string; global: boolean },
+) => {
+  validateName(props.name);
+  // Verify skill exists
+  await fetchSkillMd(props.name);
+
+  const baseDir = props.global
+    ? join(homedir(), '.agents', 'skills')
+    : join(process.cwd(), '.agents', 'skills');
+
+  const targetDir = safePath(baseDir, props.name);
+
+  if (existsSync(targetDir)) {
+    log.info(`Skill "${props.name}" is already installed at ${targetDir}`);
+    log.info('Updating...');
+  }
+
+  const remotePath = `${SKILLS_PATH}/${props.name}`;
+  await downloadDir(remotePath, targetDir);
+
+  log.info(`Installed "${props.name}" to ${targetDir}`);
+};
+
+// --- Command definition ---
+
+export const command = 'skills';
+export const describe = 'Discover and install Neon agent skills';
+export const aliases = ['skill'];
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 skills <sub-command> [options]')
+    .command(
+      'list',
+      'List available Neon agent skills',
+      (yargs) => yargs,
+      (args) => list(args as any),
+    )
+    .command(
+      'get <name>',
+      'Fetch a skill and output its contents',
+      (yargs) =>
+        yargs.positional('name', {
+          describe: 'Skill name',
+          type: 'string',
+          demandOption: true,
+        }),
+      (args) => get(args as any),
+    )
+    .command(
+      'install <name>',
+      'Install a skill into your project or home directory',
+      (yargs) =>
+        yargs
+          .positional('name', {
+            describe: 'Skill name',
+            type: 'string',
+            demandOption: true,
+          })
+          .option('global', {
+            alias: 'g',
+            describe: 'Install to ~/.agents/skills/ instead of project-local',
+            type: 'boolean',
+            default: false,
+          }),
+      (args) => install(args as any),
+    );
+
+export const handler = (args: yargs.Argv) => {
+  return args;
+};


### PR DESCRIPTION
## Summary

- Adds `neonctl skills` command with three subcommands: `list`, `get <name>`, `install <name>`
- Fetches skill metadata from `neondatabase/agent-skills` GitHub repo
- Downloads and installs skills to local (`.agents/skills/`) or global (`~/.agents/skills/`) directories
- Bypasses Neon API auth since skills don't require it
- Includes input validation (`validateName`) and path traversal protection (`safePath`) on all filesystem operations
- Handles `\r\n` line endings in SKILL.md frontmatter parsing

## Test plan

- [x] Unit tests for `parseFrontmatter` (7 cases including edge cases, quoted values, \r\n)
- [x] Unit tests for `parseBody` (6 cases including \r\n)
- [x] Unit tests for `validateName` (4 cases covering valid names, path traversal, special chars, invalid chars)
- [x] `tsc --noEmit` passes
- [x] `vitest run` passes (17 tests)
- [ ] Manual: `neonctl skills list` shows available skills
- [ ] Manual: `neonctl skills get neon-postgres` outputs skill content
- [ ] Manual: `neonctl skills install neon-postgres` downloads to `.agents/skills/`

This pull request was AI-assisted by Isaac.