### PR TITLE
feat: add skill discovery enhancements

### DIFF
--- a/src/commands/skills.test.ts
+++ b/src/commands/skills.test.ts
@@ -1,8 +1,28 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
 
-import { parseFrontmatter, parseBody, validateName } from './skills.js';
+import {
+  parseFrontmatter,
+  parseBody,
+  getInstallStatus,
+  validateName,
+} from './skills.js';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn(() => false) };
+});
+
+const existsSyncMock = vi.mocked(existsSync);
 
 describe('skills', () => {
+  beforeEach(() => {
+    existsSyncMock.mockReset();
+    existsSyncMock.mockReturnValue(false);
+  });
+
   describe('validateName', () => {
     it('accepts valid skill names', () => {
       expect(validateName('neon-postgres')).toBe('neon-postgres');
@@ -151,6 +171,38 @@ describe('skills', () => {
     it('handles \\r\\n line endings', () => {
       const content = '---\r\nname: test\r\n---\r\nBody content here';
       expect(parseBody(content)).toBe('Body content here');
+    });
+  });
+
+  describe('getInstallStatus', () => {
+    it('returns empty string when not installed', () => {
+      expect(getInstallStatus('my-skill')).toBe('');
+    });
+
+    it('returns "local" when installed locally', () => {
+      existsSyncMock.mockImplementation(
+        (path) =>
+          path ===
+          resolve(join(process.cwd(), '.agents', 'skills', 'my-skill')),
+      );
+      expect(getInstallStatus('my-skill')).toBe('local');
+    });
+
+    it('returns "global" when installed globally', () => {
+      existsSyncMock.mockImplementation(
+        (path) =>
+          path === resolve(join(homedir(), '.agents', 'skills', 'my-skill')),
+      );
+      expect(getInstallStatus('my-skill')).toBe('global');
+    });
+
+    it('returns "local, global" when installed in both locations', () => {
+      existsSyncMock.mockReturnValue(true);
+      expect(getInstallStatus('my-skill')).toBe('local, global');
+    });
+
+    it('returns empty string for invalid names instead of throwing', () => {
+      expect(getInstallStatus('../../etc')).toBe('');
     });
   });
 });

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -16,13 +16,36 @@ type SkillMeta = {
   description: string;
   compatibility?: string;
   license?: string;
+  installed?: string;
 };
 
 type OutputProps = {
   output: 'json' | 'yaml' | 'table';
 };
 
-const SKILL_FIELDS = ['name', 'description'] as const;
+const LIST_FIELDS = [
+  'name',
+  'description',
+  'compatibility',
+  'installed',
+] as const;
+
+const GET_FIELDS = [
+  'name',
+  'description',
+  'compatibility',
+  'license',
+  'installed',
+] as const;
+
+const GET_FIELDS_FULL = [
+  'name',
+  'description',
+  'compatibility',
+  'license',
+  'installed',
+  'body',
+] as const;
 
 const VALID_NAME = /^[a-z0-9][a-z0-9._-]*$/;
 
@@ -83,6 +106,19 @@ export function parseBody(content: string): string {
   return match ? match[1].trim() : content;
 }
 
+export function getInstallStatus(skillName: string): string {
+  try {
+    const localBase = join(process.cwd(), '.agents', 'skills');
+    const globalBase = join(homedir(), '.agents', 'skills');
+    const locations: string[] = [];
+    if (existsSync(safePath(localBase, skillName))) locations.push('local');
+    if (existsSync(safePath(globalBase, skillName))) locations.push('global');
+    return locations.join(', ') || '';
+  } catch {
+    return '';
+  }
+}
+
 async function fetchSkillDirs(): Promise<string[]> {
   const response = await fetch(GITHUB_API, {
     headers: { Accept: 'application/vnd.github.v3+json' },
@@ -135,28 +171,42 @@ async function downloadDir(remotePath: string, localPath: string) {
 
 // --- Subcommand handlers ---
 
-const list = async (props: OutputProps) => {
+const list = async (props: OutputProps & { search?: string }) => {
   const dirs = await fetchSkillDirs();
-  const skills: SkillMeta[] = await Promise.all(
+  let skills: SkillMeta[] = await Promise.all(
     dirs.map(async (name) => {
       try {
         const content = await fetchSkillMd(name);
-        return parseFrontmatter(content);
+        const meta = parseFrontmatter(content);
+        meta.installed = getInstallStatus(name) || undefined;
+        return meta;
       } catch {
         return {
           name,
           description: '(unable to fetch)',
           compatibility: undefined,
           license: undefined,
+          installed: getInstallStatus(name) || undefined,
         };
       }
     }),
   );
 
+  if (props.search) {
+    const term = props.search.toLowerCase();
+    skills = skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(term) ||
+        s.description.toLowerCase().includes(term),
+    );
+  }
+
   writer(props).end(skills, {
-    fields: SKILL_FIELDS,
+    fields: LIST_FIELDS,
     title: 'Available Skills',
-    emptyMessage: 'No skills found',
+    emptyMessage: props.search
+      ? `No skills matching "${props.search}"`
+      : 'No skills found',
   });
 };
 
@@ -165,23 +215,20 @@ const get = async (props: OutputProps & { name: string }) => {
   const content = await fetchSkillMd(props.name);
   const meta = parseFrontmatter(content);
   const body = parseBody(content);
+  const installed = getInstallStatus(props.name);
+
+  const skillData = { ...meta, installed: installed || undefined };
 
   if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(
-      { ...meta, body },
-      {
-        fields: [
-          'name',
-          'description',
-          'compatibility',
-          'license',
-          'body',
-        ] as any,
-      },
-    );
+    writer(props).end({ ...skillData, body }, { fields: GET_FIELDS_FULL });
   } else {
-    process.stdout.write(content);
-    process.stdout.write('\n');
+    const w = writer(props);
+    w.write(skillData, {
+      fields: GET_FIELDS,
+      title: meta.name || props.name,
+    });
+    w.end();
+    process.stdout.write('\n' + body + '\n');
   }
 };
 
@@ -220,7 +267,12 @@ export const builder = (argv: yargs.Argv) =>
     .command(
       'list',
       'List available Neon agent skills',
-      (yargs) => yargs,
+      (yargs) =>
+        yargs.option('search', {
+          alias: 's',
+          describe: 'Filter skills by name or description',
+          type: 'string',
+        }),
       (args) => list(args as any),
     )
     .command(


### PR DESCRIPTION
## Summary

Builds on #456 to improve the skill discovery experience:

- **Installed status**: `skills list` shows `local`/`global`/`local, global` column indicating where each skill is installed
- **Compatibility field**: displayed in list table output (auto-hidden when empty)
- **Search filter**: `skills list --search <term>` (`-s`) filters by substring match on name + description
- **Structured get output**: table mode shows metadata header table + body instead of raw markdown dump; JSON/YAML includes all fields (compatibility, license, installed, body)
- `getInstallStatus` gracefully handles invalid names (returns empty instead of throwing) so `skills list` never crashes on unexpected GitHub directory names

## Test plan

- [x] Unit tests for `getInstallStatus` (5 cases: not installed, local, global, both, invalid name)
- [x] All 22 tests pass
- [x] `tsc --noEmit` passes
- [ ] Manual: `neonctl skills list` shows Installed/Compatibility columns
- [ ] Manual: `neonctl skills list -s postgres` filters correctly
- [ ] Manual: `neonctl skills get neon-postgres` shows structured metadata header
- [ ] Manual: `neonctl skills get neon-postgres -o json` includes all fields

This pull request was AI-assisted by Isaac.