### PR TITLE
feat(neon-auth): add configuration subcommands

### DIFF
--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/GET.json
@@ -1,0 +1,9 @@
+{
+  "enabled": true,
+  "email_verification_method": "link",
+  "require_email_verification": false,
+  "auto_sign_in_after_verification": true,
+  "send_verification_email_on_sign_up": true,
+  "send_verification_email_on_sign_in": false,
+  "disable_sign_up": false
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/PATCH.js
@@ -1,0 +1,11 @@
+export default function (req, res) {
+  res.send({
+    enabled: req.body.enabled ?? true,
+    email_verification_method: req.body.email_verification_method ?? 'link',
+    require_email_verification: req.body.require_email_verification ?? false,
+    auto_sign_in_after_verification: req.body.auto_sign_in_after_verification ?? true,
+    send_verification_email_on_sign_up: req.body.send_verification_email_on_sign_up ?? true,
+    send_verification_email_on_sign_in: req.body.send_verification_email_on_sign_in ?? false,
+    disable_sign_up: req.body.disable_sign_up ?? false,
+  });
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_and_password/PATCH.js
@@ -1,11 +1,18 @@
+import { expect } from 'vitest';
+
 export default function (req, res) {
+  expect(req.body).toHaveProperty('enabled');
+  expect(req.body).toHaveProperty('require_email_verification');
   res.send({
     enabled: req.body.enabled ?? true,
     email_verification_method: req.body.email_verification_method ?? 'link',
     require_email_verification: req.body.require_email_verification ?? false,
-    auto_sign_in_after_verification: req.body.auto_sign_in_after_verification ?? true,
-    send_verification_email_on_sign_up: req.body.send_verification_email_on_sign_up ?? true,
-    send_verification_email_on_sign_in: req.body.send_verification_email_on_sign_in ?? false,
+    auto_sign_in_after_verification:
+      req.body.auto_sign_in_after_verification ?? true,
+    send_verification_email_on_sign_up:
+      req.body.send_verification_email_on_sign_up ?? true,
+    send_verification_email_on_sign_in:
+      req.body.send_verification_email_on_sign_in ?? false,
     disable_sign_up: req.body.disable_sign_up ?? false,
   });
 }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/GET.json
@@ -1,0 +1,5 @@
+{
+  "type": "shared",
+  "sender_email": "noreply@example.com",
+  "sender_name": "My App"
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
@@ -2,6 +2,5 @@ import { expect } from 'vitest';
 
 export default function (req, res) {
   expect(req.body).toHaveProperty('type');
-  expect(req.body).toHaveProperty('sender_email');
   res.send(req.body);
 }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
@@ -1,0 +1,3 @@
+export default function (req, res) {
+  res.send(req.body);
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/email_provider/PATCH.js
@@ -1,3 +1,7 @@
+import { expect } from 'vitest';
+
 export default function (req, res) {
+  expect(req.body).toHaveProperty('type');
+  expect(req.body).toHaveProperty('sender_email');
   res.send(req.body);
 }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
@@ -2,7 +2,6 @@
   "organization": {
     "enabled": true,
     "organization_limit": 5,
-    "allow_user_to_create_organization": true,
     "creator_role": "owner"
   },
   "email_provider": {

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
@@ -1,0 +1,14 @@
+{
+  "organization": {
+    "enabled": true,
+    "organization_limit": 5,
+    "allow_user_to_create_organization": true,
+    "creator_role": "owner"
+  },
+  "email_provider": {
+    "type": "shared",
+    "sender_email": "noreply@example.com",
+    "sender_name": "My App"
+  },
+  "allow_localhost": true
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
@@ -9,5 +9,21 @@
     "sender_email": "noreply@example.com",
     "sender_name": "My App"
   },
+  "email_and_password": {
+    "enabled": true,
+    "email_verification_method": "otp",
+    "require_email_verification": false,
+    "auto_sign_in_after_verification": true,
+    "send_verification_email_on_sign_up": false,
+    "send_verification_email_on_sign_in": false,
+    "disable_sign_up": false
+  },
+  "oauth_providers": [
+    {
+      "id": "google",
+      "type": "shared",
+      "client_id": ""
+    }
+  ],
   "allow_localhost": true
 }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
@@ -1,0 +1,8 @@
+export default function (req, res) {
+  res.send({
+    enabled: req.body.enabled ?? true,
+    organization_limit: req.body.organization_limit ?? 5,
+    allow_user_to_create_organization: req.body.allow_user_to_create_organization ?? true,
+    creator_role: req.body.creator_role ?? 'owner',
+  });
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
@@ -6,7 +6,6 @@ export default function (req, res) {
   res.send({
     enabled: req.body.enabled ?? true,
     organization_limit: req.body.organization_limit ?? 5,
-    allow_user_to_create_organization: req.body.allow_user_to_create_organization ?? true,
     creator_role: req.body.creator_role ?? 'owner',
   });
 }

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/organization/PATCH.js
@@ -1,4 +1,8 @@
+import { expect } from 'vitest';
+
 export default function (req, res) {
+  expect(req.body).toHaveProperty('enabled');
+  expect(req.body).toHaveProperty('organization_limit');
   res.send({
     enabled: req.body.enabled ?? true,
     organization_limit: req.body.organization_limit ?? 5,

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/send_test_email/POST.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/send_test_email/POST.js
@@ -1,0 +1,10 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  expect(req.body).toHaveProperty('recipient_email');
+  expect(req.body).toHaveProperty('host');
+
+  res.send({
+    success: true,
+  });
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/send_test_email/POST.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/send_test_email/POST.js
@@ -3,7 +3,7 @@ import { expect } from 'vitest';
 export default function (req, res) {
   expect(req.body).toHaveProperty('recipient_email');
   expect(req.body).toHaveProperty('host');
-
+  expect(req.body).toHaveProperty('sender_email');
   res.send({
     success: true,
   });

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/GET.json
@@ -1,0 +1,6 @@
+{
+  "enabled": false,
+  "webhook_url": "",
+  "enabled_events": [],
+  "timeout_seconds": 5
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/PUT.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/PUT.js
@@ -1,0 +1,8 @@
+export default function (req, res) {
+  res.send({
+    enabled: req.body.enabled,
+    webhook_url: req.body.webhook_url || '',
+    enabled_events: req.body.enabled_events || [],
+    timeout_seconds: req.body.timeout_seconds || 5,
+  });
+}

--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/PUT.js
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/webhooks/PUT.js
@@ -1,4 +1,8 @@
+import { expect } from 'vitest';
+
 export default function (req, res) {
+  expect(req.body).toHaveProperty('enabled');
+  expect(req.body).toHaveProperty('webhook_url');
   res.send({
     enabled: req.body.enabled,
     webhook_url: req.body.webhook_url || '',

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -1,24 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`neon-auth > allow-localhost enable 1`] = `
-"
-Localhost connections allowed
-
-"
-`;
-
-exports[`neon-auth > allow-localhost get 1`] = `
-"allow_localhost: true
-"
-`;
-
-exports[`neon-auth > disable 1`] = `
-"
-Neon Auth has been disabled
-
-"
-`;
-
 exports[`neon-auth > disable 1`] = `
 "
 Neon Auth has been disabled
@@ -113,7 +94,6 @@ sender_name: Test App
 "
 `;
 
-
 exports[`neon-auth > enable 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id
@@ -178,7 +158,7 @@ creator_role: owner
 
 exports[`neon-auth > organization update 1`] = `
 "enabled: true
-organization_limit: 5
+organization_limit: 10
 allow_user_to_create_organization: true
 creator_role: owner
 "
@@ -212,7 +192,6 @@ User created
 "
 `;
 
-
 exports[`neon-auth > user delete 1`] = `
 "
 User "test-user-id" deleted
@@ -239,7 +218,7 @@ timeout_seconds: 5
 
 exports[`neon-auth > webhook update 1`] = `
 "enabled: true
-webhook_url: ""
+webhook_url: https://hooks.test.com/webhook
 enabled_events:
   - user.created
 timeout_seconds: 5

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -160,6 +160,45 @@ creator_role: owner
 "
 `;
 
+exports[`neon-auth > plugins get 1`] = `
+"enabled: true
+organization_limit: 5
+creator_role: owner
+"
+`;
+
+exports[`neon-auth > plugins list 1`] = `
+"organization:
+  enabled: true
+  organization_limit: 5
+  creator_role: owner
+email_provider:
+  type: shared
+  sender_email: noreply@example.com
+  sender_name: My App
+email_and_password:
+  enabled: true
+  email_verification_method: otp
+  require_email_verification: false
+  auto_sign_in_after_verification: true
+  send_verification_email_on_sign_up: false
+  send_verification_email_on_sign_in: false
+  disable_sign_up: false
+oauth_providers:
+  - id: google
+    type: shared
+    client_id: ""
+allow_localhost: true
+"
+`;
+
+exports[`neon-auth > plugins update 1`] = `
+"enabled: true
+organization_limit: 10
+creator_role: owner
+"
+`;
+
 exports[`neon-auth > status 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -151,7 +151,6 @@ client_id: my-client-id
 exports[`neon-auth > organization get 1`] = `
 "enabled: true
 organization_limit: 5
-allow_user_to_create_organization: true
 creator_role: owner
 "
 `;
@@ -159,7 +158,6 @@ creator_role: owner
 exports[`neon-auth > organization update 1`] = `
 "enabled: true
 organization_limit: 10
-allow_user_to_create_organization: true
 creator_role: owner
 "
 `;

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -1,12 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`neon-auth > allow-localhost enable 1`] = `
+"
+Localhost connections allowed
+
+"
+`;
+
 exports[`neon-auth > allow-localhost get 1`] = `
 "allow_localhost: true
 "
 `;
 
-exports[`neon-auth > allow-localhost update 1`] = `
-"allow_localhost: true
+exports[`neon-auth > disable 1`] = `
+"
+Neon Auth has been disabled
+
 "
 `;
 
@@ -169,7 +178,7 @@ creator_role: owner
 
 exports[`neon-auth > organization update 1`] = `
 "enabled: true
-organization_limit: 10
+organization_limit: 5
 allow_user_to_create_organization: true
 creator_role: owner
 "
@@ -203,6 +212,7 @@ User created
 "
 `;
 
+
 exports[`neon-auth > user delete 1`] = `
 "
 User "test-user-id" deleted
@@ -229,7 +239,7 @@ timeout_seconds: 5
 
 exports[`neon-auth > webhook update 1`] = `
 "enabled: true
-webhook_url: https://hooks.test.com/webhook
+webhook_url: ""
 enabled_events:
   - user.created
 timeout_seconds: 5

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -1,5 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`neon-auth > allow-localhost get 1`] = `
+"allow_localhost: true
+"
+`;
+
+exports[`neon-auth > allow-localhost update 1`] = `
+"allow_localhost: true
+"
+`;
+
 exports[`neon-auth > disable 1`] = `
 "
 Neon Auth has been disabled
@@ -52,6 +62,48 @@ exports[`neon-auth > domain list 1`] = `
 - domain: https://app.example.com
 "
 `;
+
+exports[`neon-auth > email-password get 1`] = `
+"enabled: true
+email_verification_method: link
+require_email_verification: false
+auto_sign_in_after_verification: true
+send_verification_email_on_sign_up: true
+send_verification_email_on_sign_in: false
+disable_sign_up: false
+"
+`;
+
+exports[`neon-auth > email-password update 1`] = `
+"enabled: true
+email_verification_method: link
+require_email_verification: true
+auto_sign_in_after_verification: true
+send_verification_email_on_sign_up: true
+send_verification_email_on_sign_in: false
+disable_sign_up: false
+"
+`;
+
+exports[`neon-auth > email-provider get 1`] = `
+"type: shared
+sender_email: noreply@example.com
+sender_name: My App
+"
+`;
+
+exports[`neon-auth > email-provider test 1`] = `
+"success: true
+"
+`;
+
+exports[`neon-auth > email-provider update 1`] = `
+"type: shared
+sender_email: noreply@test.com
+sender_name: Test App
+"
+`;
+
 
 exports[`neon-auth > enable 1`] = `
 "auth_provider: better_auth
@@ -107,6 +159,22 @@ client_id: my-client-id
 "
 `;
 
+exports[`neon-auth > organization get 1`] = `
+"enabled: true
+organization_limit: 5
+allow_user_to_create_organization: true
+creator_role: owner
+"
+`;
+
+exports[`neon-auth > organization update 1`] = `
+"enabled: true
+organization_limit: 10
+allow_user_to_create_organization: true
+creator_role: owner
+"
+`;
+
 exports[`neon-auth > status 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id
@@ -148,5 +216,22 @@ Roles updated
   User ID:   test-user-id
   Roles:     admin
 
+"
+`;
+
+exports[`neon-auth > webhook get 1`] = `
+"enabled: false
+webhook_url: ""
+enabled_events: []
+timeout_seconds: 5
+"
+`;
+
+exports[`neon-auth > webhook update 1`] = `
+"enabled: true
+webhook_url: https://hooks.test.com/webhook
+enabled_events:
+  - user.created
+timeout_seconds: 5
 "
 `;

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -89,8 +89,6 @@ exports[`neon-auth > email-provider test 1`] = `
 
 exports[`neon-auth > email-provider update 1`] = `
 "type: shared
-sender_email: noreply@test.com
-sender_name: Test App
 "
 `;
 

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -192,13 +192,6 @@ allow_localhost: true
 "
 `;
 
-exports[`neon-auth > plugins update 1`] = `
-"enabled: true
-organization_limit: 10
-creator_role: owner
-"
-`;
-
 exports[`neon-auth > status 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -178,6 +178,92 @@ describe('neon-auth', () => {
     ]);
   });
 
+  // --- Email and Password ---
+
+  test('email-password get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'email-password',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('email-password update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'email-password',
+      'update',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--enabled',
+      '--require-email-verification',
+    ]);
+  });
+
+  // --- Email Provider ---
+
+  test('email-provider get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'email-provider',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('email-provider update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'email-provider',
+      'update',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--type',
+      'shared',
+      '--sender-email',
+      'noreply@test.com',
+      '--sender-name',
+      'Test App',
+    ]);
+  });
+
+  test('email-provider test', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'email-provider',
+      'test',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--recipient-email',
+      'user@test.com',
+      '--host',
+      'smtp.test.com',
+      '--port',
+      '587',
+      '--username',
+      'smtp-user',
+      '--password',
+      'smtp-pass',
+      '--sender-email',
+      'noreply@test.com',
+      '--sender-name',
+      'Test App',
+    ]);
+  });
+
   // --- Allow localhost ---
 
   test('domain allow-localhost get', async ({ testCliCommand }) => {
@@ -206,6 +292,20 @@ describe('neon-auth', () => {
     ]);
   });
 
+  // --- Organization ---
+
+  test('organization get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'organization',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
   test('domain allow-localhost disable', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
@@ -218,6 +318,53 @@ describe('neon-auth', () => {
       'test_branch',
     ]);
   });
+
+  test('organization update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'organization',
+      'update',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--enabled',
+      '--organization-limit',
+      '10',
+    ]);
+  });
+
+  // --- Webhook ---
+
+  test('webhook get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'webhook',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('webhook update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'webhook',
+      'update',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--enabled',
+      '--webhook-url',
+      'https://hooks.test.com/webhook',
+      '--enabled-events',
+      'user.created',
+    ]);
+  });
+
 
   // --- User ---
 

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -178,34 +178,6 @@ describe('neon-auth', () => {
     ]);
   });
 
-  // --- Allow Localhost ---
-
-  test('allow-localhost get', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'neon-auth',
-      'domain',
-      'allow-localhost',
-      'get',
-      '--project-id',
-      'test',
-      '--branch',
-      'test_branch',
-    ]);
-  });
-
-  test('allow-localhost enable', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'neon-auth',
-      'domain',
-      'allow-localhost',
-      'enable',
-      '--project-id',
-      'test',
-      '--branch',
-      'test_branch',
-    ]);
-  });
-
   // --- Config: Email and Password ---
 
   test('email-password get', async ({ testCliCommand }) => {
@@ -401,7 +373,6 @@ describe('neon-auth', () => {
       'user.created',
     ]);
   });
-
 
   // --- User ---
 

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -370,6 +370,48 @@ describe('neon-auth', () => {
     ]);
   });
 
+  // --- Plugins ---
+
+  test('plugins list', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'list',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('plugins get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'get',
+      'organization',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('plugins update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'update',
+      'organization',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--json',
+      '{"enabled": true, "organization_limit": 10}',
+    ]);
+  });
+
   // --- User ---
 
   test('user create', async ({ testCliCommand }) => {

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -336,7 +336,7 @@ describe('neon-auth', () => {
       '--branch',
       'test_branch',
       '--enabled',
-      '--organization-limit',
+      '--limit',
       '10',
     ]);
   });
@@ -367,7 +367,7 @@ describe('neon-auth', () => {
       '--branch',
       'test_branch',
       '--enabled',
-      '--webhook-url',
+      '--url',
       'https://hooks.test.com/webhook',
       '--enabled-events',
       'user.created',

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -235,10 +235,6 @@ describe('neon-auth', () => {
       'test_branch',
       '--type',
       'shared',
-      '--sender-email',
-      'noreply@test.com',
-      '--sender-name',
-      'Test App',
     ]);
   });
 

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -178,11 +178,40 @@ describe('neon-auth', () => {
     ]);
   });
 
-  // --- Email and Password ---
+  // --- Allow Localhost ---
+
+  test('allow-localhost get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'domain',
+      'allow-localhost',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('allow-localhost enable', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'domain',
+      'allow-localhost',
+      'enable',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  // --- Config: Email and Password ---
 
   test('email-password get', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'email-password',
       'get',
       '--project-id',
@@ -195,6 +224,7 @@ describe('neon-auth', () => {
   test('email-password update', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'email-password',
       'update',
       '--project-id',
@@ -206,11 +236,12 @@ describe('neon-auth', () => {
     ]);
   });
 
-  // --- Email Provider ---
+  // --- Config: Email Provider ---
 
   test('email-provider get', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'email-provider',
       'get',
       '--project-id',
@@ -223,6 +254,7 @@ describe('neon-auth', () => {
   test('email-provider update', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'email-provider',
       'update',
       '--project-id',
@@ -241,6 +273,7 @@ describe('neon-auth', () => {
   test('email-provider test', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'email-provider',
       'test',
       '--project-id',
@@ -292,20 +325,6 @@ describe('neon-auth', () => {
     ]);
   });
 
-  // --- Organization ---
-
-  test('organization get', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'neon-auth',
-      'organization',
-      'get',
-      '--project-id',
-      'test',
-      '--branch',
-      'test_branch',
-    ]);
-  });
-
   test('domain allow-localhost disable', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
@@ -319,9 +338,25 @@ describe('neon-auth', () => {
     ]);
   });
 
+  // --- Config: Organization ---
+
+  test('organization get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'config',
+      'organization',
+      'get',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
   test('organization update', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'organization',
       'update',
       '--project-id',
@@ -334,11 +369,12 @@ describe('neon-auth', () => {
     ]);
   });
 
-  // --- Webhook ---
+  // --- Config: Webhook ---
 
   test('webhook get', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'webhook',
       'get',
       '--project-id',
@@ -351,6 +387,7 @@ describe('neon-auth', () => {
   test('webhook update', async ({ testCliCommand }) => {
     await testCliCommand([
       'neon-auth',
+      'config',
       'webhook',
       'update',
       '--project-id',

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -397,21 +397,6 @@ describe('neon-auth', () => {
     ]);
   });
 
-  test('plugins update', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'neon-auth',
-      'plugins',
-      'update',
-      'organization',
-      '--project-id',
-      'test',
-      '--branch',
-      'test_branch',
-      '--json',
-      '{"enabled": true, "organization_limit": 10}',
-    ]);
-  });
-
   // --- User ---
 
   test('user create', async ({ testCliCommand }) => {

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -305,11 +305,15 @@ export const builder = (argv: yargs.Argv) => {
     })
     .command('config', 'Manage Neon Auth configuration', (yargs) => {
       return yargs
+        .usage('$0 neon-auth config <sub-command> [options]')
         .command(
           'email-password',
           'Manage email and password authentication settings',
           (yargs) => {
             return yargs
+              .usage(
+                '$0 neon-auth config email-password <sub-command> [options]',
+              )
               .command(
                 'get',
                 'Get email and password config',
@@ -366,6 +370,9 @@ export const builder = (argv: yargs.Argv) => {
           'Manage email provider configuration',
           (yargs) => {
             return yargs
+              .usage(
+                '$0 neon-auth config email-provider <sub-command> [options]',
+              )
               .command(
                 'get',
                 'Get email provider config',
@@ -466,6 +473,7 @@ export const builder = (argv: yargs.Argv) => {
           'Manage organization plugin settings',
           (yargs) => {
             return yargs
+              .usage('$0 neon-auth config organization <sub-command> [options]')
               .command(
                 'get',
                 'Get organization plugin config',
@@ -502,6 +510,7 @@ export const builder = (argv: yargs.Argv) => {
         )
         .command('webhook', 'Manage webhook configuration', (yargs) => {
           return yargs
+            .usage('$0 neon-auth config webhook <sub-command> [options]')
             .command(
               'get',
               'Get webhook config',

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -555,6 +555,63 @@ export const builder = (argv: yargs.Argv) => {
             );
         });
     })
+    .command(
+      'plugins',
+      'View and update Neon Auth plugin configurations',
+      (yargs) => {
+        return yargs
+          .usage('$0 neon-auth plugins <sub-command> [options]')
+          .command(
+            'list',
+            'List all plugin configurations',
+            (yargs) => yargs,
+            async (args) => {
+              await pluginsList(args as any);
+            },
+          )
+          .command(
+            'get <plugin-name>',
+            'Get a specific plugin configuration',
+            (yargs) =>
+              yargs
+                .usage('$0 neon-auth plugins get <plugin-name> [options]')
+                .positional('plugin-name', {
+                  describe:
+                    'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
+                  type: 'string',
+                  demandOption: true,
+                }),
+            async (args) => {
+              await pluginsGet(args as any);
+            },
+          )
+          .command(
+            'update <plugin-name>',
+            'Update a plugin configuration using JSON',
+            (yargs) =>
+              yargs
+                .usage(
+                  '$0 neon-auth plugins update <plugin-name> --json \'{"key": "value"}\' [options]',
+                )
+                .positional('plugin-name', {
+                  describe:
+                    'Plugin name (e.g. organization, email_and_password, email_provider, allow_localhost, webhook)',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .options({
+                  json: {
+                    describe: 'JSON configuration to apply',
+                    type: 'string',
+                    demandOption: true,
+                  },
+                }),
+            async (args) => {
+              await pluginsUpdate(args as any);
+            },
+          );
+      },
+    )
     .command('user', 'Manage Neon Auth users', (yargs) => {
       return yargs
         .usage('$0 neon-auth user <sub-command> [options]')
@@ -1346,6 +1403,167 @@ const webhookUpdate = async (
     return;
   }
   printKvBlock('Webhook configuration updated', printWebhookEntries(data));
+};
+
+// --- Plugins ---
+
+const pluginTitle = (name: string): string =>
+  name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()) +
+  ' configuration';
+
+const formatValue = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return JSON.stringify(v);
+};
+
+const PLUGIN_UPDATE_METHODS: Record<
+  string,
+  (props: AuthBranchProps, branchId: string, data: any) => Promise<any>
+> = {
+  organization: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthOrganizationPlugin(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  email_and_password: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthEmailAndPasswordConfig(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  email_provider: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthEmailProvider(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  allow_localhost: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthAllowLocalhost(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  webhook: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthWebhookConfig(
+      props.projectId,
+      branchId,
+      data,
+    ),
+};
+
+const pluginsList = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthPluginConfigs(
+    props.projectId,
+    branchId,
+  );
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data as any, {
+      fields: Object.keys(data) as any,
+    });
+    return;
+  }
+  const summarize = (value: unknown): string => {
+    if (value == null) return 'not configured';
+    if (typeof value === 'boolean') return String(value);
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number') return String(value);
+    if (Array.isArray(value))
+      return value.length === 1 ? '1 item' : `${String(value.length)} items`;
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>;
+      if ('enabled' in obj) return obj.enabled ? 'enabled' : 'disabled';
+      if ('type' in obj) return formatValue(obj.type);
+    }
+    return JSON.stringify(value);
+  };
+  const entries: [string, string][] = Object.entries(data).map(
+    ([key, value]) => [key.padEnd(24), summarize(value)],
+  );
+  printKvBlock('Neon Auth plugins', entries);
+};
+
+const pluginsGet = async (props: AuthBranchProps & { pluginName: string }) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthPluginConfigs(
+    props.projectId,
+    branchId,
+  );
+  const plugin = (data as any)[props.pluginName];
+  if (plugin === undefined) {
+    const available = Object.keys(data).join(', ');
+    throw new Error(
+      `Unknown plugin "${props.pluginName}". Available plugins: ${available}`,
+    );
+  }
+  if (props.output === 'json' || props.output === 'yaml') {
+    const fields =
+      typeof plugin === 'object' && !Array.isArray(plugin)
+        ? Object.keys(plugin)
+        : [];
+    writer(props).end(plugin, { fields: fields as any });
+    return;
+  }
+  if (typeof plugin === 'object' && !Array.isArray(plugin) && plugin != null) {
+    const entries: [string, string][] = Object.entries(plugin).map(([k, v]) => [
+      `${k}:`.padEnd(18),
+      formatValue(v),
+    ]);
+    printKvBlock(pluginTitle(props.pluginName), entries);
+  } else if (Array.isArray(plugin)) {
+    const entries: [string, string][] = plugin.map((item, i) => [
+      `[${i}]:`.padEnd(18),
+      typeof item === 'object' ? JSON.stringify(item) : String(item),
+    ]);
+    printKvBlock(pluginTitle(props.pluginName), entries);
+  } else {
+    printKvBlock(pluginTitle(props.pluginName), [
+      ['Value:'.padEnd(18), String(plugin)],
+    ]);
+  }
+};
+
+const pluginsUpdate = async (
+  props: AuthBranchProps & { pluginName: string; json: string },
+) => {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(props.json);
+  } catch {
+    throw new Error('Invalid JSON. Please provide valid JSON with --json.');
+  }
+
+  const updateMethod = PLUGIN_UPDATE_METHODS[props.pluginName];
+  if (!updateMethod) {
+    const available = Object.keys(PLUGIN_UPDATE_METHODS).join(', ');
+    throw new Error(
+      `Unknown plugin "${props.pluginName}". Updatable plugins: ${available}`,
+    );
+  }
+
+  const branchId = await resolveBranch(props);
+  const { data } = await updateMethod(props, branchId, parsed);
+
+  if (props.output === 'json' || props.output === 'yaml') {
+    const fields =
+      typeof data === 'object' && !Array.isArray(data) ? Object.keys(data) : [];
+    writer(props).end(data, { fields: fields as any });
+    return;
+  }
+  if (typeof data === 'object' && !Array.isArray(data) && data != null) {
+    const entries: [string, string][] = Object.entries(data).map(([k, v]) => [
+      `${k}:`.padEnd(18),
+      formatValue(v),
+    ]);
+    printKvBlock(`${pluginTitle(props.pluginName)} updated`, entries);
+  } else {
+    printKvBlock(`${pluginTitle(props.pluginName)} updated`, [
+      ['Value:'.padEnd(18), String(data)],
+    ]);
+  }
 };
 
 // --- User ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1176,15 +1176,47 @@ const emailProviderTest = async (
 
 // --- Organization plugin ---
 
+const printOrganizationConfig = (
+  props: AuthBranchProps,
+  data: {
+    enabled: boolean;
+    organization_limit: number;
+    allow_user_to_create_organization: boolean;
+    creator_role: string;
+  },
+  title?: string,
+) => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: ORGANIZATION_FIELDS });
+    return;
+  }
+  const kv = (key: string, value: string) =>
+    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
+  if (title) {
+    process.stdout.write(`\n${chalk.green(title)}\n`);
+  } else {
+    process.stdout.write('\n');
+  }
+  kv('Enabled:          ', String(data.enabled));
+  kv('Org Limit:        ', String(data.organization_limit));
+  kv('Creator Role:     ', data.creator_role);
+  process.stdout.write('\n');
+};
+
 const organizationGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthPluginConfigs(
     props.projectId,
     branchId,
   );
-  writer(props).end(data.organization ?? ({} as any), {
-    fields: ORGANIZATION_FIELDS,
-  });
+  const org = data.organization;
+  if (!org) {
+    process.stdout.write(
+      `\n${chalk.green('No organization plugin config found.')}\n\n`,
+    );
+    return;
+  }
+  printOrganizationConfig(props, org);
 };
 
 const organizationUpdate = async (
@@ -1204,7 +1236,7 @@ const organizationUpdate = async (
       creator_role: props.creatorRole as 'admin' | 'owner',
     },
   );
-  writer(props).end(data, { fields: ORGANIZATION_FIELDS });
+  printOrganizationConfig(props, data, 'Organization configuration updated');
 };
 
 // --- Webhook ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1031,8 +1031,11 @@ const printEmailPasswordConfig = (
   }
   const kv = (key: string, value: string) =>
     process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
-  if (title) process.stdout.write(`\n${chalk.green(title)}\n`);
-  process.stdout.write('\n');
+  if (title) {
+    process.stdout.write(`\n${chalk.green(title)}\n`);
+  } else {
+    process.stdout.write('\n');
+  }
   kv('Enabled:                    ', String(data.enabled));
   kv('Verification Method:        ', data.email_verification_method);
   kv('Require Verification:       ', String(data.require_email_verification));
@@ -1087,7 +1090,11 @@ const emailPasswordUpdate = async (
       disable_sign_up: props.disableSignUp,
     },
   );
-  printEmailPasswordConfig(props, data, 'Email password settings updated');
+  printEmailPasswordConfig(
+    props,
+    data,
+    'Email & password auth configuration updated',
+  );
 };
 
 // --- Email provider ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -82,7 +82,6 @@ const EMAIL_PROVIDER_FIELDS = [
 const ORGANIZATION_FIELDS = [
   'enabled',
   'organization_limit',
-  'allow_user_to_create_organization',
   'creator_role',
 ] as const;
 
@@ -478,13 +477,9 @@ export const builder = (argv: yargs.Argv) => {
                 describe: 'Enable the organization plugin',
                 type: 'boolean',
               },
-              'organization-limit': {
+              limit: {
                 describe: 'Maximum number of organizations a user can create',
                 type: 'number',
-              },
-              'allow-user-to-create-organization': {
-                describe: 'Allow users to create organizations',
-                type: 'boolean',
               },
               'creator-role': {
                 describe: 'Role assigned to organization creator',
@@ -517,7 +512,7 @@ export const builder = (argv: yargs.Argv) => {
                 type: 'boolean',
                 demandOption: true,
               },
-              'webhook-url': {
+              url: {
                 describe: 'Webhook endpoint URL',
                 type: 'string',
               },
@@ -532,7 +527,7 @@ export const builder = (argv: yargs.Argv) => {
                 ] as const,
                 array: true,
               },
-              'timeout-seconds': {
+              timeout: {
                 describe: 'Webhook timeout in seconds (1-10)',
                 type: 'number',
               },
@@ -1130,8 +1125,7 @@ const organizationGet = async (props: AuthBranchProps) => {
 const organizationUpdate = async (
   props: AuthBranchProps & {
     enabled?: boolean;
-    organizationLimit?: number;
-    allowUserToCreateOrganization?: boolean;
+    limit?: number;
     creatorRole?: string;
   },
 ) => {
@@ -1141,8 +1135,7 @@ const organizationUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      organization_limit: props.organizationLimit,
-      allow_user_to_create_organization: props.allowUserToCreateOrganization,
+      organization_limit: props.limit,
       creator_role: props.creatorRole as 'admin' | 'owner',
     },
   );
@@ -1163,9 +1156,9 @@ const webhookGet = async (props: AuthBranchProps) => {
 const webhookUpdate = async (
   props: AuthBranchProps & {
     enabled: boolean;
-    webhookUrl?: string;
+    url?: string;
     enabledEvents?: string[];
-    timeoutSeconds?: number;
+    timeout?: number;
   },
 ) => {
   const branchId = await resolveBranch(props);
@@ -1174,7 +1167,7 @@ const webhookUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      webhook_url: props.webhookUrl,
+      webhook_url: props.url,
       enabled_events: props.enabledEvents as
         | (
             | 'user.before_create'
@@ -1183,7 +1176,7 @@ const webhookUpdate = async (
             | 'send.magic_link'
           )[]
         | undefined,
-      timeout_seconds: props.timeoutSeconds,
+      timeout_seconds: props.timeout,
     },
   );
   writer(props).end(data, { fields: WEBHOOK_FIELDS });

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1140,6 +1140,14 @@ const emailProviderUpdate = async (
     senderName?: string;
   },
 ) => {
+  if (
+    props.type === 'standard' &&
+    (!props.host || !props.port || !props.username || !props.password)
+  ) {
+    throw new Error(
+      '--host, --port, --username, and --password are required for standard email provider',
+    );
+  }
   const branchId = await resolveBranch(props);
   let config: any;
   if (props.type === 'standard') {

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1099,13 +1099,47 @@ const emailPasswordUpdate = async (
 
 // --- Email provider ---
 
+const printEmailProviderConfig = (
+  props: AuthBranchProps,
+  data: {
+    type: string;
+    host?: string;
+    port?: number;
+    username?: string;
+    sender_email?: string;
+    sender_name?: string;
+  },
+  title?: string,
+) => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: EMAIL_PROVIDER_FIELDS });
+    return;
+  }
+  const kv = (key: string, value: string) =>
+    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
+  if (title) {
+    process.stdout.write(`\n${chalk.green(title)}\n`);
+  } else {
+    process.stdout.write('\n');
+  }
+  kv('Type:          ', data.type);
+  if (data.type === 'standard') {
+    kv('Host:          ', data.host ?? '');
+    kv('Port:          ', data.port != null ? String(data.port) : '');
+    kv('Username:      ', data.username ?? '');
+  }
+  kv('Sender Email:  ', data.sender_email ?? '');
+  kv('Sender Name:   ', data.sender_name ?? '');
+  process.stdout.write('\n');
+};
+
 const emailProviderGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthEmailProvider(
     props.projectId,
     branchId,
   );
-  writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS });
+  printEmailProviderConfig(props, data as any);
 };
 
 const emailProviderUpdate = async (
@@ -1143,7 +1177,11 @@ const emailProviderUpdate = async (
     branchId,
     config,
   );
-  writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS });
+  printEmailProviderConfig(
+    props,
+    data as any,
+    'Email provider configuration updated',
+  );
 };
 
 const emailProviderTest = async (
@@ -1171,7 +1209,17 @@ const emailProviderTest = async (
       sender_name: props.senderName,
     },
   );
-  writer(props).end(data, { fields: TEST_EMAIL_FIELDS });
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: TEST_EMAIL_FIELDS });
+  } else if (data.success) {
+    process.stdout.write(
+      `\n${chalk.green('Test email sent successfully')}\n\n`,
+    );
+  } else {
+    process.stdout.write(
+      `\n${chalk.green('Test email failed')}\n  ${data.error_message ?? 'Unknown error'}\n\n`,
+    );
+  }
 };
 
 // --- Organization plugin ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1148,6 +1148,8 @@ const emailProviderUpdate = async (
       '--host, --port, --username, and --password are required for standard email provider',
     );
   }
+  const warnSharedSender =
+    props.type === 'shared' && (props.senderEmail || props.senderName);
   const branchId = await resolveBranch(props);
   let config: any;
   if (props.type === 'standard') {
@@ -1163,8 +1165,6 @@ const emailProviderUpdate = async (
   } else {
     config = {
       type: 'shared',
-      sender_email: props.senderEmail,
-      sender_name: props.senderName,
     };
   }
   const { data } = await props.apiClient.updateNeonAuthEmailProvider(
@@ -1174,12 +1174,18 @@ const emailProviderUpdate = async (
   );
   if (props.output === 'json' || props.output === 'yaml') {
     writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS as any });
-    return;
+  } else {
+    printKvBlock(
+      'Email provider configuration updated',
+      printEmailProviderEntries(data as any),
+    );
   }
-  printKvBlock(
-    'Email provider configuration updated',
-    printEmailProviderEntries(data as any),
-  );
+  if (warnSharedSender) {
+    process.stderr.write(
+      `${chalk.yellow('Warning:')} --sender-email and --sender-name are ignored for the shared email provider. ` +
+        `These values only take effect with --type standard.\n\n`,
+    );
+  }
 };
 
 const emailProviderTest = async (

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -491,7 +491,7 @@ export const builder = (argv: yargs.Argv) => {
                       describe: 'Enable the organization plugin',
                       type: 'boolean',
                     },
-                    limit: {
+                    'organization-limit': {
                       describe:
                         'Maximum number of organizations a user can create',
                       type: 'number',
@@ -529,7 +529,7 @@ export const builder = (argv: yargs.Argv) => {
                     type: 'boolean',
                     demandOption: true,
                   },
-                  url: {
+                  'webhook-url': {
                     describe: 'Webhook endpoint URL',
                     type: 'string',
                   },
@@ -1205,7 +1205,7 @@ const emailProviderTest = async (
     printMessage('Test email sent successfully');
   } else {
     process.stdout.write(
-      `\n${chalk.green('Test email failed')}\n  ${data.error_message ?? 'Unknown error'}\n\n`,
+      `\n${chalk.red('Test email failed')}\n  ${data.error_message ?? 'Unknown error'}\n\n`,
     );
   }
 };
@@ -1230,14 +1230,14 @@ const organizationGet = async (props: AuthBranchProps) => {
   );
   const org = data.organization;
   if (!org) {
-    if (props.output !== 'table') {
+    if (props.output === 'json' || props.output === 'yaml') {
       writer(props).end({} as any, { fields: ORGANIZATION_FIELDS as any });
       return;
     }
     printMessage('No organization plugin config found.');
     return;
   }
-  if (props.output !== 'table') {
+  if (props.output === 'json' || props.output === 'yaml') {
     writer(props).end(org as any, { fields: ORGANIZATION_FIELDS as any });
     return;
   }
@@ -1247,7 +1247,7 @@ const organizationGet = async (props: AuthBranchProps) => {
 const organizationUpdate = async (
   props: AuthBranchProps & {
     enabled?: boolean;
-    limit?: number;
+    organizationLimit?: number;
     creatorRole?: string;
   },
 ) => {
@@ -1257,11 +1257,11 @@ const organizationUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      organization_limit: props.limit,
+      organization_limit: props.organizationLimit,
       creator_role: props.creatorRole as 'admin' | 'owner',
     },
   );
-  if (props.output !== 'table') {
+  if (props.output === 'json' || props.output === 'yaml') {
     writer(props).end(data as any, { fields: ORGANIZATION_FIELDS as any });
     return;
   }
@@ -1304,7 +1304,7 @@ const webhookGet = async (props: AuthBranchProps) => {
 const webhookUpdate = async (
   props: AuthBranchProps & {
     enabled: boolean;
-    url?: string;
+    webhookUrl?: string;
     enabledEvents?: string[];
     timeout?: number;
   },
@@ -1315,7 +1315,7 @@ const webhookUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      webhook_url: props.url,
+      webhook_url: props.webhookUrl,
       enabled_events: props.enabledEvents as
         | (
             | 'user.before_create'

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1012,48 +1012,32 @@ const allowLocalhostDisable = async (props: AuthBranchProps) => {
 
 // --- Email and password ---
 
-const printEmailPasswordConfig = (
-  props: AuthBranchProps,
-  data: {
-    enabled: boolean;
-    email_verification_method: string;
-    require_email_verification: boolean;
-    auto_sign_in_after_verification: boolean;
-    send_verification_email_on_sign_up: boolean;
-    send_verification_email_on_sign_in: boolean;
-    disable_sign_up: boolean;
-  },
-  title?: string,
-) => {
-  if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
-    return;
-  }
-  const kv = (key: string, value: string) =>
-    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
-  if (title) {
-    process.stdout.write(`\n${chalk.green(title)}\n`);
-  } else {
-    process.stdout.write('\n');
-  }
-  kv('Enabled:                    ', String(data.enabled));
-  kv('Verification Method:        ', data.email_verification_method);
-  kv('Require Verification:       ', String(data.require_email_verification));
-  kv(
+const printEmailPasswordEntries = (data: {
+  enabled: boolean;
+  email_verification_method: string;
+  require_email_verification: boolean;
+  auto_sign_in_after_verification: boolean;
+  send_verification_email_on_sign_up: boolean;
+  send_verification_email_on_sign_in: boolean;
+  disable_sign_up: boolean;
+}): [string, string][] => [
+  ['Enabled:                    ', String(data.enabled)],
+  ['Verification Method:        ', data.email_verification_method],
+  ['Require Verification:       ', String(data.require_email_verification)],
+  [
     'Auto Sign In After Verify:  ',
     String(data.auto_sign_in_after_verification),
-  );
-  kv(
+  ],
+  [
     'Send Email On Sign Up:      ',
     String(data.send_verification_email_on_sign_up),
-  );
-  kv(
+  ],
+  [
     'Send Email On Sign In:      ',
     String(data.send_verification_email_on_sign_in),
-  );
-  kv('Disable Sign Up:            ', String(data.disable_sign_up));
-  process.stdout.write('\n');
-};
+  ],
+  ['Disable Sign Up:            ', String(data.disable_sign_up)],
+];
 
 const emailPasswordGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
@@ -1061,7 +1045,14 @@ const emailPasswordGet = async (props: AuthBranchProps) => {
     props.projectId,
     branchId,
   );
-  printEmailPasswordConfig(props, data);
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+    return;
+  }
+  printKvBlock(
+    'Email & password auth configuration',
+    printEmailPasswordEntries(data),
+  );
 };
 
 const emailPasswordUpdate = async (
@@ -1090,48 +1081,37 @@ const emailPasswordUpdate = async (
       disable_sign_up: props.disableSignUp,
     },
   );
-  printEmailPasswordConfig(
-    props,
-    data,
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+    return;
+  }
+  printKvBlock(
     'Email & password auth configuration updated',
+    printEmailPasswordEntries(data),
   );
 };
 
 // --- Email provider ---
 
-const printEmailProviderConfig = (
-  props: AuthBranchProps,
-  data: {
-    type: string;
-    host?: string;
-    port?: number;
-    username?: string;
-    sender_email?: string;
-    sender_name?: string;
-  },
-  title?: string,
-) => {
-  if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(data, { fields: EMAIL_PROVIDER_FIELDS });
-    return;
-  }
-  const kv = (key: string, value: string) =>
-    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
-  if (title) {
-    process.stdout.write(`\n${chalk.green(title)}\n`);
-  } else {
-    process.stdout.write('\n');
-  }
-  kv('Type:          ', data.type);
-  if (data.type === 'standard') {
-    kv('Host:          ', data.host ?? '');
-    kv('Port:          ', data.port != null ? String(data.port) : '');
-    kv('Username:      ', data.username ?? '');
-  }
-  kv('Sender Email:  ', data.sender_email ?? '');
-  kv('Sender Name:   ', data.sender_name ?? '');
-  process.stdout.write('\n');
-};
+const printEmailProviderEntries = (data: {
+  type: string;
+  host?: string;
+  port?: number;
+  username?: string;
+  sender_email?: string;
+  sender_name?: string;
+}): [string, string | undefined][] => [
+  ['Type:          ', data.type],
+  ...(data.type === 'standard'
+    ? ([
+        ['Host:          ', data.host],
+        ['Port:          ', data.port != null ? String(data.port) : undefined],
+        ['Username:      ', data.username],
+      ] as [string, string | undefined][])
+    : []),
+  ['Sender Email:  ', data.sender_email],
+  ['Sender Name:   ', data.sender_name],
+];
 
 const emailProviderGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
@@ -1139,7 +1119,14 @@ const emailProviderGet = async (props: AuthBranchProps) => {
     props.projectId,
     branchId,
   );
-  printEmailProviderConfig(props, data as any);
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS as any });
+    return;
+  }
+  printKvBlock(
+    'Email provider configuration',
+    printEmailProviderEntries(data as any),
+  );
 };
 
 const emailProviderUpdate = async (
@@ -1177,10 +1164,13 @@ const emailProviderUpdate = async (
     branchId,
     config,
   );
-  printEmailProviderConfig(
-    props,
-    data as any,
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS as any });
+    return;
+  }
+  printKvBlock(
     'Email provider configuration updated',
+    printEmailProviderEntries(data as any),
   );
 };
 
@@ -1212,9 +1202,7 @@ const emailProviderTest = async (
   if (props.output === 'json' || props.output === 'yaml') {
     writer(props).end(data, { fields: TEST_EMAIL_FIELDS });
   } else if (data.success) {
-    process.stdout.write(
-      `\n${chalk.green('Test email sent successfully')}\n\n`,
-    );
+    printMessage('Test email sent successfully');
   } else {
     process.stdout.write(
       `\n${chalk.green('Test email failed')}\n  ${data.error_message ?? 'Unknown error'}\n\n`,
@@ -1224,32 +1212,15 @@ const emailProviderTest = async (
 
 // --- Organization plugin ---
 
-const printOrganizationConfig = (
-  props: AuthBranchProps,
-  data: {
-    enabled: boolean;
-    organization_limit: number;
-    allow_user_to_create_organization: boolean;
-    creator_role: string;
-  },
-  title?: string,
-) => {
-  if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(data, { fields: ORGANIZATION_FIELDS });
-    return;
-  }
-  const kv = (key: string, value: string) =>
-    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
-  if (title) {
-    process.stdout.write(`\n${chalk.green(title)}\n`);
-  } else {
-    process.stdout.write('\n');
-  }
-  kv('Enabled:          ', String(data.enabled));
-  kv('Org Limit:        ', String(data.organization_limit));
-  kv('Creator Role:     ', data.creator_role);
-  process.stdout.write('\n');
-};
+const printOrganizationEntries = (data: {
+  enabled: boolean;
+  organization_limit: number;
+  creator_role: string;
+}): [string, string][] => [
+  ['Enabled:          ', String(data.enabled)],
+  ['Org Limit:        ', String(data.organization_limit)],
+  ['Creator Role:     ', data.creator_role],
+];
 
 const organizationGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
@@ -1259,12 +1230,18 @@ const organizationGet = async (props: AuthBranchProps) => {
   );
   const org = data.organization;
   if (!org) {
-    process.stdout.write(
-      `\n${chalk.green('No organization plugin config found.')}\n\n`,
-    );
+    if (props.output !== 'table') {
+      writer(props).end({} as any, { fields: ORGANIZATION_FIELDS as any });
+      return;
+    }
+    printMessage('No organization plugin config found.');
     return;
   }
-  printOrganizationConfig(props, org);
+  if (props.output !== 'table') {
+    writer(props).end(org as any, { fields: ORGANIZATION_FIELDS as any });
+    return;
+  }
+  printKvBlock('Organization configuration', printOrganizationEntries(org));
 };
 
 const organizationUpdate = async (
@@ -1284,41 +1261,32 @@ const organizationUpdate = async (
       creator_role: props.creatorRole as 'admin' | 'owner',
     },
   );
-  printOrganizationConfig(props, data, 'Organization configuration updated');
+  if (props.output !== 'table') {
+    writer(props).end(data as any, { fields: ORGANIZATION_FIELDS as any });
+    return;
+  }
+  printKvBlock(
+    'Organization configuration updated',
+    printOrganizationEntries(data),
+  );
 };
 
 // --- Webhook ---
 
-const printWebhookConfig = (
-  props: AuthBranchProps,
-  data: {
-    enabled: boolean;
-    webhook_url?: string;
-    enabled_events?: string[];
-    timeout_seconds?: number;
-  },
-  title?: string,
-) => {
-  if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(data, { fields: WEBHOOK_FIELDS });
-    return;
-  }
-  const kv = (key: string, value: string) =>
-    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
-  if (title) {
-    process.stdout.write(`\n${chalk.green(title)}\n`);
-  } else {
-    process.stdout.write('\n');
-  }
-  kv('Enabled:        ', String(data.enabled));
-  kv('URL:            ', data.webhook_url ?? '');
-  kv('Events:         ', (data.enabled_events ?? []).join(', '));
-  kv(
+const printWebhookEntries = (data: {
+  enabled: boolean;
+  webhook_url?: string;
+  enabled_events?: string[];
+  timeout_seconds?: number;
+}): [string, string][] => [
+  ['Enabled:        ', String(data.enabled)],
+  ['URL:            ', data.webhook_url ?? ''],
+  ['Events:         ', (data.enabled_events ?? []).join(', ')],
+  [
     'Timeout (sec):  ',
     data.timeout_seconds != null ? String(data.timeout_seconds) : '',
-  );
-  process.stdout.write('\n');
-};
+  ],
+];
 
 const webhookGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
@@ -1326,7 +1294,11 @@ const webhookGet = async (props: AuthBranchProps) => {
     props.projectId,
     branchId,
   );
-  printWebhookConfig(props, data);
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: WEBHOOK_FIELDS });
+    return;
+  }
+  printKvBlock('Webhook configuration', printWebhookEntries(data));
 };
 
 const webhookUpdate = async (
@@ -1355,7 +1327,11 @@ const webhookUpdate = async (
       timeout_seconds: props.timeout,
     },
   );
-  printWebhookConfig(props, data, 'Webhook configuration updated');
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: WEBHOOK_FIELDS });
+    return;
+  }
+  printKvBlock('Webhook configuration updated', printWebhookEntries(data));
 };
 
 // --- User ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1241,13 +1241,44 @@ const organizationUpdate = async (
 
 // --- Webhook ---
 
+const printWebhookConfig = (
+  props: AuthBranchProps,
+  data: {
+    enabled: boolean;
+    webhook_url?: string;
+    enabled_events?: string[];
+    timeout_seconds?: number;
+  },
+  title?: string,
+) => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: WEBHOOK_FIELDS });
+    return;
+  }
+  const kv = (key: string, value: string) =>
+    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
+  if (title) {
+    process.stdout.write(`\n${chalk.green(title)}\n`);
+  } else {
+    process.stdout.write('\n');
+  }
+  kv('Enabled:        ', String(data.enabled));
+  kv('URL:            ', data.webhook_url ?? '');
+  kv('Events:         ', (data.enabled_events ?? []).join(', '));
+  kv(
+    'Timeout (sec):  ',
+    data.timeout_seconds != null ? String(data.timeout_seconds) : '',
+  );
+  process.stdout.write('\n');
+};
+
 const webhookGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthWebhookConfig(
     props.projectId,
     branchId,
   );
-  writer(props).end(data, { fields: WEBHOOK_FIELDS });
+  printWebhookConfig(props, data);
 };
 
 const webhookUpdate = async (
@@ -1276,7 +1307,7 @@ const webhookUpdate = async (
       timeout_seconds: props.timeout,
     },
   );
-  writer(props).end(data, { fields: WEBHOOK_FIELDS });
+  printWebhookConfig(props, data, 'Webhook configuration updated');
 };
 
 // --- User ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -4,6 +4,7 @@ import {
   NeonAuthIntegration,
   NeonAuthOauthProviderId,
   NeonAuthOauthProviderType,
+  NeonAuthEmailVerificationMethod,
 } from '@neondatabase/api-client';
 import { isAxiosError } from 'axios';
 import chalk from 'chalk';
@@ -58,6 +59,41 @@ const SUPPORTED_OAUTH_PROVIDERS = [
 ] as const;
 
 const DOMAIN_FIELDS = ['domain'] as const;
+
+const EMAIL_PASSWORD_FIELDS = [
+  'enabled',
+  'email_verification_method',
+  'require_email_verification',
+  'auto_sign_in_after_verification',
+  'send_verification_email_on_sign_up',
+  'send_verification_email_on_sign_in',
+  'disable_sign_up',
+] as const;
+
+const EMAIL_PROVIDER_FIELDS = [
+  'type',
+  'host',
+  'port',
+  'username',
+  'sender_email',
+  'sender_name',
+] as const;
+
+const ORGANIZATION_FIELDS = [
+  'enabled',
+  'organization_limit',
+  'allow_user_to_create_organization',
+  'creator_role',
+] as const;
+
+const WEBHOOK_FIELDS = [
+  'enabled',
+  'webhook_url',
+  'enabled_events',
+  'timeout_seconds',
+] as const;
+
+const TEST_EMAIL_FIELDS = ['success', 'error_message'] as const;
 
 export const command = 'neon-auth';
 export const describe = 'Manage Neon Auth';
@@ -266,6 +302,244 @@ export const builder = (argv: yargs.Argv) => {
                   await allowLocalhostDisable(args as any);
                 },
               ),
+        );
+    })
+    .command(
+      'email-password',
+      'Manage email and password authentication settings',
+      (yargs) => {
+        return yargs
+          .command(
+            'get',
+            'Get email and password config',
+            (yargs) => yargs,
+            async (args) => {
+              await emailPasswordGet(args as any);
+            },
+          )
+          .command(
+            'update',
+            'Update email and password config',
+            (yargs) =>
+              yargs.options({
+                enabled: {
+                  describe: 'Enable email and password authentication',
+                  type: 'boolean',
+                },
+                'email-verification-method': {
+                  describe: 'Email verification method',
+                  type: 'string',
+                  choices: Object.values(NeonAuthEmailVerificationMethod),
+                },
+                'require-email-verification': {
+                  describe:
+                    'Require email verification before users can sign in',
+                  type: 'boolean',
+                },
+                'auto-sign-in-after-verification': {
+                  describe: 'Auto sign in users after verifying their email',
+                  type: 'boolean',
+                },
+                'send-verification-email-on-sign-up': {
+                  describe: 'Send verification email on sign up',
+                  type: 'boolean',
+                },
+                'send-verification-email-on-sign-in': {
+                  describe: 'Send verification email on sign in',
+                  type: 'boolean',
+                },
+                'disable-sign-up': {
+                  describe: 'Disable new user sign ups',
+                  type: 'boolean',
+                },
+              }),
+            async (args) => {
+              await emailPasswordUpdate(args as any);
+            },
+          );
+      },
+    )
+    .command(
+      'email-provider',
+      'Manage email provider configuration',
+      (yargs) => {
+        return yargs
+          .command(
+            'get',
+            'Get email provider config',
+            (yargs) => yargs,
+            async (args) => {
+              await emailProviderGet(args as any);
+            },
+          )
+          .command(
+            'update',
+            'Update email provider config',
+            (yargs) =>
+              yargs.options({
+                type: {
+                  describe: 'Email provider type',
+                  type: 'string',
+                  choices: ['standard', 'shared'] as const,
+                  demandOption: true,
+                },
+                host: {
+                  describe: 'SMTP host (required for standard)',
+                  type: 'string',
+                },
+                port: {
+                  describe: 'SMTP port (required for standard)',
+                  type: 'number',
+                },
+                username: {
+                  describe: 'SMTP username (required for standard)',
+                  type: 'string',
+                },
+                password: {
+                  describe: 'SMTP password (required for standard)',
+                  type: 'string',
+                },
+                'sender-email': {
+                  describe: 'Sender email address',
+                  type: 'string',
+                },
+                'sender-name': {
+                  describe: 'Sender display name',
+                  type: 'string',
+                },
+              }),
+            async (args) => {
+              await emailProviderUpdate(args as any);
+            },
+          )
+          .command(
+            'test',
+            'Send a test email',
+            (yargs) =>
+              yargs.options({
+                'recipient-email': {
+                  describe: 'Email address to send test email to',
+                  type: 'string',
+                  demandOption: true,
+                },
+                host: {
+                  describe: 'SMTP host',
+                  type: 'string',
+                  demandOption: true,
+                },
+                port: {
+                  describe: 'SMTP port',
+                  type: 'number',
+                  demandOption: true,
+                },
+                username: {
+                  describe: 'SMTP username',
+                  type: 'string',
+                  demandOption: true,
+                },
+                password: {
+                  describe: 'SMTP password',
+                  type: 'string',
+                  demandOption: true,
+                },
+                'sender-email': {
+                  describe: 'Sender email address',
+                  type: 'string',
+                  demandOption: true,
+                },
+                'sender-name': {
+                  describe: 'Sender display name',
+                  type: 'string',
+                  demandOption: true,
+                },
+              }),
+            async (args) => {
+              await emailProviderTest(args as any);
+            },
+          );
+      },
+    )
+    .command('organization', 'Manage organization plugin settings', (yargs) => {
+      return yargs
+        .command(
+          'get',
+          'Get organization plugin config',
+          (yargs) => yargs,
+          async (args) => {
+            await organizationGet(args as any);
+          },
+        )
+        .command(
+          'update',
+          'Update organization plugin config',
+          (yargs) =>
+            yargs.options({
+              enabled: {
+                describe: 'Enable the organization plugin',
+                type: 'boolean',
+              },
+              'organization-limit': {
+                describe: 'Maximum number of organizations a user can create',
+                type: 'number',
+              },
+              'allow-user-to-create-organization': {
+                describe: 'Allow users to create organizations',
+                type: 'boolean',
+              },
+              'creator-role': {
+                describe: 'Role assigned to organization creator',
+                type: 'string',
+                choices: ['admin', 'owner'] as const,
+              },
+            }),
+          async (args) => {
+            await organizationUpdate(args as any);
+          },
+        );
+    })
+    .command('webhook', 'Manage webhook configuration', (yargs) => {
+      return yargs
+        .command(
+          'get',
+          'Get webhook config',
+          (yargs) => yargs,
+          async (args) => {
+            await webhookGet(args as any);
+          },
+        )
+        .command(
+          'update',
+          'Update webhook config',
+          (yargs) =>
+            yargs.options({
+              enabled: {
+                describe: 'Enable webhooks',
+                type: 'boolean',
+                demandOption: true,
+              },
+              'webhook-url': {
+                describe: 'Webhook endpoint URL',
+                type: 'string',
+              },
+              'enabled-events': {
+                describe: 'Events to enable',
+                type: 'string',
+                choices: [
+                  'user.before_create',
+                  'user.created',
+                  'send.otp',
+                  'send.magic_link',
+                ] as const,
+                array: true,
+              },
+              'timeout-seconds': {
+                describe: 'Webhook timeout in seconds (1-10)',
+                type: 'number',
+              },
+            }),
+          async (args) => {
+            await webhookUpdate(args as any);
+          },
         );
     })
     .command('user', 'Manage Neon Auth users', (yargs) => {
@@ -721,6 +995,198 @@ const allowLocalhostDisable = async (props: AuthBranchProps) => {
     },
   );
   printMessage('Localhost connections restricted');
+};
+
+// --- Email and password ---
+
+const emailPasswordGet = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthEmailAndPasswordConfig(
+    props.projectId,
+    branchId,
+  );
+  writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+};
+
+const emailPasswordUpdate = async (
+  props: AuthBranchProps & {
+    enabled?: boolean;
+    emailVerificationMethod?: string;
+    requireEmailVerification?: boolean;
+    autoSignInAfterVerification?: boolean;
+    sendVerificationEmailOnSignUp?: boolean;
+    sendVerificationEmailOnSignIn?: boolean;
+    disableSignUp?: boolean;
+  },
+) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.updateNeonAuthEmailAndPasswordConfig(
+    props.projectId,
+    branchId,
+    {
+      enabled: props.enabled,
+      email_verification_method:
+        props.emailVerificationMethod as NeonAuthEmailVerificationMethod,
+      require_email_verification: props.requireEmailVerification,
+      auto_sign_in_after_verification: props.autoSignInAfterVerification,
+      send_verification_email_on_sign_up: props.sendVerificationEmailOnSignUp,
+      send_verification_email_on_sign_in: props.sendVerificationEmailOnSignIn,
+      disable_sign_up: props.disableSignUp,
+    },
+  );
+  writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+};
+
+// --- Email provider ---
+
+const emailProviderGet = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthEmailProvider(
+    props.projectId,
+    branchId,
+  );
+  writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS });
+};
+
+const emailProviderUpdate = async (
+  props: AuthBranchProps & {
+    type: string;
+    host?: string;
+    port?: number;
+    username?: string;
+    password?: string;
+    senderEmail?: string;
+    senderName?: string;
+  },
+) => {
+  const branchId = await resolveBranch(props);
+  let config: any;
+  if (props.type === 'standard') {
+    config = {
+      type: 'standard',
+      host: props.host,
+      port: props.port,
+      username: props.username,
+      password: props.password,
+      sender_email: props.senderEmail,
+      sender_name: props.senderName,
+    };
+  } else {
+    config = {
+      type: 'shared',
+      sender_email: props.senderEmail,
+      sender_name: props.senderName,
+    };
+  }
+  const { data } = await props.apiClient.updateNeonAuthEmailProvider(
+    props.projectId,
+    branchId,
+    config,
+  );
+  writer(props).end(data as any, { fields: EMAIL_PROVIDER_FIELDS });
+};
+
+const emailProviderTest = async (
+  props: AuthBranchProps & {
+    recipientEmail: string;
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+    senderEmail: string;
+    senderName: string;
+  },
+) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.sendNeonAuthTestEmail(
+    props.projectId,
+    branchId,
+    {
+      recipient_email: props.recipientEmail,
+      host: props.host,
+      port: props.port,
+      username: props.username,
+      password: props.password,
+      sender_email: props.senderEmail,
+      sender_name: props.senderName,
+    },
+  );
+  writer(props).end(data, { fields: TEST_EMAIL_FIELDS });
+};
+
+// --- Organization plugin ---
+
+const organizationGet = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthPluginConfigs(
+    props.projectId,
+    branchId,
+  );
+  writer(props).end(data.organization ?? ({} as any), {
+    fields: ORGANIZATION_FIELDS,
+  });
+};
+
+const organizationUpdate = async (
+  props: AuthBranchProps & {
+    enabled?: boolean;
+    organizationLimit?: number;
+    allowUserToCreateOrganization?: boolean;
+    creatorRole?: string;
+  },
+) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.updateNeonAuthOrganizationPlugin(
+    props.projectId,
+    branchId,
+    {
+      enabled: props.enabled,
+      organization_limit: props.organizationLimit,
+      allow_user_to_create_organization: props.allowUserToCreateOrganization,
+      creator_role: props.creatorRole as 'admin' | 'owner',
+    },
+  );
+  writer(props).end(data, { fields: ORGANIZATION_FIELDS });
+};
+
+// --- Webhook ---
+
+const webhookGet = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthWebhookConfig(
+    props.projectId,
+    branchId,
+  );
+  writer(props).end(data, { fields: WEBHOOK_FIELDS });
+};
+
+const webhookUpdate = async (
+  props: AuthBranchProps & {
+    enabled: boolean;
+    webhookUrl?: string;
+    enabledEvents?: string[];
+    timeoutSeconds?: number;
+  },
+) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.updateNeonAuthWebhookConfig(
+    props.projectId,
+    branchId,
+    {
+      enabled: props.enabled,
+      webhook_url: props.webhookUrl,
+      enabled_events: props.enabledEvents as
+        | (
+            | 'user.before_create'
+            | 'user.created'
+            | 'send.otp'
+            | 'send.magic_link'
+          )[]
+        | undefined,
+      timeout_seconds: props.timeoutSeconds,
+    },
+  );
+  writer(props).end(data, { fields: WEBHOOK_FIELDS });
 };
 
 // --- User ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -491,7 +491,7 @@ export const builder = (argv: yargs.Argv) => {
                       describe: 'Enable the organization plugin',
                       type: 'boolean',
                     },
-                    'organization-limit': {
+                    limit: {
                       describe:
                         'Maximum number of organizations a user can create',
                       type: 'number',
@@ -529,7 +529,7 @@ export const builder = (argv: yargs.Argv) => {
                     type: 'boolean',
                     demandOption: true,
                   },
-                  'webhook-url': {
+                  url: {
                     describe: 'Webhook endpoint URL',
                     type: 'string',
                   },
@@ -1247,7 +1247,7 @@ const organizationGet = async (props: AuthBranchProps) => {
 const organizationUpdate = async (
   props: AuthBranchProps & {
     enabled?: boolean;
-    organizationLimit?: number;
+    limit?: number;
     creatorRole?: string;
   },
 ) => {
@@ -1257,7 +1257,7 @@ const organizationUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      organization_limit: props.organizationLimit,
+      organization_limit: props.limit,
       creator_role: props.creatorRole as 'admin' | 'owner',
     },
   );
@@ -1304,7 +1304,7 @@ const webhookGet = async (props: AuthBranchProps) => {
 const webhookUpdate = async (
   props: AuthBranchProps & {
     enabled: boolean;
-    webhookUrl?: string;
+    url?: string;
     enabledEvents?: string[];
     timeout?: number;
   },
@@ -1315,7 +1315,7 @@ const webhookUpdate = async (
     branchId,
     {
       enabled: props.enabled,
-      webhook_url: props.webhookUrl,
+      webhook_url: props.url,
       enabled_events: props.enabledEvents as
         | (
             | 'user.before_create'

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -303,239 +303,248 @@ export const builder = (argv: yargs.Argv) => {
               ),
         );
     })
-    .command(
-      'email-password',
-      'Manage email and password authentication settings',
-      (yargs) => {
-        return yargs
-          .command(
-            'get',
-            'Get email and password config',
-            (yargs) => yargs,
-            async (args) => {
-              await emailPasswordGet(args as any);
-            },
-          )
-          .command(
-            'update',
-            'Update email and password config',
-            (yargs) =>
-              yargs.options({
-                enabled: {
-                  describe: 'Enable email and password authentication',
-                  type: 'boolean',
-                },
-                'email-verification-method': {
-                  describe: 'Email verification method',
-                  type: 'string',
-                  choices: Object.values(NeonAuthEmailVerificationMethod),
-                },
-                'require-email-verification': {
-                  describe:
-                    'Require email verification before users can sign in',
-                  type: 'boolean',
-                },
-                'auto-sign-in-after-verification': {
-                  describe: 'Auto sign in users after verifying their email',
-                  type: 'boolean',
-                },
-                'send-verification-email-on-sign-up': {
-                  describe: 'Send verification email on sign up',
-                  type: 'boolean',
-                },
-                'send-verification-email-on-sign-in': {
-                  describe: 'Send verification email on sign in',
-                  type: 'boolean',
-                },
-                'disable-sign-up': {
-                  describe: 'Disable new user sign ups',
-                  type: 'boolean',
-                },
-              }),
-            async (args) => {
-              await emailPasswordUpdate(args as any);
-            },
-          );
-      },
-    )
-    .command(
-      'email-provider',
-      'Manage email provider configuration',
-      (yargs) => {
-        return yargs
-          .command(
-            'get',
-            'Get email provider config',
-            (yargs) => yargs,
-            async (args) => {
-              await emailProviderGet(args as any);
-            },
-          )
-          .command(
-            'update',
-            'Update email provider config',
-            (yargs) =>
-              yargs.options({
-                type: {
-                  describe: 'Email provider type',
-                  type: 'string',
-                  choices: ['standard', 'shared'] as const,
-                  demandOption: true,
-                },
-                host: {
-                  describe: 'SMTP host (required for standard)',
-                  type: 'string',
-                },
-                port: {
-                  describe: 'SMTP port (required for standard)',
-                  type: 'number',
-                },
-                username: {
-                  describe: 'SMTP username (required for standard)',
-                  type: 'string',
-                },
-                password: {
-                  describe: 'SMTP password (required for standard)',
-                  type: 'string',
-                },
-                'sender-email': {
-                  describe: 'Sender email address',
-                  type: 'string',
-                },
-                'sender-name': {
-                  describe: 'Sender display name',
-                  type: 'string',
-                },
-              }),
-            async (args) => {
-              await emailProviderUpdate(args as any);
-            },
-          )
-          .command(
-            'test',
-            'Send a test email',
-            (yargs) =>
-              yargs.options({
-                'recipient-email': {
-                  describe: 'Email address to send test email to',
-                  type: 'string',
-                  demandOption: true,
-                },
-                host: {
-                  describe: 'SMTP host',
-                  type: 'string',
-                  demandOption: true,
-                },
-                port: {
-                  describe: 'SMTP port',
-                  type: 'number',
-                  demandOption: true,
-                },
-                username: {
-                  describe: 'SMTP username',
-                  type: 'string',
-                  demandOption: true,
-                },
-                password: {
-                  describe: 'SMTP password',
-                  type: 'string',
-                  demandOption: true,
-                },
-                'sender-email': {
-                  describe: 'Sender email address',
-                  type: 'string',
-                  demandOption: true,
-                },
-                'sender-name': {
-                  describe: 'Sender display name',
-                  type: 'string',
-                  demandOption: true,
-                },
-              }),
-            async (args) => {
-              await emailProviderTest(args as any);
-            },
-          );
-      },
-    )
-    .command('organization', 'Manage organization plugin settings', (yargs) => {
+    .command('config', 'Manage Neon Auth configuration', (yargs) => {
       return yargs
         .command(
-          'get',
-          'Get organization plugin config',
-          (yargs) => yargs,
-          async (args) => {
-            await organizationGet(args as any);
+          'email-password',
+          'Manage email and password authentication settings',
+          (yargs) => {
+            return yargs
+              .command(
+                'get',
+                'Get email and password config',
+                (yargs) => yargs,
+                async (args) => {
+                  await emailPasswordGet(args as any);
+                },
+              )
+              .command(
+                'update',
+                'Update email and password config',
+                (yargs) =>
+                  yargs.options({
+                    enabled: {
+                      describe: 'Enable email and password authentication',
+                      type: 'boolean',
+                    },
+                    'email-verification-method': {
+                      describe: 'Email verification method',
+                      type: 'string',
+                      choices: Object.values(NeonAuthEmailVerificationMethod),
+                    },
+                    'require-email-verification': {
+                      describe:
+                        'Require email verification before users can sign in',
+                      type: 'boolean',
+                    },
+                    'auto-sign-in-after-verification': {
+                      describe:
+                        'Auto sign in users after verifying their email',
+                      type: 'boolean',
+                    },
+                    'send-verification-email-on-sign-up': {
+                      describe: 'Send verification email on sign up',
+                      type: 'boolean',
+                    },
+                    'send-verification-email-on-sign-in': {
+                      describe: 'Send verification email on sign in',
+                      type: 'boolean',
+                    },
+                    'disable-sign-up': {
+                      describe: 'Disable new user sign ups',
+                      type: 'boolean',
+                    },
+                  }),
+                async (args) => {
+                  await emailPasswordUpdate(args as any);
+                },
+              );
           },
         )
         .command(
-          'update',
-          'Update organization plugin config',
-          (yargs) =>
-            yargs.options({
-              enabled: {
-                describe: 'Enable the organization plugin',
-                type: 'boolean',
-              },
-              limit: {
-                describe: 'Maximum number of organizations a user can create',
-                type: 'number',
-              },
-              'creator-role': {
-                describe: 'Role assigned to organization creator',
-                type: 'string',
-                choices: ['admin', 'owner'] as const,
-              },
-            }),
-          async (args) => {
-            await organizationUpdate(args as any);
-          },
-        );
-    })
-    .command('webhook', 'Manage webhook configuration', (yargs) => {
-      return yargs
-        .command(
-          'get',
-          'Get webhook config',
-          (yargs) => yargs,
-          async (args) => {
-            await webhookGet(args as any);
+          'email-provider',
+          'Manage email provider configuration',
+          (yargs) => {
+            return yargs
+              .command(
+                'get',
+                'Get email provider config',
+                (yargs) => yargs,
+                async (args) => {
+                  await emailProviderGet(args as any);
+                },
+              )
+              .command(
+                'update',
+                'Update email provider config',
+                (yargs) =>
+                  yargs.options({
+                    type: {
+                      describe: 'Email provider type',
+                      type: 'string',
+                      choices: ['standard', 'shared'] as const,
+                      demandOption: true,
+                    },
+                    host: {
+                      describe: 'SMTP host (required for standard)',
+                      type: 'string',
+                    },
+                    port: {
+                      describe: 'SMTP port (required for standard)',
+                      type: 'number',
+                    },
+                    username: {
+                      describe: 'SMTP username (required for standard)',
+                      type: 'string',
+                    },
+                    password: {
+                      describe: 'SMTP password (required for standard)',
+                      type: 'string',
+                    },
+                    'sender-email': {
+                      describe: 'Sender email address',
+                      type: 'string',
+                    },
+                    'sender-name': {
+                      describe: 'Sender display name',
+                      type: 'string',
+                    },
+                  }),
+                async (args) => {
+                  await emailProviderUpdate(args as any);
+                },
+              )
+              .command(
+                'test',
+                'Send a test email',
+                (yargs) =>
+                  yargs.options({
+                    'recipient-email': {
+                      describe: 'Email address to send test email to',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                    host: {
+                      describe: 'SMTP host',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                    port: {
+                      describe: 'SMTP port',
+                      type: 'number',
+                      demandOption: true,
+                    },
+                    username: {
+                      describe: 'SMTP username',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                    password: {
+                      describe: 'SMTP password',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                    'sender-email': {
+                      describe: 'Sender email address',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                    'sender-name': {
+                      describe: 'Sender display name',
+                      type: 'string',
+                      demandOption: true,
+                    },
+                  }),
+                async (args) => {
+                  await emailProviderTest(args as any);
+                },
+              );
           },
         )
         .command(
-          'update',
-          'Update webhook config',
-          (yargs) =>
-            yargs.options({
-              enabled: {
-                describe: 'Enable webhooks',
-                type: 'boolean',
-                demandOption: true,
-              },
-              url: {
-                describe: 'Webhook endpoint URL',
-                type: 'string',
-              },
-              'enabled-events': {
-                describe: 'Events to enable',
-                type: 'string',
-                choices: [
-                  'user.before_create',
-                  'user.created',
-                  'send.otp',
-                  'send.magic_link',
-                ] as const,
-                array: true,
-              },
-              timeout: {
-                describe: 'Webhook timeout in seconds (1-10)',
-                type: 'number',
-              },
-            }),
-          async (args) => {
-            await webhookUpdate(args as any);
+          'organization',
+          'Manage organization plugin settings',
+          (yargs) => {
+            return yargs
+              .command(
+                'get',
+                'Get organization plugin config',
+                (yargs) => yargs,
+                async (args) => {
+                  await organizationGet(args as any);
+                },
+              )
+              .command(
+                'update',
+                'Update organization plugin config',
+                (yargs) =>
+                  yargs.options({
+                    enabled: {
+                      describe: 'Enable the organization plugin',
+                      type: 'boolean',
+                    },
+                    limit: {
+                      describe:
+                        'Maximum number of organizations a user can create',
+                      type: 'number',
+                    },
+                    'creator-role': {
+                      describe: 'Role assigned to organization creator',
+                      type: 'string',
+                      choices: ['admin', 'owner'] as const,
+                    },
+                  }),
+                async (args) => {
+                  await organizationUpdate(args as any);
+                },
+              );
           },
-        );
+        )
+        .command('webhook', 'Manage webhook configuration', (yargs) => {
+          return yargs
+            .command(
+              'get',
+              'Get webhook config',
+              (yargs) => yargs,
+              async (args) => {
+                await webhookGet(args as any);
+              },
+            )
+            .command(
+              'update',
+              'Update webhook config',
+              (yargs) =>
+                yargs.options({
+                  enabled: {
+                    describe: 'Enable webhooks',
+                    type: 'boolean',
+                    demandOption: true,
+                  },
+                  url: {
+                    describe: 'Webhook endpoint URL',
+                    type: 'string',
+                  },
+                  'enabled-events': {
+                    describe: 'Events to enable',
+                    type: 'string',
+                    choices: [
+                      'user.before_create',
+                      'user.created',
+                      'send.otp',
+                      'send.magic_link',
+                    ] as const,
+                    array: true,
+                  },
+                  timeout: {
+                    describe: 'Webhook timeout in seconds (1-10)',
+                    type: 'number',
+                  },
+                }),
+              async (args) => {
+                await webhookUpdate(args as any);
+              },
+            );
+        });
     })
     .command('user', 'Manage Neon Auth users', (yargs) => {
       return yargs

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -1012,13 +1012,53 @@ const allowLocalhostDisable = async (props: AuthBranchProps) => {
 
 // --- Email and password ---
 
+const printEmailPasswordConfig = (
+  props: AuthBranchProps,
+  data: {
+    enabled: boolean;
+    email_verification_method: string;
+    require_email_verification: boolean;
+    auto_sign_in_after_verification: boolean;
+    send_verification_email_on_sign_up: boolean;
+    send_verification_email_on_sign_in: boolean;
+    disable_sign_up: boolean;
+  },
+  title?: string,
+) => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+    return;
+  }
+  const kv = (key: string, value: string) =>
+    process.stdout.write(`  ${chalk.green(key)}  ${value}\n`);
+  if (title) process.stdout.write(`\n${chalk.green(title)}\n`);
+  process.stdout.write('\n');
+  kv('Enabled:                    ', String(data.enabled));
+  kv('Verification Method:        ', data.email_verification_method);
+  kv('Require Verification:       ', String(data.require_email_verification));
+  kv(
+    'Auto Sign In After Verify:  ',
+    String(data.auto_sign_in_after_verification),
+  );
+  kv(
+    'Send Email On Sign Up:      ',
+    String(data.send_verification_email_on_sign_up),
+  );
+  kv(
+    'Send Email On Sign In:      ',
+    String(data.send_verification_email_on_sign_in),
+  );
+  kv('Disable Sign Up:            ', String(data.disable_sign_up));
+  process.stdout.write('\n');
+};
+
 const emailPasswordGet = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthEmailAndPasswordConfig(
     props.projectId,
     branchId,
   );
-  writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+  printEmailPasswordConfig(props, data);
 };
 
 const emailPasswordUpdate = async (
@@ -1047,7 +1087,7 @@ const emailPasswordUpdate = async (
       disable_sign_up: props.disableSignUp,
     },
   );
-  writer(props).end(data, { fields: EMAIL_PASSWORD_FIELDS });
+  printEmailPasswordConfig(props, data, 'Email password settings updated');
 };
 
 // --- Email provider ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -555,63 +555,34 @@ export const builder = (argv: yargs.Argv) => {
             );
         });
     })
-    .command(
-      'plugins',
-      'View and update Neon Auth plugin configurations',
-      (yargs) => {
-        return yargs
-          .usage('$0 neon-auth plugins <sub-command> [options]')
-          .command(
-            'list',
-            'List all plugin configurations',
-            (yargs) => yargs,
-            async (args) => {
-              await pluginsList(args as any);
-            },
-          )
-          .command(
-            'get <plugin-name>',
-            'Get a specific plugin configuration',
-            (yargs) =>
-              yargs
-                .usage('$0 neon-auth plugins get <plugin-name> [options]')
-                .positional('plugin-name', {
-                  describe:
-                    'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
-                  type: 'string',
-                  demandOption: true,
-                }),
-            async (args) => {
-              await pluginsGet(args as any);
-            },
-          )
-          .command(
-            'update <plugin-name>',
-            'Update a plugin configuration using JSON',
-            (yargs) =>
-              yargs
-                .usage(
-                  '$0 neon-auth plugins update <plugin-name> --json \'{"key": "value"}\' [options]',
-                )
-                .positional('plugin-name', {
-                  describe:
-                    'Plugin name (e.g. organization, email_and_password, email_provider, allow_localhost, webhook)',
-                  type: 'string',
-                  demandOption: true,
-                })
-                .options({
-                  json: {
-                    describe: 'JSON configuration to apply',
-                    type: 'string',
-                    demandOption: true,
-                  },
-                }),
-            async (args) => {
-              await pluginsUpdate(args as any);
-            },
-          );
-      },
-    )
+    .command('plugins', 'View Neon Auth plugin configurations', (yargs) => {
+      return yargs
+        .usage('$0 neon-auth plugins <sub-command> [options]')
+        .command(
+          'list',
+          'List all plugin configurations',
+          (yargs) => yargs,
+          async (args) => {
+            await pluginsList(args as any);
+          },
+        )
+        .command(
+          'get <plugin-name>',
+          'Get a specific plugin configuration',
+          (yargs) =>
+            yargs
+              .usage('$0 neon-auth plugins get <plugin-name> [options]')
+              .positional('plugin-name', {
+                describe:
+                  'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
+                type: 'string',
+                demandOption: true,
+              }),
+          async (args) => {
+            await pluginsGet(args as any);
+          },
+        );
+    })
     .command('user', 'Manage Neon Auth users', (yargs) => {
       return yargs
         .usage('$0 neon-auth user <sub-command> [options]')
@@ -1418,42 +1389,6 @@ const formatValue = (v: unknown): string => {
   return JSON.stringify(v);
 };
 
-const PLUGIN_UPDATE_METHODS: Record<
-  string,
-  (props: AuthBranchProps, branchId: string, data: any) => Promise<any>
-> = {
-  organization: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthOrganizationPlugin(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  email_and_password: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthEmailAndPasswordConfig(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  email_provider: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthEmailProvider(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  allow_localhost: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthAllowLocalhost(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  webhook: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthWebhookConfig(
-      props.projectId,
-      branchId,
-      data,
-    ),
-};
-
 const pluginsList = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthPluginConfigs(
@@ -1522,46 +1457,6 @@ const pluginsGet = async (props: AuthBranchProps & { pluginName: string }) => {
   } else {
     printKvBlock(pluginTitle(props.pluginName), [
       ['Value:'.padEnd(18), String(plugin)],
-    ]);
-  }
-};
-
-const pluginsUpdate = async (
-  props: AuthBranchProps & { pluginName: string; json: string },
-) => {
-  let parsed: any;
-  try {
-    parsed = JSON.parse(props.json);
-  } catch {
-    throw new Error('Invalid JSON. Please provide valid JSON with --json.');
-  }
-
-  const updateMethod = PLUGIN_UPDATE_METHODS[props.pluginName];
-  if (!updateMethod) {
-    const available = Object.keys(PLUGIN_UPDATE_METHODS).join(', ');
-    throw new Error(
-      `Unknown plugin "${props.pluginName}". Updatable plugins: ${available}`,
-    );
-  }
-
-  const branchId = await resolveBranch(props);
-  const { data } = await updateMethod(props, branchId, parsed);
-
-  if (props.output === 'json' || props.output === 'yaml') {
-    const fields =
-      typeof data === 'object' && !Array.isArray(data) ? Object.keys(data) : [];
-    writer(props).end(data, { fields: fields as any });
-    return;
-  }
-  if (typeof data === 'object' && !Array.isArray(data) && data != null) {
-    const entries: [string, string][] = Object.entries(data).map(([k, v]) => [
-      `${k}:`.padEnd(18),
-      formatValue(v),
-    ]);
-    printKvBlock(`${pluginTitle(props.pluginName)} updated`, entries);
-  } else {
-    printKvBlock(`${pluginTitle(props.pluginName)} updated`, [
-      ['Value:'.padEnd(18), String(data)],
     ]);
   }
 };


### PR DESCRIPTION
## Summary
- Adds configuration management subcommands under `neon-auth config`:
  - `email-password get/update` — email+password auth settings (verification method, sign-up controls)
  - `email-provider get/update/test` — SMTP/email provider configuration (standard or shared)
  - `organization get/update` — organization plugin settings (enable/disable, limits, creator role)
  - `webhook get/update` — webhook configuration (URL, events, timeout)
- Config subcommands grouped under `neon-auth config` namespace
- Warns when `--sender-email`/`--sender-name` are passed with `--type shared` on email provider update (API silently ignores these values)
- Stops sending ignored sender fields in the request body for shared type

## Details
- Styled key-value output consistent with other neon-auth commands
- SMTP validation: `--host`, `--port`, `--username`, `--password` required for standard email provider
- `email-provider test` sends a test email via SMTP credentials
- Stacked on #459

## Test plan
- [x] Each configuration subcommand's get/update operations work correctly
- [x] `neonctl neon-auth config email-provider test` sends test email
- [x] Shared email provider warning displays when sender fields are passed
- [x] Unit tests pass (28 tests)

This pull request was AI-assisted by Isaac.