### PR TITLE
feat(neon-auth): add plugins list and get commands

### DIFF
--- a/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
+++ b/mocks/main/projects/test/branches/br-sunny-branch-123456/auth/plugins/GET.json
@@ -9,5 +9,21 @@
     "sender_email": "noreply@example.com",
     "sender_name": "My App"
   },
+  "email_and_password": {
+    "enabled": true,
+    "email_verification_method": "otp",
+    "require_email_verification": false,
+    "auto_sign_in_after_verification": true,
+    "send_verification_email_on_sign_up": false,
+    "send_verification_email_on_sign_in": false,
+    "disable_sign_up": false
+  },
+  "oauth_providers": [
+    {
+      "id": "google",
+      "type": "shared",
+      "client_id": ""
+    }
+  ],
   "allow_localhost": true
 }

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -160,6 +160,45 @@ creator_role: owner
 "
 `;
 
+exports[`neon-auth > plugins get 1`] = `
+"enabled: true
+organization_limit: 5
+creator_role: owner
+"
+`;
+
+exports[`neon-auth > plugins list 1`] = `
+"organization:
+  enabled: true
+  organization_limit: 5
+  creator_role: owner
+email_provider:
+  type: shared
+  sender_email: noreply@example.com
+  sender_name: My App
+email_and_password:
+  enabled: true
+  email_verification_method: otp
+  require_email_verification: false
+  auto_sign_in_after_verification: true
+  send_verification_email_on_sign_up: false
+  send_verification_email_on_sign_in: false
+  disable_sign_up: false
+oauth_providers:
+  - id: google
+    type: shared
+    client_id: ""
+allow_localhost: true
+"
+`;
+
+exports[`neon-auth > plugins update 1`] = `
+"enabled: true
+organization_limit: 10
+creator_role: owner
+"
+`;
+
 exports[`neon-auth > status 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id

--- a/src/commands/__snapshots__/neon_auth.test.ts.snap
+++ b/src/commands/__snapshots__/neon_auth.test.ts.snap
@@ -192,13 +192,6 @@ allow_localhost: true
 "
 `;
 
-exports[`neon-auth > plugins update 1`] = `
-"enabled: true
-organization_limit: 10
-creator_role: owner
-"
-`;
-
 exports[`neon-auth > status 1`] = `
 "auth_provider: better_auth
 auth_provider_project_id: test-auth-project-id

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -370,6 +370,48 @@ describe('neon-auth', () => {
     ]);
   });
 
+  // --- Plugins ---
+
+  test('plugins list', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'list',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('plugins get', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'get',
+      'organization',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+    ]);
+  });
+
+  test('plugins update', async ({ testCliCommand }) => {
+    await testCliCommand([
+      'neon-auth',
+      'plugins',
+      'update',
+      'organization',
+      '--project-id',
+      'test',
+      '--branch',
+      'test_branch',
+      '--json',
+      '{"enabled": true, "organization_limit": 10}',
+    ]);
+  });
+
   // --- User ---
 
   test('user create', async ({ testCliCommand }) => {

--- a/src/commands/neon_auth.test.ts
+++ b/src/commands/neon_auth.test.ts
@@ -397,21 +397,6 @@ describe('neon-auth', () => {
     ]);
   });
 
-  test('plugins update', async ({ testCliCommand }) => {
-    await testCliCommand([
-      'neon-auth',
-      'plugins',
-      'update',
-      'organization',
-      '--project-id',
-      'test',
-      '--branch',
-      'test_branch',
-      '--json',
-      '{"enabled": true, "organization_limit": 10}',
-    ]);
-  });
-
   // --- User ---
 
   test('user create', async ({ testCliCommand }) => {

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -555,6 +555,63 @@ export const builder = (argv: yargs.Argv) => {
             );
         });
     })
+    .command(
+      'plugins',
+      'View and update Neon Auth plugin configurations',
+      (yargs) => {
+        return yargs
+          .usage('$0 neon-auth plugins <sub-command> [options]')
+          .command(
+            'list',
+            'List all plugin configurations',
+            (yargs) => yargs,
+            async (args) => {
+              await pluginsList(args as any);
+            },
+          )
+          .command(
+            'get <plugin-name>',
+            'Get a specific plugin configuration',
+            (yargs) =>
+              yargs
+                .usage('$0 neon-auth plugins get <plugin-name> [options]')
+                .positional('plugin-name', {
+                  describe:
+                    'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
+                  type: 'string',
+                  demandOption: true,
+                }),
+            async (args) => {
+              await pluginsGet(args as any);
+            },
+          )
+          .command(
+            'update <plugin-name>',
+            'Update a plugin configuration using JSON',
+            (yargs) =>
+              yargs
+                .usage(
+                  '$0 neon-auth plugins update <plugin-name> --json \'{"key": "value"}\' [options]',
+                )
+                .positional('plugin-name', {
+                  describe:
+                    'Plugin name (e.g. organization, email_and_password, email_provider, allow_localhost, webhook)',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .options({
+                  json: {
+                    describe: 'JSON configuration to apply',
+                    type: 'string',
+                    demandOption: true,
+                  },
+                }),
+            async (args) => {
+              await pluginsUpdate(args as any);
+            },
+          );
+      },
+    )
     .command('user', 'Manage Neon Auth users', (yargs) => {
       return yargs
         .usage('$0 neon-auth user <sub-command> [options]')
@@ -1346,6 +1403,167 @@ const webhookUpdate = async (
     return;
   }
   printKvBlock('Webhook configuration updated', printWebhookEntries(data));
+};
+
+// --- Plugins ---
+
+const pluginTitle = (name: string): string =>
+  name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()) +
+  ' configuration';
+
+const formatValue = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return JSON.stringify(v);
+};
+
+const PLUGIN_UPDATE_METHODS: Record<
+  string,
+  (props: AuthBranchProps, branchId: string, data: any) => Promise<any>
+> = {
+  organization: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthOrganizationPlugin(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  email_and_password: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthEmailAndPasswordConfig(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  email_provider: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthEmailProvider(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  allow_localhost: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthAllowLocalhost(
+      props.projectId,
+      branchId,
+      data,
+    ),
+  webhook: (props, branchId, data) =>
+    props.apiClient.updateNeonAuthWebhookConfig(
+      props.projectId,
+      branchId,
+      data,
+    ),
+};
+
+const pluginsList = async (props: AuthBranchProps) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthPluginConfigs(
+    props.projectId,
+    branchId,
+  );
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(data as any, {
+      fields: Object.keys(data) as any,
+    });
+    return;
+  }
+  const summarize = (value: unknown): string => {
+    if (value == null) return 'not configured';
+    if (typeof value === 'boolean') return String(value);
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number') return String(value);
+    if (Array.isArray(value))
+      return value.length === 1 ? '1 item' : `${String(value.length)} items`;
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>;
+      if ('enabled' in obj) return obj.enabled ? 'enabled' : 'disabled';
+      if ('type' in obj) return formatValue(obj.type);
+    }
+    return JSON.stringify(value);
+  };
+  const entries: [string, string][] = Object.entries(data).map(
+    ([key, value]) => [key.padEnd(24), summarize(value)],
+  );
+  printKvBlock('Neon Auth plugins', entries);
+};
+
+const pluginsGet = async (props: AuthBranchProps & { pluginName: string }) => {
+  const branchId = await resolveBranch(props);
+  const { data } = await props.apiClient.getNeonAuthPluginConfigs(
+    props.projectId,
+    branchId,
+  );
+  const plugin = (data as any)[props.pluginName];
+  if (plugin === undefined) {
+    const available = Object.keys(data).join(', ');
+    throw new Error(
+      `Unknown plugin "${props.pluginName}". Available plugins: ${available}`,
+    );
+  }
+  if (props.output === 'json' || props.output === 'yaml') {
+    const fields =
+      typeof plugin === 'object' && !Array.isArray(plugin)
+        ? Object.keys(plugin)
+        : [];
+    writer(props).end(plugin, { fields: fields as any });
+    return;
+  }
+  if (typeof plugin === 'object' && !Array.isArray(plugin) && plugin != null) {
+    const entries: [string, string][] = Object.entries(plugin).map(([k, v]) => [
+      `${k}:`.padEnd(18),
+      formatValue(v),
+    ]);
+    printKvBlock(pluginTitle(props.pluginName), entries);
+  } else if (Array.isArray(plugin)) {
+    const entries: [string, string][] = plugin.map((item, i) => [
+      `[${i}]:`.padEnd(18),
+      typeof item === 'object' ? JSON.stringify(item) : String(item),
+    ]);
+    printKvBlock(pluginTitle(props.pluginName), entries);
+  } else {
+    printKvBlock(pluginTitle(props.pluginName), [
+      ['Value:'.padEnd(18), String(plugin)],
+    ]);
+  }
+};
+
+const pluginsUpdate = async (
+  props: AuthBranchProps & { pluginName: string; json: string },
+) => {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(props.json);
+  } catch {
+    throw new Error('Invalid JSON. Please provide valid JSON with --json.');
+  }
+
+  const updateMethod = PLUGIN_UPDATE_METHODS[props.pluginName];
+  if (!updateMethod) {
+    const available = Object.keys(PLUGIN_UPDATE_METHODS).join(', ');
+    throw new Error(
+      `Unknown plugin "${props.pluginName}". Updatable plugins: ${available}`,
+    );
+  }
+
+  const branchId = await resolveBranch(props);
+  const { data } = await updateMethod(props, branchId, parsed);
+
+  if (props.output === 'json' || props.output === 'yaml') {
+    const fields =
+      typeof data === 'object' && !Array.isArray(data) ? Object.keys(data) : [];
+    writer(props).end(data, { fields: fields as any });
+    return;
+  }
+  if (typeof data === 'object' && !Array.isArray(data) && data != null) {
+    const entries: [string, string][] = Object.entries(data).map(([k, v]) => [
+      `${k}:`.padEnd(18),
+      formatValue(v),
+    ]);
+    printKvBlock(`${pluginTitle(props.pluginName)} updated`, entries);
+  } else {
+    printKvBlock(`${pluginTitle(props.pluginName)} updated`, [
+      ['Value:'.padEnd(18), String(data)],
+    ]);
+  }
 };
 
 // --- User ---

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -555,63 +555,34 @@ export const builder = (argv: yargs.Argv) => {
             );
         });
     })
-    .command(
-      'plugins',
-      'View and update Neon Auth plugin configurations',
-      (yargs) => {
-        return yargs
-          .usage('$0 neon-auth plugins <sub-command> [options]')
-          .command(
-            'list',
-            'List all plugin configurations',
-            (yargs) => yargs,
-            async (args) => {
-              await pluginsList(args as any);
-            },
-          )
-          .command(
-            'get <plugin-name>',
-            'Get a specific plugin configuration',
-            (yargs) =>
-              yargs
-                .usage('$0 neon-auth plugins get <plugin-name> [options]')
-                .positional('plugin-name', {
-                  describe:
-                    'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
-                  type: 'string',
-                  demandOption: true,
-                }),
-            async (args) => {
-              await pluginsGet(args as any);
-            },
-          )
-          .command(
-            'update <plugin-name>',
-            'Update a plugin configuration using JSON',
-            (yargs) =>
-              yargs
-                .usage(
-                  '$0 neon-auth plugins update <plugin-name> --json \'{"key": "value"}\' [options]',
-                )
-                .positional('plugin-name', {
-                  describe:
-                    'Plugin name (e.g. organization, email_and_password, email_provider, allow_localhost, webhook)',
-                  type: 'string',
-                  demandOption: true,
-                })
-                .options({
-                  json: {
-                    describe: 'JSON configuration to apply',
-                    type: 'string',
-                    demandOption: true,
-                  },
-                }),
-            async (args) => {
-              await pluginsUpdate(args as any);
-            },
-          );
-      },
-    )
+    .command('plugins', 'View Neon Auth plugin configurations', (yargs) => {
+      return yargs
+        .usage('$0 neon-auth plugins <sub-command> [options]')
+        .command(
+          'list',
+          'List all plugin configurations',
+          (yargs) => yargs,
+          async (args) => {
+            await pluginsList(args as any);
+          },
+        )
+        .command(
+          'get <plugin-name>',
+          'Get a specific plugin configuration',
+          (yargs) =>
+            yargs
+              .usage('$0 neon-auth plugins get <plugin-name> [options]')
+              .positional('plugin-name', {
+                describe:
+                  'Plugin name (e.g. organization, email_provider, email_and_password, oauth_providers, allow_localhost)',
+                type: 'string',
+                demandOption: true,
+              }),
+          async (args) => {
+            await pluginsGet(args as any);
+          },
+        );
+    })
     .command('user', 'Manage Neon Auth users', (yargs) => {
       return yargs
         .usage('$0 neon-auth user <sub-command> [options]')
@@ -1418,42 +1389,6 @@ const formatValue = (v: unknown): string => {
   return JSON.stringify(v);
 };
 
-const PLUGIN_UPDATE_METHODS: Record<
-  string,
-  (props: AuthBranchProps, branchId: string, data: any) => Promise<any>
-> = {
-  organization: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthOrganizationPlugin(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  email_and_password: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthEmailAndPasswordConfig(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  email_provider: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthEmailProvider(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  allow_localhost: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthAllowLocalhost(
-      props.projectId,
-      branchId,
-      data,
-    ),
-  webhook: (props, branchId, data) =>
-    props.apiClient.updateNeonAuthWebhookConfig(
-      props.projectId,
-      branchId,
-      data,
-    ),
-};
-
 const pluginsList = async (props: AuthBranchProps) => {
   const branchId = await resolveBranch(props);
   const { data } = await props.apiClient.getNeonAuthPluginConfigs(
@@ -1522,46 +1457,6 @@ const pluginsGet = async (props: AuthBranchProps & { pluginName: string }) => {
   } else {
     printKvBlock(pluginTitle(props.pluginName), [
       ['Value:'.padEnd(18), String(plugin)],
-    ]);
-  }
-};
-
-const pluginsUpdate = async (
-  props: AuthBranchProps & { pluginName: string; json: string },
-) => {
-  let parsed: any;
-  try {
-    parsed = JSON.parse(props.json);
-  } catch {
-    throw new Error('Invalid JSON. Please provide valid JSON with --json.');
-  }
-
-  const updateMethod = PLUGIN_UPDATE_METHODS[props.pluginName];
-  if (!updateMethod) {
-    const available = Object.keys(PLUGIN_UPDATE_METHODS).join(', ');
-    throw new Error(
-      `Unknown plugin "${props.pluginName}". Updatable plugins: ${available}`,
-    );
-  }
-
-  const branchId = await resolveBranch(props);
-  const { data } = await updateMethod(props, branchId, parsed);
-
-  if (props.output === 'json' || props.output === 'yaml') {
-    const fields =
-      typeof data === 'object' && !Array.isArray(data) ? Object.keys(data) : [];
-    writer(props).end(data, { fields: fields as any });
-    return;
-  }
-  if (typeof data === 'object' && !Array.isArray(data) && data != null) {
-    const entries: [string, string][] = Object.entries(data).map(([k, v]) => [
-      `${k}:`.padEnd(18),
-      formatValue(v),
-    ]);
-    printKvBlock(`${pluginTitle(props.pluginName)} updated`, entries);
-  } else {
-    printKvBlock(`${pluginTitle(props.pluginName)} updated`, [
-      ['Value:'.padEnd(18), String(data)],
     ]);
   }
 };


### PR DESCRIPTION
## Summary
- Adds `neon-auth plugins` subcommand for viewing plugin configurations:
  - `plugins list` — summary view of all plugins from `GET /auth/plugins` (new plugins appear automatically without CLI changes)
  - `plugins get <name>` — detailed view of a single plugin's configuration
- JSON/YAML output returns full data for scripting; table output shows a concise summary for `list`

## Details
- `plugins list` dynamically renders whatever the API returns — new plugins (magic_link, phone_number, etc.) are visible immediately
- `plugins get` uses human-readable titles (e.g. "Organization configuration")
- Stacked on #460

## Test plan
- [x] All 30 neon-auth tests pass (2 new tests for plugins list/get)
- [x] Manually tested `plugins list` against a real project
- [ ] Verify `plugins get` works for each known plugin name
- [ ] Test against staging to verify new plugins (magic_link, phone_number) appear in `plugins list`

This pull request was AI-assisted by Isaac.