### PR TITLE
feat: add env file to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bundle/
 coverage
 tmp/
 .history
+.env


### PR DESCRIPTION
## Summary
- Adds `.env` to `.gitignore` to prevent accidental commits of environment files containing secrets.

## Test plan
- [x] Verify `.env` files are excluded from `git status`

This pull request was AI-assisted by Isaac.