### PR TITLE
feat: add data-api command for Neon Data API CRUD

### DIFF
--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/DELETE.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/DELETE.js
@@ -1,0 +1,3 @@
+export default function (req, res) {
+  res.status(200).send({});
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/GET.json
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/GET.json
@@ -1,0 +1,12 @@
+{
+  "url": "https://app-test.dataproxy.neon.tech",
+  "status": "active",
+  "settings": {
+    "db_aggregates_enabled": true,
+    "db_anon_role": "anonymous",
+    "db_schemas": ["public", "analytics"],
+    "jwt_role_claim_key": ".role",
+    "db_max_rows": 1000
+  },
+  "available_schemas": ["public", "analytics", "private"]
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/PATCH.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/PATCH.js
@@ -1,18 +1,30 @@
 import { expect } from 'vitest';
 
 export default function (req, res) {
-  // Differentiate replace vs merge by inspecting the body.
-  // --replace path: only the explicitly passed fields appear in settings.
-  // merge path:    fields previously fetched from GET also appear.
-  if (req.body.settings && req.body.settings.db_max_rows === 250) {
+  if (Object.keys(req.body).length === 0) {
+    // cache-refresh test: empty body refreshes schema cache without changing settings.
+    expect(req.body).toEqual({});
+  } else if (
+    req.body.settings &&
+    req.body.settings.db_max_rows === 250 &&
+    Object.keys(req.body.settings).length === 1
+  ) {
     // --replace test sends ONLY db_max_rows
     expect(req.body).toEqual({
       settings: { db_max_rows: 250 },
     });
   } else {
-    // merge test asserts these are present, then we'll lock down further
-    // when implementing merge (Task 7)
-    expect(req.body.settings).toBeDefined();
+    // merge test: db_max_rows changed by the user; everything else
+    // matches the GET fixture's settings.
+    expect(req.body).toEqual({
+      settings: {
+        db_aggregates_enabled: true,
+        db_anon_role: 'anonymous',
+        db_schemas: ['public', 'analytics'],
+        jwt_role_claim_key: '.role',
+        db_max_rows: 9999,
+      },
+    });
   }
   res.status(200).send({});
 }

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/PATCH.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/PATCH.js
@@ -1,0 +1,18 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  // Differentiate replace vs merge by inspecting the body.
+  // --replace path: only the explicitly passed fields appear in settings.
+  // merge path:    fields previously fetched from GET also appear.
+  if (req.body.settings && req.body.settings.db_max_rows === 250) {
+    // --replace test sends ONLY db_max_rows
+    expect(req.body).toEqual({
+      settings: { db_max_rows: 250 },
+    });
+  } else {
+    // merge test asserts these are present, then we'll lock down further
+    // when implementing merge (Task 7)
+    expect(req.body.settings).toBeDefined();
+  }
+  res.status(200).send({});
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/data-api/db1/POST.js
@@ -1,0 +1,19 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  expect(req.body).toMatchObject({
+    auth_provider: 'neon_auth',
+    add_default_grants: true,
+    settings: {
+      db_schemas: ['public', 'analytics'],
+      db_max_rows: 500,
+    },
+  });
+  expect(req.body.skip_auth_schema).toBeUndefined();
+  expect(req.body.settings.db_anon_role).toBeUndefined();
+  expect(req.body.settings.server_timing_enabled).toBeUndefined();
+
+  res.status(200).send({
+    url: 'https://app-test.dataproxy.neon.tech',
+  });
+}

--- a/mocks/single_org_multidb/projects/test-project-123456/branches/GET.json
+++ b/mocks/single_org_multidb/projects/test-project-123456/branches/GET.json
@@ -1,0 +1,11 @@
+{
+  "branches": [
+    {
+      "id": "br-main-branch-123456",
+      "name": "main",
+      "default": true,
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/mocks/single_org_multidb/projects/test-project-123456/branches/br-main-branch-123456/databases/GET.json
+++ b/mocks/single_org_multidb/projects/test-project-123456/branches/br-main-branch-123456/databases/GET.json
@@ -1,0 +1,6 @@
+{
+  "databases": [
+    { "name": "db1", "owner_name": "user1" },
+    { "name": "db2", "owner_name": "user1" }
+  ]
+}

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`data-api > delete 1`] = `""`;

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -1,3 +1,26 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`data-api > delete 1`] = `""`;
+
+exports[`data-api > get 1`] = `
+"url: https://app-test.dataproxy.neon.tech
+status: active
+settings:
+  db_aggregates_enabled: true
+  db_anon_role: anonymous
+  db_schemas:
+    - public
+    - analytics
+  jwt_role_claim_key: .role
+  db_max_rows: 1000
+"
+`;
+
+exports[`data-api > get with table output 1`] = `
+"┌──────────────────────────────────────┬────────┬───────────────────┐
+│ Url                                  │ Status │ Db Schemas        │
+├──────────────────────────────────────┼────────┼───────────────────┤
+│ https://app-test.dataproxy.neon.tech │ active │ public, analytics │
+└──────────────────────────────────────┴────────┴───────────────────┘
+"
+`;

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -25,6 +25,20 @@ settings:
 "
 `;
 
+exports[`data-api > get with fully implicit resolution 1`] = `
+"url: https://app-test.dataproxy.neon.tech
+status: active
+settings:
+  db_aggregates_enabled: true
+  db_anon_role: anonymous
+  db_schemas:
+    - public
+    - analytics
+  jwt_role_claim_key: .role
+  db_max_rows: 1000
+"
+`;
+
 exports[`data-api > get with table output 1`] = `
 "┌──────────────────────────────────────┬────────┬───────────────────┐
 │ Url                                  │ Status │ Db Schemas        │
@@ -41,3 +55,5 @@ exports[`data-api > update --replace 1`] = `""`;
 exports[`data-api > update fails when no settings flags are passed 1`] = `""`;
 
 exports[`data-api > update merges with existing settings 1`] = `""`;
+
+exports[`data-api > update with fully implicit resolution 1`] = `""`;

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -1,5 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`data-api > create 1`] = `
+"url: https://app-test.dataproxy.neon.tech
+"
+`;
+
 exports[`data-api > delete 1`] = `""`;
 
 exports[`data-api > get 1`] = `

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -31,3 +31,7 @@ exports[`data-api > get with table output 1`] = `
 `;
 
 exports[`data-api > update --replace 1`] = `""`;
+
+exports[`data-api > update --replace with no flags refreshes schema cache 1`] = `""`;
+
+exports[`data-api > update merges with existing settings 1`] = `""`;

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -29,3 +29,5 @@ exports[`data-api > get with table output 1`] = `
 └──────────────────────────────────────┴────────┴───────────────────┘
 "
 `;
+
+exports[`data-api > update --replace 1`] = `""`;

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -7,6 +7,10 @@ exports[`data-api > create 1`] = `
 
 exports[`data-api > delete 1`] = `""`;
 
+exports[`data-api > delete fails with helpful error when multiple databases 1`] = `""`;
+
+exports[`data-api > delete with implicit database 1`] = `""`;
+
 exports[`data-api > get 1`] = `
 "url: https://app-test.dataproxy.neon.tech
 status: active

--- a/src/commands/__snapshots__/data_api.test.ts.snap
+++ b/src/commands/__snapshots__/data_api.test.ts.snap
@@ -34,8 +34,10 @@ exports[`data-api > get with table output 1`] = `
 "
 `;
 
+exports[`data-api > refresh-schema sends empty PATCH 1`] = `""`;
+
 exports[`data-api > update --replace 1`] = `""`;
 
-exports[`data-api > update --replace with no flags refreshes schema cache 1`] = `""`;
+exports[`data-api > update fails when no settings flags are passed 1`] = `""`;
 
 exports[`data-api > update merges with existing settings 1`] = `""`;

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -53,4 +53,27 @@ describe('data-api', () => {
       { mockDir: 'single_org', outputTable: true },
     );
   });
+
+  test('create', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'create',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+        '--auth-provider',
+        'neon_auth',
+        '--add-default-grants',
+        '--db-schemas',
+        'public,analytics',
+        '--db-max-rows',
+        '500',
+      ],
+      { mockDir: 'single_org' },
+    );
+  });
 });

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -122,11 +122,9 @@ describe('data-api', () => {
     );
   });
 
-  test('update --replace with no flags refreshes schema cache', async ({
+  test('update fails when no settings flags are passed', async ({
     testCliCommand,
   }) => {
-    // Server treats an empty body as a no-op settings update + schema cache
-    // refresh, so passing --replace alone is a valid (and useful) operation.
     await testCliCommand(
       [
         'data-api',
@@ -141,8 +139,29 @@ describe('data-api', () => {
       ],
       {
         mockDir: 'single_org',
+        code: 1,
         stderr:
-          'INFO: Data API settings updated for db1 on branch br-main-branch-123456',
+          'ERROR: No settings flags provided. Pass at least one setting flag to update, or use `data-api refresh-schema` to refresh the schema cache without changing settings.',
+      },
+    );
+  });
+
+  test('refresh-schema sends empty PATCH', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'refresh-schema',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API schema cache refreshed for db1 on branch br-main-branch-123456',
       },
     );
   });

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -1,0 +1,24 @@
+import { describe } from 'vitest';
+import { test } from '../test_utils/fixtures';
+
+describe('data-api', () => {
+  test('delete', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'delete',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API deleted for db1 on branch br-main-branch-123456',
+      },
+    );
+  });
+});

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -76,4 +76,27 @@ describe('data-api', () => {
       { mockDir: 'single_org' },
     );
   });
+
+  test('update --replace', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'update',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+        '--replace',
+        '--db-max-rows',
+        '250',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API settings updated for db1 on branch br-main-branch-123456',
+      },
+    );
+  });
 });

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -99,4 +99,51 @@ describe('data-api', () => {
       },
     );
   });
+
+  test('update merges with existing settings', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'update',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+        '--db-max-rows',
+        '9999',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API settings updated for db1 on branch br-main-branch-123456',
+      },
+    );
+  });
+
+  test('update --replace with no flags refreshes schema cache', async ({
+    testCliCommand,
+  }) => {
+    // Server treats an empty body as a no-op settings update + schema cache
+    // refresh, so passing --replace alone is a valid (and useful) operation.
+    await testCliCommand(
+      [
+        'data-api',
+        'update',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+        '--replace',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API settings updated for db1 on branch br-main-branch-123456',
+      },
+    );
+  });
 });

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -146,4 +146,45 @@ describe('data-api', () => {
       },
     );
   });
+
+  test('delete with implicit database', async ({ testCliCommand }) => {
+    // The single_org fixture has exactly one database (db1) on the main branch,
+    // so omitting --database should resolve it automatically.
+    await testCliCommand(
+      [
+        'data-api',
+        'delete',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        stderr:
+          'INFO: Data API deleted for db1 on branch br-main-branch-123456',
+      },
+    );
+  });
+
+  test('delete fails with helpful error when multiple databases', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'delete',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org_multidb',
+        code: 1,
+        stderr:
+          'ERROR: Multiple databases found for the branch, please provide one with the --database option: db1, db2',
+      },
+    );
+  });
 });

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -186,6 +186,20 @@ describe('data-api', () => {
     );
   });
 
+  test('get with fully implicit resolution', async ({ testCliCommand }) => {
+    // single_org has one org, one project, one default branch (main), one
+    // database (db1) — all three should be auto-resolved when omitted.
+    await testCliCommand(['data-api', 'get'], { mockDir: 'single_org' });
+  });
+
+  test('update with fully implicit resolution', async ({ testCliCommand }) => {
+    await testCliCommand(['data-api', 'update', '--db-max-rows', '9999'], {
+      mockDir: 'single_org',
+      stderr:
+        'INFO: Data API settings updated for db1 on branch br-main-branch-123456',
+    });
+  });
+
   test('delete fails with helpful error when multiple databases', async ({
     testCliCommand,
   }) => {

--- a/src/commands/data_api.test.ts
+++ b/src/commands/data_api.test.ts
@@ -21,4 +21,36 @@ describe('data-api', () => {
       },
     );
   });
+
+  test('get', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'get',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+      ],
+      { mockDir: 'single_org' },
+    );
+  });
+
+  test('get with table output', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'data-api',
+        'get',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+        '--database',
+        'db1',
+      ],
+      { mockDir: 'single_org', outputTable: true },
+    );
+  });
 });

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -153,6 +153,12 @@ export const builder = (argv: yargs.Argv) =>
       (args) => update(args as any),
     )
     .command(
+      'refresh-schema',
+      'Refresh the Data API schema cache without changing settings',
+      (yargs) => yargs,
+      (args) => refreshSchema(args as any),
+    )
+    .command(
       'delete',
       'Tear down the Neon Data API for a database',
       (yargs) => yargs,
@@ -277,6 +283,12 @@ const update = async (
 
   const userSettings = buildSettings(props);
 
+  if (!userSettings) {
+    throw new Error(
+      'No settings flags provided. Pass at least one setting flag to update, or use `data-api refresh-schema` to refresh the schema cache without changing settings.',
+    );
+  }
+
   let settings: DataAPISettings | undefined;
   if (props.replace) {
     settings = userSettings;
@@ -326,6 +338,36 @@ const update = async (
     throw err;
   }
   log.info(`Data API settings updated for ${database} on branch ${branchId}`);
+};
+
+const refreshSchema = async (props: DataApiProps): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const database = await resolveSingleDatabase({
+    apiClient: props.apiClient,
+    projectId: props.projectId,
+    branchId,
+    database: props.database,
+  });
+  try {
+    await retryOnLock(() =>
+      props.apiClient.updateProjectBranchDataApi(
+        props.projectId,
+        branchId,
+        database,
+        {},
+      ),
+    );
+  } catch (err: unknown) {
+    if (isAxiosError(err) && err.response?.status === 404) {
+      throw new Error(
+        `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+      );
+    }
+    throw err;
+  }
+  log.info(
+    `Data API schema cache refreshed for ${database} on branch ${branchId}`,
+  );
 };
 
 const deleteDataApi = async (props: DataApiProps): Promise<void> => {

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -64,7 +64,8 @@ const settingsFlags = {
   },
   'openapi-mode': {
     type: 'string',
-    describe: 'OpenAPI mode (e.g., "ignore-privileges", "disabled")',
+    choices: ['ignore-privileges', 'disabled'],
+    describe: 'OpenAPI mode',
   },
   'server-cors-allowed-origins': {
     type: 'string',
@@ -378,12 +379,21 @@ const deleteDataApi = async (props: DataApiProps): Promise<void> => {
     branchId,
     database: props.database,
   });
-  await retryOnLock(() =>
-    props.apiClient.deleteProjectBranchDataApi(
-      props.projectId,
-      branchId,
-      database,
-    ),
-  );
+  try {
+    await retryOnLock(() =>
+      props.apiClient.deleteProjectBranchDataApi(
+        props.projectId,
+        branchId,
+        database,
+      ),
+    );
+  } catch (err: unknown) {
+    if (isAxiosError(err) && err.response?.status === 404) {
+      throw new Error(
+        `Data API is not provisioned for ${database} on branch ${branchId}.`,
+      );
+    }
+    throw err;
+  }
   log.info(`Data API deleted for ${database} on branch ${branchId}`);
 };

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -1,0 +1,172 @@
+import yargs from 'yargs';
+
+import { BranchScopeProps } from '../types.js';
+import { fillSingleProject } from '../utils/enrichers.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const SETTINGS_FIELDS = [
+  'db_aggregates_enabled',
+  'db_anon_role',
+  'db_extra_search_path',
+  'db_max_rows',
+  'db_schemas',
+  'jwt_role_claim_key',
+  'jwt_cache_max_lifetime',
+  'openapi_mode',
+  'server_cors_allowed_origins',
+  'server_timing_enabled',
+] as const;
+
+type DataApiProps = BranchScopeProps & {
+  database?: string;
+};
+
+const settingsFlags = {
+  'db-aggregates-enabled': {
+    type: 'boolean',
+    describe: 'Enable aggregate functions in queries',
+  },
+  'db-anon-role': {
+    type: 'string',
+    describe: 'Database role used for anonymous (unauthenticated) requests',
+  },
+  'db-extra-search-path': {
+    type: 'string',
+    describe: 'Extra schemas appended to the search path',
+  },
+  'db-max-rows': {
+    type: 'number',
+    describe: 'Maximum number of rows returned by a single request',
+  },
+  'db-schemas': {
+    type: 'string',
+    describe: 'Comma-separated list of schemas exposed via the Data API',
+  },
+  'jwt-role-claim-key': {
+    type: 'string',
+    describe: 'JWT claim path used to extract the role',
+  },
+  'jwt-cache-max-lifetime': {
+    type: 'number',
+    describe: 'Maximum JWT cache lifetime in seconds',
+  },
+  'openapi-mode': {
+    type: 'string',
+    describe: 'OpenAPI mode (e.g., "ignore-privileges", "disabled")',
+  },
+  'server-cors-allowed-origins': {
+    type: 'string',
+    describe: 'CORS allowed origins',
+  },
+  'server-timing-enabled': {
+    type: 'boolean',
+    describe: 'Enable Server-Timing response headers',
+  },
+} as const;
+
+export const command = 'data-api';
+export const describe = 'Manage the Neon Data API for a database';
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 data-api <sub-command> [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+      database: {
+        describe: 'Database name',
+        type: 'string',
+      },
+    })
+    .middleware(fillSingleProject as any)
+    .command(
+      'create',
+      'Provision the Neon Data API for a database',
+      (yargs) =>
+        yargs.options({
+          'auth-provider': {
+            type: 'string',
+            choices: ['neon_auth', 'external'],
+            describe: 'Authentication provider',
+          },
+          'jwks-url': {
+            type: 'string',
+            describe: 'URL that lists the JWKS (used with external auth)',
+          },
+          'provider-name': {
+            type: 'string',
+            describe: 'Name of the auth provider (e.g. Clerk, Stytch, Auth0)',
+          },
+          'jwt-audience': {
+            type: 'string',
+            describe: 'Expected JWT audience claim',
+          },
+          'add-default-grants': {
+            type: 'boolean',
+            describe:
+              'Grant all permissions on tables in the public schema to authenticated users',
+          },
+          'skip-auth-schema': {
+            type: 'boolean',
+            describe: 'Skip creating the auth schema and RLS functions',
+          },
+          ...settingsFlags,
+        }),
+      (args) => create(args as any),
+    )
+    .command(
+      'get',
+      'Show the Neon Data API status and settings',
+      (yargs) => yargs,
+      (args) => get(args as any),
+    )
+    .command(
+      'update',
+      'Update Neon Data API settings (merges with current settings by default)',
+      (yargs) =>
+        yargs.options({
+          replace: {
+            type: 'boolean',
+            default: false,
+            describe:
+              'Replace settings with only the flags provided. Omitted settings revert to server defaults.',
+          },
+          ...settingsFlags,
+        }),
+      (args) => update(args as any),
+    )
+    .command(
+      'delete',
+      'Tear down the Neon Data API for a database',
+      (yargs) => yargs,
+      (args) => deleteDataApi(args as any),
+    );
+
+export const handler = (args: yargs.Argv) => {
+  return args;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const create = (_props: DataApiProps): Promise<void> => {
+  throw new Error('Not yet implemented');
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const get = (_props: DataApiProps): Promise<void> => {
+  throw new Error('Not yet implemented');
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const update = (_props: DataApiProps & { replace: boolean }): Promise<void> => {
+  throw new Error('Not yet implemented');
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const deleteDataApi = (_props: DataApiProps): Promise<void> => {
+  throw new Error('Not yet implemented');
+};

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -12,6 +12,7 @@ import { writer } from '../writer.js';
 import type {
   DataAPICreateRequest,
   DataAPISettings,
+  DataAPIUpdateRequest,
 } from '@neondatabase/api-client';
 
 const SETTINGS_FIELDS = [
@@ -262,9 +263,37 @@ const get = async (props: DataApiProps): Promise<void> => {
   writer(props).end(tableRow, { fields: GET_FIELDS });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const update = (_props: DataApiProps & { replace: boolean }): Promise<void> => {
-  throw new Error('Not yet implemented');
+const update = async (
+  props: DataApiProps & { replace: boolean } & Record<string, unknown>,
+): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const database = await resolveSingleDatabase({
+    apiClient: props.apiClient,
+    projectId: props.projectId,
+    branchId,
+    database: props.database,
+  });
+
+  let settings: DataAPISettings | undefined;
+  if (props.replace) {
+    settings = buildSettings(props);
+  } else {
+    // Merge path implemented in Task 7
+    throw new Error('Merge mode not yet implemented — pass --replace for now');
+  }
+
+  const body: DataAPIUpdateRequest = {};
+  if (settings) body.settings = settings;
+
+  await retryOnLock(() =>
+    props.apiClient.updateProjectBranchDataApi(
+      props.projectId,
+      branchId,
+      database,
+      body,
+    ),
+  );
+  log.info(`Data API settings updated for ${database} on branch ${branchId}`);
 };
 
 const deleteDataApi = async (props: DataApiProps): Promise<void> => {

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { isAxiosError } from 'axios';
 
 import { retryOnLock } from '../api.js';
 import { BranchScopeProps } from '../types.js';
@@ -274,25 +275,56 @@ const update = async (
     database: props.database,
   });
 
+  const userSettings = buildSettings(props);
+
   let settings: DataAPISettings | undefined;
   if (props.replace) {
-    settings = buildSettings(props);
+    settings = userSettings;
   } else {
-    // Merge path implemented in Task 7
-    throw new Error('Merge mode not yet implemented — pass --replace for now');
+    let current: DataAPISettings | undefined;
+    try {
+      const { data } = await props.apiClient.getProjectBranchDataApi(
+        props.projectId,
+        branchId,
+        database,
+      );
+      current = data.settings ?? undefined;
+    } catch (err: unknown) {
+      if (isAxiosError(err) && err.response?.status === 404) {
+        throw new Error(
+          `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+        );
+      }
+      throw err;
+    }
+    if (!current) {
+      throw new Error(
+        `Could not read current Data API settings for ${database} on branch ${branchId}. Retry, or pass --replace to overwrite.`,
+      );
+    }
+    settings = { ...current, ...(userSettings ?? {}) };
   }
 
   const body: DataAPIUpdateRequest = {};
   if (settings) body.settings = settings;
 
-  await retryOnLock(() =>
-    props.apiClient.updateProjectBranchDataApi(
-      props.projectId,
-      branchId,
-      database,
-      body,
-    ),
-  );
+  try {
+    await retryOnLock(() =>
+      props.apiClient.updateProjectBranchDataApi(
+        props.projectId,
+        branchId,
+        database,
+        body,
+      ),
+    );
+  } catch (err: unknown) {
+    if (isAxiosError(err) && err.response?.status === 404) {
+      throw new Error(
+        `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+      );
+    }
+    throw err;
+  }
   log.info(`Data API settings updated for ${database} on branch ${branchId}`);
 };
 

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -9,8 +9,11 @@ import {
 } from '../utils/enrichers.js';
 import { log } from '../log.js';
 import { writer } from '../writer.js';
+import type {
+  DataAPICreateRequest,
+  DataAPISettings,
+} from '@neondatabase/api-client';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SETTINGS_FIELDS = [
   'db_aggregates_enabled',
   'db_anon_role',
@@ -158,9 +161,71 @@ export const handler = (args: yargs.Argv) => {
   return args;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const create = (_props: DataApiProps): Promise<void> => {
-  throw new Error('Not yet implemented');
+const TOP_LEVEL_CREATE_FIELDS = [
+  'auth_provider',
+  'jwks_url',
+  'provider_name',
+  'jwt_audience',
+  'add_default_grants',
+  'skip_auth_schema',
+] as const;
+
+const argKey = (snake: string) => snake.replace(/_/g, '-');
+
+const buildSettings = (
+  args: Record<string, unknown>,
+): DataAPISettings | undefined => {
+  const settings: Record<string, unknown> = {};
+  for (const field of SETTINGS_FIELDS) {
+    const value = args[argKey(field)];
+    if (value === undefined) continue;
+    if (field === 'db_schemas' && typeof value === 'string') {
+      settings[field] = value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else {
+      settings[field] = value;
+    }
+  }
+  return Object.keys(settings).length > 0
+    ? (settings as DataAPISettings)
+    : undefined;
+};
+
+const buildCreateBody = (
+  args: Record<string, unknown>,
+): DataAPICreateRequest => {
+  const body: Record<string, unknown> = {};
+  for (const field of TOP_LEVEL_CREATE_FIELDS) {
+    const value = args[argKey(field)];
+    if (value !== undefined) body[field] = value;
+  }
+  const settings = buildSettings(args);
+  if (settings) body.settings = settings;
+  return body as DataAPICreateRequest;
+};
+
+const create = async (
+  props: DataApiProps & Record<string, unknown>,
+): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const database = await resolveSingleDatabase({
+    apiClient: props.apiClient,
+    projectId: props.projectId,
+    branchId,
+    database: props.database,
+  });
+  const body = buildCreateBody(props);
+  const { data } = await retryOnLock(() =>
+    props.apiClient.createProjectBranchDataApi(
+      props.projectId,
+      branchId,
+      database,
+      body,
+    ),
+  );
+  writer(props).end(data, { fields: ['url'] });
 };
 
 const GET_FIELDS = ['url', 'status', 'db_schemas'] as const;

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -8,6 +8,7 @@ import {
   resolveSingleDatabase,
 } from '../utils/enrichers.js';
 import { log } from '../log.js';
+import { writer } from '../writer.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SETTINGS_FIELDS = [
@@ -162,9 +163,38 @@ const create = (_props: DataApiProps): Promise<void> => {
   throw new Error('Not yet implemented');
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const get = (_props: DataApiProps): Promise<void> => {
-  throw new Error('Not yet implemented');
+const GET_FIELDS = ['url', 'status', 'db_schemas'] as const;
+
+const get = async (props: DataApiProps): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const database = await resolveSingleDatabase({
+    apiClient: props.apiClient,
+    projectId: props.projectId,
+    branchId,
+    database: props.database,
+  });
+  const { data } = await props.apiClient.getProjectBranchDataApi(
+    props.projectId,
+    branchId,
+    database,
+  );
+
+  // Drop available_schemas from json/yaml output (not part of the public surface).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { available_schemas: _ignored, ...publicData } = data;
+
+  // For table output, flatten db_schemas onto the top-level for column rendering.
+  const tableRow = {
+    url: publicData.url,
+    status: publicData.status,
+    db_schemas: (publicData.settings?.db_schemas ?? []).join(', '),
+  };
+
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(publicData, { fields: GET_FIELDS });
+    return;
+  }
+  writer(props).end(tableRow, { fields: GET_FIELDS });
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -1,7 +1,13 @@
 import yargs from 'yargs';
 
+import { retryOnLock } from '../api.js';
 import { BranchScopeProps } from '../types.js';
-import { fillSingleProject } from '../utils/enrichers.js';
+import {
+  branchIdFromProps,
+  fillSingleProject,
+  resolveSingleDatabase,
+} from '../utils/enrichers.js';
+import { log } from '../log.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SETTINGS_FIELDS = [
@@ -166,7 +172,20 @@ const update = (_props: DataApiProps & { replace: boolean }): Promise<void> => {
   throw new Error('Not yet implemented');
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const deleteDataApi = (_props: DataApiProps): Promise<void> => {
-  throw new Error('Not yet implemented');
+const deleteDataApi = async (props: DataApiProps): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const database = await resolveSingleDatabase({
+    apiClient: props.apiClient,
+    projectId: props.projectId,
+    branchId,
+    database: props.database,
+  });
+  await retryOnLock(() =>
+    props.apiClient.deleteProjectBranchDataApi(
+      props.projectId,
+      branchId,
+      database,
+    ),
+  );
+  log.info(`Data API deleted for ${database} on branch ${branchId}`);
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,6 +12,7 @@ import * as cs from './connection_string.js';
 import * as psql from './psql.js';
 import * as setContext from './set_context.js';
 import * as init from './init.js';
+import * as dataApi from './data_api.js';
 
 export default [
   auth,
@@ -28,4 +29,5 @@ export default [
   psql,
   setContext,
   init,
+  dataApi,
 ];

--- a/src/utils/enrichers.ts
+++ b/src/utils/enrichers.ts
@@ -5,7 +5,7 @@ import {
   OrgScopeProps,
 } from '../types.js';
 import { looksLikeBranchId } from './formats.js';
-import { Branch } from '@neondatabase/api-client';
+import { Branch, Database } from '@neondatabase/api-client';
 import { isAxiosError } from 'axios';
 
 export const branchIdResolve = async ({
@@ -65,6 +65,38 @@ const getBranchIdFromProps = async (props: BranchScopeProps) => {
 export const branchIdFromProps = async (props: BranchScopeProps) => {
   (props as any).branchId = await getBranchIdFromProps(props);
   return (props as any).branchId;
+};
+
+export const resolveSingleDatabase = async (props: {
+  apiClient: CommonProps['apiClient'];
+  projectId: string;
+  branchId: string;
+  database?: string;
+}): Promise<string> => {
+  const { data } = await props.apiClient.listProjectBranchDatabases(
+    props.projectId,
+    props.branchId,
+  );
+  const databases = data.databases;
+
+  if (props.database !== undefined) {
+    if (!databases.find((d: Database) => d.name === props.database)) {
+      throw new Error(
+        `Database not found: ${props.database}. Available databases on branch ${props.branchId}: ${databases.map((d: Database) => d.name).join(', ')}`,
+      );
+    }
+    return props.database;
+  }
+
+  if (databases.length === 0) {
+    throw new Error(`No databases found for the branch: ${props.branchId}`);
+  }
+  if (databases.length === 1) {
+    return databases[0].name;
+  }
+  throw new Error(
+    `Multiple databases found for the branch, please provide one with the --database option: ${databases.map((d: Database) => d.name).join(', ')}`,
+  );
 };
 
 export const fillSingleProject = async (


### PR DESCRIPTION
## Summary

  Adds a top-level `neonctl data-api` command with full CRUD against `/projects/{project_id}/branches/{branch_id}/data-api/{database_name}`:

  - `create` — provision the Data API (auth-provider config + PostgREST settings)
  - `get` — show URL, status, and settings
  - `update` — update settings; defaults to read-then-write **merge** to avoid silently clobbering server-side state; `--replace` opts in to a full replace (omitted settings revert to server
  defaults)
  - `delete` — tear down
  - `refresh-schema` — refresh the Data API schema cache without changing settings (sends an empty PATCH body, which the server treats as a no-op settings update + cache refresh)

  Notable design choices:

  - **Merge by default for `update`.** The server-side PATCH endpoint replaces the full settings object using server defaults for omitted fields, so a naive partial PATCH would silently
  destroy user config. Default mode does GET-then-PATCH; `--replace` is the explicit escape hatch.
  - **Hardcoded `SETTINGS_FIELDS` array** as the single source of truth for which keys belong inside `settings`; both `create` and `update` iterate this list to build request bodies.
  - New `resolveSingleDatabase` helper in `src/utils/enrichers.ts` for shared database auto-resolution (pick if exactly one, error helpfully on multiple).
  - All mutating calls wrapped in `retryOnLock`. `update` errors when no settings flags are passed in either mode.

  No `@neondatabase/api-client` bump — the four required methods exist in 2.6.0.

  ## Test plan

  - [x] 9 new tests in `src/commands/data_api.test.ts` covering all subcommands, both update modes, merge body shape, no-flag guard, implicit database resolution, and multi-database error
  - [x] Mock fixtures under `mocks/single_org/` and a new `mocks/single_org_multidb/` with two databases
  - [x] Full suite passes: `npx vitest run` → 156/156
  - [x] Lint clean: `bun run lint`
  - [x] Help output verified: `data-api --help`, `data-api create --help` (16 flags), `data-api update --help` (11 flags, no auth-provider flags)