### PR TITLE
feat: granular exit codes for shell-pipeline branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ Global options are supported with any Neon CLI command.
   neonctl branches create --help
   ```
 
+## Exit codes
+
+The CLI exits with a code that indicates the class of result. Use these in shell pipelines to branch without parsing error messages.
+
+| Code | Meaning                                                    |
+| :--- | :--------------------------------------------------------- |
+| `0`  | Success                                                    |
+| `1`  | Generic / unclassified error                               |
+| `2`  | Usage error (unknown command, missing or invalid argument) |
+| `3`  | Authentication or authorization failed (HTTP 401, 403)     |
+| `4`  | Resource not found (HTTP 404)                              |
+| `5`  | Conflict (HTTP 409 — e.g. resource already exists)         |
+| `6`  | Rate limited (HTTP 429)                                    |
+| `7`  | Network error or request timeout                           |
+
+Example:
+
+```bash
+neon projects get my-project
+case $? in
+  0) echo "ok" ;;
+  3) neon auth ;;
+  4) neon projects create --name my-project ;;
+  *) echo "unexpected failure" >&2; exit 1 ;;
+esac
+```
+
 ## Contribute
 
 To run the CLI locally, execute the build command after making changes:

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -118,7 +118,7 @@ describe('set_context', () => {
           overrideContextFile,
         ],
         {
-          code: 1,
+          code: 4,
           stderr: 'ERROR: Not Found',
         },
       );

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import {
+  classifyError,
+  EXIT_CODES,
+  ErrorCode,
+  exitCodeForError,
+  matchErrorCode,
+} from './errors';
+
+const makeAxiosError = (opts: {
+  status?: number;
+  code?: string;
+  message?: string;
+}): AxiosError => {
+  const err = new AxiosError(
+    opts.message ?? 'request failed',
+    opts.code,
+    undefined,
+    undefined,
+    opts.status !== undefined
+      ? {
+          status: opts.status,
+          statusText: '',
+          data: undefined,
+          headers: new AxiosHeaders(),
+          config: { headers: new AxiosHeaders() } as never,
+        }
+      : undefined,
+  );
+  return err;
+};
+
+describe('classifyError', () => {
+  it('maps ECONNABORTED to REQUEST_TIMEOUT', () => {
+    expect(classifyError(makeAxiosError({ code: 'ECONNABORTED' }))).toBe(
+      'REQUEST_TIMEOUT',
+    );
+  });
+
+  it('maps ETIMEDOUT to REQUEST_TIMEOUT', () => {
+    expect(classifyError(makeAxiosError({ code: 'ETIMEDOUT' }))).toBe(
+      'REQUEST_TIMEOUT',
+    );
+  });
+
+  it('maps axios error without response to NETWORK_ERROR', () => {
+    expect(classifyError(makeAxiosError({ code: 'ECONNREFUSED' }))).toBe(
+      'NETWORK_ERROR',
+    );
+  });
+
+  it('maps 401 to AUTH_FAILED', () => {
+    expect(classifyError(makeAxiosError({ status: 401 }))).toBe('AUTH_FAILED');
+  });
+
+  it('maps 403 to AUTH_FAILED', () => {
+    expect(classifyError(makeAxiosError({ status: 403 }))).toBe('AUTH_FAILED');
+  });
+
+  it('maps 404 to NOT_FOUND', () => {
+    expect(classifyError(makeAxiosError({ status: 404 }))).toBe('NOT_FOUND');
+  });
+
+  it('maps 409 to CONFLICT', () => {
+    expect(classifyError(makeAxiosError({ status: 409 }))).toBe('CONFLICT');
+  });
+
+  it('maps 429 to RATE_LIMIT', () => {
+    expect(classifyError(makeAxiosError({ status: 429 }))).toBe('RATE_LIMIT');
+  });
+
+  it('maps other 4xx to API_ERROR', () => {
+    expect(classifyError(makeAxiosError({ status: 400 }))).toBe('API_ERROR');
+  });
+
+  it('maps 5xx to API_ERROR', () => {
+    expect(classifyError(makeAxiosError({ status: 500 }))).toBe('API_ERROR');
+    expect(classifyError(makeAxiosError({ status: 503 }))).toBe('API_ERROR');
+  });
+
+  it('classifies yargs usage errors as USAGE_ERROR', () => {
+    expect(classifyError(new Error('Unknown argument: foo'))).toBe(
+      'USAGE_ERROR',
+    );
+    expect(classifyError(new Error('Not enough non-option arguments: 0'))).toBe(
+      'USAGE_ERROR',
+    );
+  });
+
+  it('keeps regex-matched specific codes for known yargs prefixes', () => {
+    expect(classifyError(new Error('Unknown command: foo'))).toBe(
+      'UNKNOWN_COMMAND',
+    );
+    expect(classifyError(new Error('Missing required argument: bar'))).toBe(
+      'MISSING_ARGUMENT',
+    );
+  });
+
+  it('falls through to UNKNOWN_ERROR for generic errors', () => {
+    expect(classifyError(new Error('something else broke'))).toBe(
+      'UNKNOWN_ERROR',
+    );
+  });
+
+  it('handles non-Error inputs', () => {
+    expect(classifyError(undefined)).toBe('UNKNOWN_ERROR');
+    expect(classifyError('a string')).toBe('UNKNOWN_ERROR');
+  });
+});
+
+describe('exitCodeForError / EXIT_CODES', () => {
+  it.each<[ErrorCode, number]>([
+    ['UNKNOWN_COMMAND', 2],
+    ['MISSING_ARGUMENT', 2],
+    ['USAGE_ERROR', 2],
+    ['AUTH_FAILED', 3],
+    ['AUTH_BROWSER_FAILED', 3],
+    ['NOT_FOUND', 4],
+    ['CONFLICT', 5],
+    ['RATE_LIMIT', 6],
+    ['REQUEST_TIMEOUT', 7],
+    ['NETWORK_ERROR', 7],
+    ['API_ERROR', 1],
+    ['UNKNOWN_ERROR', 1],
+    ['CREDENTIALS_DELETE_FAILED', 1],
+    ['NPX_NOT_FOUND', 1],
+    ['NEON_INIT_FAILED', 1],
+  ])('maps %s to exit code %i', (code, exit) => {
+    expect(exitCodeForError(code)).toBe(exit);
+    expect(EXIT_CODES[code]).toBe(exit);
+  });
+});
+
+describe('matchErrorCode', () => {
+  it('handles undefined message', () => {
+    expect(matchErrorCode(undefined)).toBe('UNKNOWN_ERROR');
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,20 +1,63 @@
+import { isAxiosError } from 'axios';
+
 export type ErrorCode =
   | 'REQUEST_TIMEOUT'
+  | 'NETWORK_ERROR'
   | 'AUTH_FAILED'
   | 'AUTH_BROWSER_FAILED'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'RATE_LIMIT'
   | 'API_ERROR'
   | 'UNKNOWN_COMMAND'
   | 'MISSING_ARGUMENT'
+  | 'USAGE_ERROR'
   | 'CREDENTIALS_DELETE_FAILED'
   | 'NPX_NOT_FOUND'
   | 'NEON_INIT_FAILED'
   | 'UNKNOWN_ERROR';
+
+// Documented in README. Keep in sync.
+export const EXIT_CODES: Record<ErrorCode, number> = {
+  UNKNOWN_COMMAND: 2,
+  MISSING_ARGUMENT: 2,
+  USAGE_ERROR: 2,
+  AUTH_FAILED: 3,
+  AUTH_BROWSER_FAILED: 3,
+  NOT_FOUND: 4,
+  CONFLICT: 5,
+  RATE_LIMIT: 6,
+  REQUEST_TIMEOUT: 7,
+  NETWORK_ERROR: 7,
+  API_ERROR: 1,
+  CREDENTIALS_DELETE_FAILED: 1,
+  NPX_NOT_FOUND: 1,
+  NEON_INIT_FAILED: 1,
+  UNKNOWN_ERROR: 1,
+};
+
+export const exitCodeForError = (code: ErrorCode): number => EXIT_CODES[code];
 
 const ERROR_MATCHERS = [
   [/^Unknown command: (.*)$/, 'UNKNOWN_COMMAND'],
   [/^Missing required argument: (.*)$/, 'MISSING_ARGUMENT'],
   [/^Failed to open web browser. (.*)$/, 'AUTH_BROWSER_FAILED'],
 ] as const;
+
+// Yargs surfaces validation failures as plain Errors with messages that start
+// with one of these stable prefixes. Treat them all as USAGE_ERROR (exit 2)
+// even when the specific prefix isn't in ERROR_MATCHERS.
+const YARGS_USAGE_PREFIXES = [
+  'Unknown command:',
+  'Unknown argument:',
+  'Unknown arguments:',
+  'Missing required argument:',
+  'Missing required arguments:',
+  'Not enough non-option arguments:',
+  'Too many non-option arguments:',
+  'Invalid values:',
+  'Did you mean ',
+];
 
 export const matchErrorCode = (message?: string): ErrorCode => {
   if (!message) {
@@ -25,6 +68,45 @@ export const matchErrorCode = (message?: string): ErrorCode => {
     if (match) {
       return code;
     }
+  }
+  if (YARGS_USAGE_PREFIXES.some((prefix) => message.startsWith(prefix))) {
+    return 'USAGE_ERROR';
+  }
+  return 'UNKNOWN_ERROR';
+};
+
+// Classify an error caught from the API client / network into an ErrorCode at
+// the source. Non-axios errors fall through to message-based matching.
+export const classifyError = (err: unknown): ErrorCode => {
+  if (isAxiosError(err)) {
+    if (
+      err.code === 'ECONNABORTED' ||
+      err.code === 'ETIMEDOUT' ||
+      err.code === 'ESOCKETTIMEDOUT'
+    ) {
+      return 'REQUEST_TIMEOUT';
+    }
+    if (!err.response) {
+      // Connection refused, DNS failure, etc.
+      return 'NETWORK_ERROR';
+    }
+    const status = err.response.status;
+    if (status === 401 || status === 403) {
+      return 'AUTH_FAILED';
+    }
+    if (status === 404) {
+      return 'NOT_FOUND';
+    }
+    if (status === 409) {
+      return 'CONFLICT';
+    }
+    if (status === 429) {
+      return 'RATE_LIMIT';
+    }
+    return 'API_ERROR';
+  }
+  if (err instanceof Error) {
+    return matchErrorCode(err.message);
   }
   return 'UNKNOWN_ERROR';
 };

--- a/src/help.ts
+++ b/src/help.ts
@@ -177,9 +177,17 @@ const formatHelp = (help: string) => {
   return [...result, ...lines];
 };
 
+const EXIT_CODES_LINE =
+  'Exit codes: 0 ok | 2 usage | 3 auth | 4 not-found | 5 conflict | 6 rate-limit | 7 network/timeout | 1 unknown';
+
 export const showHelp = async (argv: yargs.Argv) => {
   // add wrap to ensure that there are no line breaks
   const help = await argv.getHelp();
-  process.stderr.write(formatHelp(help).join('\n') + '\n');
+  const lines = formatHelp(help);
+  // Surface the exit-code contract on every --help screen (root and sub-
+  // commands) so agents reading help on first contact learn it without
+  // needing to find the README. Documented in README under "Exit codes".
+  lines.push('', EXIT_CODES_LINE);
+  process.stderr.write(lines.join('\n') + '\n');
   process.exit(0);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import {
   trackEvent,
 } from './analytics.js';
 import { isAxiosError } from 'axios';
-import { matchErrorCode } from './errors.js';
+import { classifyError, ErrorCode, exitCodeForError } from './errors.js';
 import { showHelp } from './help.js';
 import { currentContextFile, enrichFromContext } from './context.js';
 
@@ -166,7 +166,12 @@ builder = builder
   .wrap(null)
   .fail(false);
 
-async function handleError(msg: string, err: unknown): Promise<boolean> {
+type HandleErrorResult = { retry: boolean; code: ErrorCode };
+
+async function handleError(
+  msg: string,
+  err: unknown,
+): Promise<HandleErrorResult> {
   if (process.argv.some((arg) => arg === '--help' || arg === '-h')) {
     await showHelp(builder);
     process.exit(0);
@@ -177,44 +182,51 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
     log.debug('Stack: %s', err.stack);
   }
 
+  const code = classifyError(err);
+
   if (isAxiosError(err)) {
-    if (err.code === 'ECONNABORTED') {
+    if (code === 'REQUEST_TIMEOUT') {
       log.error('Request timed out');
-      sendError(err, 'REQUEST_TIMEOUT');
-      return false;
-    } else if (err.response?.status === 401) {
-      sendError(err, 'AUTH_FAILED');
+      sendError(err, code);
+      return { retry: false, code };
+    }
+    // Only HTTP 401 indicates stale/invalid credentials worth wiping.
+    // 403 (also AUTH_FAILED for exit-code purposes) means the user is
+    // authenticated but lacks permission for the resource — deleting
+    // credentials would not help.
+    if (err.response?.status === 401) {
+      sendError(err, code);
       log.info('Authentication failed, deleting credentials...');
       try {
         deleteCredentials(defaultDir);
-        return true; // Allow retry for auth failures
+        return { retry: true, code };
       } catch (deleteErr) {
         log.debug(
           'Failed to delete credentials: %s',
           deleteErr instanceof Error ? deleteErr.message : 'unknown error',
         );
-        return false;
+        return { retry: false, code };
       }
-    } else {
-      if (err.response?.data?.message) {
-        log.error(err.response?.data?.message);
-      }
-      log.debug(
-        'status: %d %s | path: %s',
-        err.response?.status,
-        err.response?.statusText,
-        err.request?.path,
-      );
-      sendError(err, 'API_ERROR');
-      return false;
     }
-  } else {
-    const error =
-      err instanceof Error ? err : new Error(msg || 'Unknown error');
-    sendError(error, matchErrorCode(error.message));
-    log.error(error.message);
-    return false;
+    if (err.response?.data?.message) {
+      log.error(err.response.data.message);
+    } else if (code === 'NETWORK_ERROR') {
+      log.error(err.message);
+    }
+    log.debug(
+      'status: %d %s | path: %s',
+      err.response?.status,
+      err.response?.statusText,
+      err.request?.path,
+    );
+    sendError(err, code);
+    return { retry: false, code };
   }
+
+  const error = err instanceof Error ? err : new Error(msg || 'Unknown error');
+  sendError(error, code);
+  log.error(error.message);
+  return { retry: false, code };
 }
 
 void (async () => {
@@ -244,12 +256,12 @@ void (async () => {
       break;
     } catch (err) {
       attempts++;
-      const shouldRetry = await handleError('', err);
-      if (!shouldRetry || attempts >= MAX_ATTEMPTS) {
+      const { retry, code } = await handleError('', err);
+      if (!retry || attempts >= MAX_ATTEMPTS) {
         await closeAnalytics();
-        process.exit(1);
+        process.exit(exitCodeForError(code));
       }
-      // If shouldRetry is true and we haven't hit max attempts, loop continues
+      // If retry is true and we haven't hit max attempts, loop continues
     }
   }
 })();


### PR DESCRIPTION
## Why

Today every `neonctl` failure exits `1`. A shell script or coding agent that wants to react differently to "not found" vs "auth failed" vs "rate-limited" has to string-parse a human error message, which breaks the first time we edit the message.

We don't have telemetry proving heavy agent traffic on `neonctl` today — this is an investment in being the *most* agent-friendly DB CLI rather than a fix for an observed pain. The bet: as agents get more autonomy in CI and remote-runner contexts, the CLI's machine contract is what they'll lean on. The CLI is also the only production-grade agent surface Neon ships — our own MCP docs say *"Use MCP only for local development or IDE-based workflows ... Never connect MCP agents to production databases"* ([neon.com/docs/ai/neon-mcp-server](https://neon.com/docs/ai/neon-mcp-server)) — so anything an agent does against Neon from CI or a remote runner has to go through this binary.

The peer comparison is interesting. They don't, mostly:

- `gh` documents [4 exit codes](https://cli.github.com/manual/gh_help_exit-codes) (0, 1, 2 for cancelled, 4 for auth) and notes the list is non-exhaustive.
- `gcloud`'s [scripting docs](https://docs.cloud.google.com/sdk/docs/scripting-gcloud) say only "non-zero on error".
- `kubectl`, Stripe CLI, Supabase CLI — no documented granular contract.

So this is closer to "going first" than "catching up".

## What

Map errors to a typed `ErrorCode` at the source (HTTP status for axios, regex/prefix for yargs usage) and exit with a documented code.

| Exit | Meaning                                                    |
| :--- | :--------------------------------------------------------- |
| `0`  | Success                                                    |
| `1`  | Generic / unclassified error                               |
| `2`  | Usage error (unknown command, missing or invalid argument) |
| `3`  | Authentication or authorization failed (HTTP 401, 403)     |
| `4`  | Resource not found (HTTP 404)                              |
| `5`  | Conflict (HTTP 409)                                        |
| `6`  | Rate limited (HTTP 429)                                    |
| `7`  | Network error or request timeout                           |

The contract is documented in `README.md` and surfaced on **every** `--help` screen (root, subcommand, sub-subcommand) so an agent learns it on first contact without finding the README:

```
$ neon projects --help
...
Exit codes: 0 ok | 2 usage | 3 auth | 4 not-found | 5 conflict | 6 rate-limit | 7 network/timeout | 1 unknown
```

### Behavior changes (intentional)

- API 404 → exit 4 (was 1).
- API 401 → exit 3 (was 1). Credential-delete-and-retry preserved.
- API 403 → exit 3 (was 1). Does **not** delete local credentials anymore — the user is authenticated and just lacks permission on the resource; wiping the key would not help and was an over-reach.

## Scope

Smallest shippable piece of a broader error-foundation effort. Follow-ups, separate PRs:

- Include the code name in stderr (`ERROR [NOT_FOUND]: ...`) so the agent can pick the contract up purely from the error response.
- Structured JSON error envelope on stderr when `-o json` is active.
- Request-ID propagation (the `x-neon-ret-request-id` header is already pulled into analytics — surface it on the user-facing output too).
- Replacing the residual regex-based `matchErrorCode` with source-classified codes on every error path.
- Adding the exit-code table to `llms.txt` and to a managed `AGENTS.md` block (planned in the broader agent-readiness work).

## Test plan

- [x] `bun run lint` — green
- [x] `bun run test` — 177/177 pass, including new `src/errors.test.ts` and updated `set_context.test.ts` for the 404 → 4 change
- [x] `bun run typecheck` — green
- [x] `neon totally-not-a-command; echo $?` → `2`
- [x] `neon --help`, `neon projects --help`, `neon projects list --help` all end with the exit-codes line

Live-API checks for 401/403/404 skipped because the 401 path wipes `~/.config/neonctl/credentials.json`; unit tests cover all three.