### PR TITLE
feat: add link command for Vercel-style project linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ bundle/
 .vscode
 .idea
 .neon
+.env
+.env.local
+.env.*.local
 coverage
 tmp/
 .history

--- a/README.md
+++ b/README.md
@@ -62,6 +62,86 @@ For information about obtaining an Neon API key, see [Authentication](https://ap
 
 The Neon CLI supports autocompletion, which you can configure in a few easy steps. See [Neon CLI commands — completion](https://neon.tech/docs/reference/cli-completion) for instructions.
 
+## Linking a project
+
+`neonctl link` is a Vercel-style command that binds the current directory to a Neon project. It picks (or creates) an organization, picks (or creates) a project, resolves the project's default branch, and writes a `.neon` file with `{ "orgId", "projectId", "branchId" }`. Subsequent commands run in this directory (or any sub-directory) automatically pick up that context.
+
+There are three modes:
+
+**Interactive (default)** — guided prompts for humans:
+
+```bash
+$ neonctl link
+? Which organization would you like to link? › Personal Org (org-abc123)
+? Which project would you like to link? › + Create new project
+? Name for the new project: › my-app
+? Which region should the new project run in? › AWS US East (Ohio) (aws-us-east-2)
+Created project polished-snowflake-12345678 ("my-app") in aws-us-east-2.
+Linked .neon:
+  orgId:    org-abc123
+  projectId: polished-snowflake-12345678
+  branchId:  br-main-branch-87654321
+```
+
+**Non-interactive (flags or `--params` JSON)** — for scripts and CI:
+
+```bash
+# Link to an existing project
+neonctl link --org-id org-abc123 --project-id polished-snowflake-12345678
+
+# Create a new project and link
+neonctl link --org-id org-abc123 --project-name my-app --region-id aws-us-east-2
+
+# Same payload, one JSON blob
+neonctl link --params '{"orgId":"org-abc123","projectName":"my-app","regionId":"aws-us-east-2"}'
+```
+
+**Agent mode (`--agent`)** — a JSON state machine designed for AI coding assistants. Each invocation returns a single JSON object with a `status` discriminator describing the next step, the available options, and the exact follow-up command to run.
+
+```bash
+$ neonctl link --agent
+{
+  "status": "needs_org",
+  "instruction": "Ask the user which of these 2 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
+  "options": [
+    { "id": "org-abc123", "name": "Personal Org" },
+    { "id": "org-team",   "name": "Team Org" }
+  ],
+  "next_command_template": "neonctl link --agent --org-id <org_id>"
+}
+
+$ neonctl link --agent --org-id org-abc123
+{
+  "status": "needs_project",
+  "instruction": "Ask the user whether to link to one of these 1 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
+  "options": [
+    { "id": "polished-snowflake-12345678", "name": "my-app" }
+  ],
+  "create_option": {
+    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
+    "next_command_template": "neonctl link --agent --org-id org-abc123 --project-name <name> --region-id <region_id>"
+  },
+  "next_command_template": "neonctl link --agent --org-id org-abc123 --project-id <project_id>"
+}
+
+$ neonctl link --agent --org-id org-abc123 --project-id polished-snowflake-12345678
+{
+  "status": "linked",
+  "context_file": "/path/to/cwd/.neon",
+  "context": {
+    "orgId": "org-abc123",
+    "projectId": "polished-snowflake-12345678",
+    "branchId": "br-main-branch-87654321"
+  },
+  "project": { "id": "polished-snowflake-12345678" },
+  "message": "Linked /path/to/cwd/.neon to project polished-snowflake-12345678 (org org-abc123) on branch br-main-branch-87654321."
+}
+```
+
+The agent flow also handles project creation. If the agent sends `--project-name` without `--region-id`, the next response is `needs_project_details` with the list of supported regions.
+
+`link` is a thin wrapper around `set-context`: both write to the same `.neon` file via a shared `applyContext` helper, so anything `link` can write, `set-context` can write too (including the newly-supported `--branch-id` flag).
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                 | Description                    |
@@ -77,6 +157,7 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 | [connection-string](https://neon.com/docs/reference/cli-connection-string) |                                                                                             | Get connection string          |
 | psql                                                                       |                                                                                             | Connect to a database via psql |
 | [set-context](https://neon.com/docs/reference/cli-set-context)             |                                                                                             | Set context for session        |
+| [link](https://neon.com/docs/reference/cli-link)                           |                                                                                             | Link a directory to a project  |
 | [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                             | Generate a completion script   |
 
 ## Global options

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ $ neonctl link --agent --org-id org-abc123 --project-id polished-snowflake-12345
 
 The agent flow also handles project creation. If the agent sends `--project-name` without `--region-id`, the next response is `needs_project_details` with the list of supported regions.
 
+**Organization-scoped API keys** (those created at the organization level rather than the user level) cannot list user organizations or call the regions endpoint. `link` handles this transparently:
+
+- If the API key is org-scoped and at least one project already exists in the org, the CLI auto-detects the `org_id` from the first project. In interactive mode it prints an informational message; in `--agent` mode it skips straight to `needs_project`.
+- If the API key is org-scoped and no projects exist yet, `--agent` returns a `needs_org` response with `options: []` and an instruction telling the user to find their org ID in the Neon Console. Interactive mode prints an error pointing to `--org-id`.
+- When the regions endpoint is not allowed, `link` falls back to a built-in static region list.
+
+**Agent error contract**: any unexpected failure in `--agent` mode is reported as JSON to stdout with exit code 1, so agents can always parse the response:
+
+```json
+{
+  "status": "error",
+  "code": "CLIENT_ERROR",
+  "message": "user has no access to projects"
+}
+```
+
 `link` is a thin wrapper around `set-context`: both write to the same `.neon` file via a shared `applyContext` helper, so anything `link` can write, `set-context` can write too (including the newly-supported `--branch-id` flag).
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The agent flow also handles project creation. If the agent sends `--project-name
 
 **Where `.neon` lives**: `link` (and `set-context`) write `.neon` into the **current working directory** by default. If an existing `.neon` is found in any parent directory, that file is reused — so commands run from a sub-directory of a linked project still pick up the project's context. To pin the location explicitly, pass `--context-file <path>`.
 
+**`.gitignore` scaffolding**: whenever `.neon` is written, the CLI also makes sure a `.gitignore` sits alongside it listing `.neon`. If `.gitignore` doesn't exist it's created with a single `.neon` line; if it does exist, `.neon` is appended only when missing (no duplicates, your other entries are left alone).
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                 | Description                    |

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The agent flow also handles project creation. If the agent sends `--project-name
 
 `link` is a thin wrapper around `set-context`: both write to the same `.neon` file via a shared `applyContext` helper, so anything `link` can write, `set-context` can write too (including the newly-supported `--branch-id` flag).
 
+**Where `.neon` lives**: `link` (and `set-context`) write `.neon` into the **current working directory** by default. If an existing `.neon` is found in any parent directory, that file is reused — so commands run from a sub-directory of a linked project still pick up the project's context. To pin the location explicitly, pass `--context-file <path>`.
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                 | Description                    |

--- a/mocks/main/regions/GET.js
+++ b/mocks/main/regions/GET.js
@@ -1,0 +1,34 @@
+export default function (_req, res) {
+  res.json({
+    regions: [
+      {
+        region_id: 'aws-us-east-2',
+        name: 'AWS US East (Ohio)',
+        default: true,
+        geo_lat: '40.0',
+        geo_long: '-83.0',
+      },
+      {
+        region_id: 'aws-us-east-1',
+        name: 'AWS US East (N. Virginia)',
+        default: false,
+        geo_lat: '37.5',
+        geo_long: '-77.5',
+      },
+      {
+        region_id: 'aws-us-west-2',
+        name: 'AWS US West (Oregon)',
+        default: false,
+        geo_lat: '45.5',
+        geo_long: '-122.7',
+      },
+      {
+        region_id: 'aws-eu-central-1',
+        name: 'AWS Europe (Frankfurt)',
+        default: false,
+        geo_lat: '50.1',
+        geo_long: '8.7',
+      },
+    ],
+  });
+}

--- a/mocks/org-key-empty/projects/GET.js
+++ b/mocks/org-key-empty/projects/GET.js
@@ -1,0 +1,3 @@
+export default function (_req, res) {
+  res.json({ projects: [] });
+}

--- a/mocks/org-key-empty/users/me/organizations/GET.js
+++ b/mocks/org-key-empty/users/me/organizations/GET.js
@@ -1,0 +1,6 @@
+export default function (_req, res) {
+  res.status(403).json({
+    code: '',
+    message: 'not allowed for organization API keys',
+  });
+}

--- a/mocks/org-key/projects/GET.js
+++ b/mocks/org-key/projects/GET.js
@@ -1,0 +1,14 @@
+export default function (_req, res) {
+  res.json({
+    projects: [
+      {
+        id: 'detected-project-12345',
+        name: 'detected_project',
+        region_id: 'aws-us-east-2',
+        org_id: 'org-detected-99887766',
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z',
+      },
+    ],
+  });
+}

--- a/mocks/org-key/projects/detected-project-12345/branches/GET.json
+++ b/mocks/org-key/projects/detected-project-12345/branches/GET.json
@@ -1,0 +1,13 @@
+{
+  "annotations": {},
+  "branches": [
+    {
+      "id": "br-detected-default-12345",
+      "name": "main",
+      "default": true,
+      "created_at": "2024-01-01T00:00:00.000Z",
+      "updated_at": "2024-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    }
+  ]
+}

--- a/mocks/org-key/regions/GET.js
+++ b/mocks/org-key/regions/GET.js
@@ -1,0 +1,6 @@
+export default function (_req, res) {
+  res.status(403).json({
+    code: '',
+    message: 'not allowed for organization API keys',
+  });
+}

--- a/mocks/org-key/users/me/organizations/GET.js
+++ b/mocks/org-key/users/me/organizations/GET.js
@@ -1,0 +1,6 @@
+export default function (_req, res) {
+  res.status(403).json({
+    code: '',
+    message: 'not allowed for organization API keys',
+  });
+}

--- a/src/commands/__snapshots__/link.test.ts.snap
+++ b/src/commands/__snapshots__/link.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`link > --agent mode > with full project details creates project and emits linked JSON 1`] = `
 "{
   "status": "linked",
-  "context_file": "<TMP>/agent_linked_create.neon",
+  "context_file": "<TMP>/agent_linked_create/.neon",
   "context": {
     "orgId": "org-2",
     "projectId": "new-project-789012",
@@ -13,7 +13,7 @@ exports[`link > --agent mode > with full project details creates project and emi
     "id": "new-project-789012",
     "name": "test_project"
   },
-  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create.neon."
+  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create/.neon."
 }
 "
 `;
@@ -79,7 +79,7 @@ exports[`link > --agent mode > with only --org-id emits needs_project JSON 1`] =
 exports[`link > --agent mode > with org+project emits linked JSON and writes .neon 1`] = `
 "{
   "status": "linked",
-  "context_file": "<TMP>/agent_linked_existing.neon",
+  "context_file": "<TMP>/agent_linked_existing/.neon",
   "context": {
     "orgId": "org-2",
     "projectId": "test",
@@ -88,7 +88,7 @@ exports[`link > --agent mode > with org+project emits linked JSON and writes .ne
   "project": {
     "id": "test"
   },
-  "message": "Linked <TMP>/agent_linked_existing.neon to project test (org org-2) on branch br-main-branch-123456."
+  "message": "Linked <TMP>/agent_linked_existing/.neon to project test (org org-2) on branch br-main-branch-123456."
 }
 "
 `;
@@ -132,11 +132,40 @@ exports[`link > --agent mode > with org+projectName but no region emits needs_pr
 "
 `;
 
+exports[`link > gitignore scaffolding > appends .neon to an existing .gitignore without duplicating 1`] = `
+"Linked <TMP>/gi_appends/.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > gitignore scaffolding > appends .neon to an existing .gitignore without duplicating 2`] = `
+"Linked <TMP>/gi_appends/.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > gitignore scaffolding > creates a .gitignore listing .neon next to the context file 1`] = `
+"Linked <TMP>/gi_creates/.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > gitignore scaffolding > set-context also scaffolds .gitignore via the shared applyContext 1`] = `""`;
+
 exports[`link > non-interactive flag mode > conflicting inputs (--project-id with --project-name) fails 1`] = `""`;
 
 exports[`link > non-interactive flag mode > link creates a new project and writes .neon 1`] = `
 "Created project new-project-789012 ("test_project").
-Linked <TMP>/flag_create.neon:
+Linked <TMP>/flag_create/.neon:
   orgId:    org-2
   projectId: new-project-789012
   branchId:  br-test-branch-789012
@@ -153,7 +182,7 @@ exports[`link > non-interactive flag mode > link creates a new project and write
 `;
 
 exports[`link > non-interactive flag mode > link to existing project writes .neon with default branch id 1`] = `
-"Linked <TMP>/flag_existing.neon:
+"Linked <TMP>/flag_existing/.neon:
   orgId:    org-2
   projectId: test
   branchId:  br-main-branch-123456
@@ -170,7 +199,7 @@ exports[`link > non-interactive flag mode > link to existing project writes .neo
 `;
 
 exports[`link > non-interactive flag mode > link with --params JSON behaves like flags 1`] = `
-"Linked <TMP>/flag_params.neon:
+"Linked <TMP>/flag_params/.neon:
   orgId:    org-2
   projectId: test
   branchId:  br-main-branch-123456
@@ -263,7 +292,7 @@ exports[`link > org-scoped API key behavior > agent mode with no orgs available 
 `;
 
 exports[`link > overwrites an existing .neon when re-linking non-interactively 1`] = `
-"Linked <TMP>/overwrite.neon:
+"Linked <TMP>/overwrite/.neon:
   orgId:    org-2
   projectId: test
   branchId:  br-main-branch-123456

--- a/src/commands/__snapshots__/link.test.ts.snap
+++ b/src/commands/__snapshots__/link.test.ts.snap
@@ -186,6 +186,82 @@ exports[`link > non-interactive flag mode > link with --params JSON behaves like
 }"
 `;
 
+exports[`link > org-scoped API key behavior > agent mode auto-detects org from existing projects when org listing is forbidden 1`] = `
+"{
+  "status": "needs_project",
+  "instruction": "Ask the user whether to link to one of these 1 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
+  "options": [
+    {
+      "id": "detected-project-12345",
+      "name": "detected_project",
+      "region_id": "aws-us-east-2"
+    }
+  ],
+  "create_option": {
+    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
+    "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-name <name> --region-id <region_id>"
+  },
+  "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-id <project_id>"
+}
+"
+`;
+
+exports[`link > org-scoped API key behavior > agent mode falls back to static regions when getActiveRegions is forbidden 1`] = `
+"{
+  "status": "needs_project_details",
+  "instruction": "Ask the user which region to create project \\"whatever\\" in. After they pick one, re-run the next_command_template with the chosen --region-id value.",
+  "regions": [
+    {
+      "id": "aws-us-west-2",
+      "name": "aws-us-west-2",
+      "default": false
+    },
+    {
+      "id": "aws-ap-southeast-1",
+      "name": "aws-ap-southeast-1",
+      "default": false
+    },
+    {
+      "id": "aws-ap-southeast-2",
+      "name": "aws-ap-southeast-2",
+      "default": false
+    },
+    {
+      "id": "aws-eu-central-1",
+      "name": "aws-eu-central-1",
+      "default": false
+    },
+    {
+      "id": "aws-us-east-2",
+      "name": "aws-us-east-2",
+      "default": true
+    },
+    {
+      "id": "aws-us-east-1",
+      "name": "aws-us-east-1",
+      "default": false
+    },
+    {
+      "id": "azure-eastus2",
+      "name": "azure-eastus2",
+      "default": false
+    }
+  ],
+  "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-name whatever --region-id <region_id>"
+}
+"
+`;
+
+exports[`link > org-scoped API key behavior > agent mode with no orgs available and no projects emits orgKeyLimited needs_org 1`] = `
+"{
+  "status": "needs_org",
+  "instruction": "This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like \`org-bitter-breeze-12345678\`) and re-run the next_command_template with that --org-id.",
+  "options": [],
+  "next_command_template": "neonctl link --agent --org-id <org_id>"
+}
+"
+`;
+
 exports[`link > overwrites an existing .neon when re-linking non-interactively 1`] = `
 "Linked <TMP>/overwrite.neon:
   orgId:    org-2

--- a/src/commands/__snapshots__/link.test.ts.snap
+++ b/src/commands/__snapshots__/link.test.ts.snap
@@ -1,0 +1,213 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`link > --agent mode > with full project details creates project and emits linked JSON 1`] = `
+"{
+  "status": "linked",
+  "context_file": "<TMP>/agent_linked_create.neon",
+  "context": {
+    "orgId": "org-2",
+    "projectId": "new-project-789012",
+    "branchId": "br-test-branch-789012"
+  },
+  "project": {
+    "id": "new-project-789012",
+    "name": "test_project"
+  },
+  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create.neon."
+}
+"
+`;
+
+exports[`link > --agent mode > with full project details creates project and emits linked JSON 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "new-project-789012",
+  "branchId": "br-test-branch-789012"
+}"
+`;
+
+exports[`link > --agent mode > with no flags emits needs_org JSON 1`] = `
+"{
+  "status": "needs_org",
+  "instruction": "Ask the user which of these 3 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
+  "options": [
+    {
+      "id": 1,
+      "name": "Organization 1"
+    },
+    {
+      "id": 2,
+      "name": "Organization 2"
+    },
+    {
+      "id": 3,
+      "name": "Organization 3"
+    }
+  ],
+  "next_command_template": "neonctl link --agent --org-id <org_id>"
+}
+"
+`;
+
+exports[`link > --agent mode > with only --org-id emits needs_project JSON 1`] = `
+"{
+  "status": "needs_project",
+  "instruction": "Ask the user whether to link to one of these 3 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
+  "options": [
+    {
+      "id": 4,
+      "name": "Project_4"
+    },
+    {
+      "id": 5,
+      "name": "Project_5"
+    },
+    {
+      "id": 6,
+      "name": "Project_6"
+    }
+  ],
+  "create_option": {
+    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
+    "next_command_template": "neonctl link --agent --org-id org-2 --project-name <name> --region-id <region_id>"
+  },
+  "next_command_template": "neonctl link --agent --org-id org-2 --project-id <project_id>"
+}
+"
+`;
+
+exports[`link > --agent mode > with org+project emits linked JSON and writes .neon 1`] = `
+"{
+  "status": "linked",
+  "context_file": "<TMP>/agent_linked_existing.neon",
+  "context": {
+    "orgId": "org-2",
+    "projectId": "test",
+    "branchId": "br-main-branch-123456"
+  },
+  "project": {
+    "id": "test"
+  },
+  "message": "Linked <TMP>/agent_linked_existing.neon to project test (org org-2) on branch br-main-branch-123456."
+}
+"
+`;
+
+exports[`link > --agent mode > with org+project emits linked JSON and writes .neon 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "test",
+  "branchId": "br-main-branch-123456"
+}"
+`;
+
+exports[`link > --agent mode > with org+projectName but no region emits needs_project_details JSON 1`] = `
+"{
+  "status": "needs_project_details",
+  "instruction": "Ask the user which region to create project \\"demo\\" in. After they pick one, re-run the next_command_template with the chosen --region-id value.",
+  "regions": [
+    {
+      "id": "aws-us-east-2",
+      "name": "AWS US East (Ohio)",
+      "default": true
+    },
+    {
+      "id": "aws-us-east-1",
+      "name": "AWS US East (N. Virginia)",
+      "default": false
+    },
+    {
+      "id": "aws-us-west-2",
+      "name": "AWS US West (Oregon)",
+      "default": false
+    },
+    {
+      "id": "aws-eu-central-1",
+      "name": "AWS Europe (Frankfurt)",
+      "default": false
+    }
+  ],
+  "next_command_template": "neonctl link --agent --org-id org-2 --project-name demo --region-id <region_id>"
+}
+"
+`;
+
+exports[`link > non-interactive flag mode > conflicting inputs (--project-id with --project-name) fails 1`] = `""`;
+
+exports[`link > non-interactive flag mode > link creates a new project and writes .neon 1`] = `
+"Created project new-project-789012 ("test_project").
+Linked <TMP>/flag_create.neon:
+  orgId:    org-2
+  projectId: new-project-789012
+  branchId:  br-test-branch-789012
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link creates a new project and writes .neon 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "new-project-789012",
+  "branchId": "br-test-branch-789012"
+}"
+`;
+
+exports[`link > non-interactive flag mode > link to existing project writes .neon with default branch id 1`] = `
+"Linked <TMP>/flag_existing.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link to existing project writes .neon with default branch id 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "test",
+  "branchId": "br-main-branch-123456"
+}"
+`;
+
+exports[`link > non-interactive flag mode > link with --params JSON behaves like flags 1`] = `
+"Linked <TMP>/flag_params.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link with --params JSON behaves like flags 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "test",
+  "branchId": "br-main-branch-123456"
+}"
+`;
+
+exports[`link > overwrites an existing .neon when re-linking non-interactively 1`] = `
+"Linked <TMP>/overwrite.neon:
+  orgId:    org-2
+  projectId: test
+  branchId:  br-main-branch-123456
+
+"
+`;
+
+exports[`link > overwrites an existing .neon when re-linking non-interactively 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "test",
+  "branchId": "br-main-branch-123456"
+}"
+`;
+
+exports[`link > set-context regression > set-context --branch-id writes branchId to .neon 1`] = `""`;
+
+exports[`link > set-context regression > set-context --branch-id writes branchId to .neon 2`] = `
+"{
+  "projectId": "test_project",
+  "branchId": "br-main-branch-123456"
+}"
+`;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,6 +11,7 @@ import * as operations from './operations.js';
 import * as cs from './connection_string.js';
 import * as psql from './psql.js';
 import * as setContext from './set_context.js';
+import * as link from './link.js';
 import * as init from './init.js';
 import * as dataApi from './data_api.js';
 
@@ -28,6 +29,7 @@ export default [
   cs,
   psql,
   setContext,
+  link,
   init,
   dataApi,
 ];

--- a/src/commands/link.test.ts
+++ b/src/commands/link.test.ts
@@ -1,0 +1,345 @@
+import { fork } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeAll, describe, expect } from 'vitest';
+
+import { test as originalTest } from '../test_utils/fixtures';
+
+// All tests in this file share a single temporary directory whose path is
+// normalized in snapshots to `<TMP>` so that absolute paths in command output
+// (both human summaries and agent JSON) remain stable across runs and machines.
+const TEST_TMP = mkdtempSync(join(tmpdir(), 'neonctl-link-'));
+
+const TMP_TOKEN = '<TMP>';
+
+beforeAll(() => {
+  // Replace any reference to the per-run tmp directory with a stable token so
+  // snapshots only carry the deterministic suffix portion of paths.
+  expect.addSnapshotSerializer({
+    test: (val) => typeof val === 'string' && val.includes(TEST_TMP),
+    serialize: (val, config, indentation, depth, refs, printer) =>
+      printer(
+        (val as string).split(TEST_TMP).join(TMP_TOKEN),
+        config,
+        indentation,
+        depth,
+        refs,
+      ),
+  });
+});
+
+const test = originalTest.extend<{
+  cleanupFile: (name: string) => void;
+  readFile: (name: string) => string;
+  removeFile: (name: string) => void;
+  tmpContext: (label: string) => string;
+  runLinkInCi: (args: string[]) => Promise<{
+    code: number;
+    stdout: string;
+    stderr: string;
+  }>;
+}>({
+  // eslint-disable-next-line no-empty-pattern
+  cleanupFile: async ({}, use) => {
+    let writtenFilename: string | undefined;
+    await use((name) => (writtenFilename = name));
+    if (writtenFilename) {
+      try {
+        rmSync(writtenFilename);
+      } catch {
+        // ignore
+      }
+    }
+  },
+  readFile: async ({ cleanupFile }, use) => {
+    await use((name) => {
+      const content = readFileSync(name, 'utf-8');
+      cleanupFile(name);
+      return content;
+    });
+  },
+  // eslint-disable-next-line no-empty-pattern
+  removeFile: async ({}, use) => {
+    await use((name) => {
+      try {
+        rmSync(name);
+      } catch {
+        // ignore
+      }
+    });
+  },
+  // eslint-disable-next-line no-empty-pattern
+  tmpContext: async ({}, use) => {
+    await use((label) => join(TEST_TMP, `${label}.neon`));
+  },
+  runLinkInCi: async ({ runMockServer }, use) => {
+    await use(async (args) => {
+      const server = await runMockServer('main');
+      const port = (server.address() as AddressInfo).port;
+      return new Promise((resolve, reject) => {
+        const cp = fork(
+          join(process.cwd(), './dist/index.js'),
+          [
+            '--api-host',
+            `http://localhost:${port}`,
+            '--output',
+            'yaml',
+            '--api-key',
+            'test-key',
+            '--no-analytics',
+            ...args,
+          ],
+          {
+            stdio: 'pipe',
+            env: {
+              PATH: `mocks/bin:${process.env.PATH}`,
+              CI: 'true',
+            },
+          },
+        );
+        let stdout = '';
+        let stderr = '';
+        cp.stdout?.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+        cp.stderr?.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+        cp.on('error', reject);
+        cp.on('close', (code) => {
+          resolve({ code: code ?? -1, stdout, stderr });
+        });
+      });
+    });
+  },
+});
+
+describe('link', () => {
+  describe('non-interactive flag mode', () => {
+    test('link to existing project writes .neon with default branch id', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('flag_existing');
+      await testCliCommand([
+        'link',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+
+    test('link with --params JSON behaves like flags', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('flag_params');
+      await testCliCommand([
+        'link',
+        '--params',
+        JSON.stringify({ orgId: 'org-2', projectId: 'test' }),
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+
+    test('link creates a new project and writes .neon', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('flag_create');
+      await testCliCommand([
+        'link',
+        '--org-id',
+        'org-2',
+        '--project-name',
+        'test_project',
+        '--region-id',
+        'aws-us-east-2',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+
+    test('conflicting inputs (--project-id with --project-name) fails', async ({
+      testCliCommand,
+      tmpContext,
+    }) => {
+      await testCliCommand(
+        [
+          'link',
+          '--org-id',
+          'org-2',
+          '--project-id',
+          'test',
+          '--project-name',
+          'test_project',
+          '--context-file',
+          tmpContext('flag_conflict'),
+        ],
+        {
+          code: 1,
+          stderr:
+            'ERROR: Conflicting inputs: --project-id selects an existing project; --project-name and --region-id describe a new one. Pass only one set.',
+        },
+      );
+    });
+  });
+
+  describe('--agent mode', () => {
+    test('with no flags emits needs_org JSON', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('agent_needs_org');
+      await testCliCommand(['link', '--agent', '--context-file', ctx]);
+      removeFile(ctx);
+    });
+
+    test('with only --org-id emits needs_project JSON', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('agent_needs_project');
+      await testCliCommand([
+        'link',
+        '--agent',
+        '--org-id',
+        'org-2',
+        '--context-file',
+        ctx,
+      ]);
+      removeFile(ctx);
+    });
+
+    test('with org+project emits linked JSON and writes .neon', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('agent_linked_existing');
+      await testCliCommand([
+        'link',
+        '--agent',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+
+    test('with org+projectName but no region emits needs_project_details JSON', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('agent_needs_region');
+      await testCliCommand([
+        'link',
+        '--agent',
+        '--org-id',
+        'org-2',
+        '--project-name',
+        'demo',
+        '--context-file',
+        ctx,
+      ]);
+      removeFile(ctx);
+    });
+
+    test('with full project details creates project and emits linked JSON', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('agent_linked_create');
+      await testCliCommand([
+        'link',
+        '--agent',
+        '--org-id',
+        'org-2',
+        '--project-name',
+        'test_project',
+        '--region-id',
+        'aws-us-east-2',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+  });
+
+  describe('CI guard', () => {
+    test('errors out with helpful message when no inputs provided in CI', async ({
+      runLinkInCi,
+      tmpContext,
+    }) => {
+      const result = await runLinkInCi([
+        'link',
+        '--context-file',
+        tmpContext('ci_guard'),
+      ]);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain('CI environment detected');
+      expect(result.stderr).toContain('neonctl link --agent');
+    });
+  });
+
+  describe('set-context regression', () => {
+    test('set-context --branch-id writes branchId to .neon', async ({
+      testCliCommand,
+      readFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('sc_branch');
+      await testCliCommand([
+        'set-context',
+        '--project-id',
+        'test_project',
+        '--branch-id',
+        'br-main-branch-123456',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFile(ctx)).toMatchSnapshot();
+    });
+  });
+
+  test('overwrites an existing .neon when re-linking non-interactively', async ({
+    testCliCommand,
+    readFile,
+    tmpContext,
+  }) => {
+    const ctx = tmpContext('overwrite');
+    writeFileSync(
+      ctx,
+      JSON.stringify({ orgId: 'old', projectId: 'old', branchId: 'old' }),
+    );
+    await testCliCommand([
+      'link',
+      '--org-id',
+      'org-2',
+      '--project-id',
+      'test',
+      '--context-file',
+      ctx,
+    ]);
+    expect(readFile(ctx)).toMatchSnapshot();
+  });
+});

--- a/src/commands/link.test.ts
+++ b/src/commands/link.test.ts
@@ -1,5 +1,11 @@
 import { fork } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -70,9 +76,16 @@ const test = originalTest.extend<{
       }
     });
   },
+  // Each test gets its OWN sub-directory under TEST_TMP so the
+  // `.gitignore` scaffolded next to the `.neon` written by one test doesn't
+  // affect another test in the same file.
   // eslint-disable-next-line no-empty-pattern
   tmpContext: async ({}, use) => {
-    await use((label) => join(TEST_TMP, `${label}.neon`));
+    await use((label) => {
+      const dir = join(TEST_TMP, label);
+      mkdirSync(dir, { recursive: true });
+      return join(dir, '.neon');
+    });
   },
   runLinkInCi: async ({ runMockServer }, use) => {
     await use(async (args) => {
@@ -440,5 +453,72 @@ describe('link', () => {
       ctx,
     ]);
     expect(readFile(ctx)).toMatchSnapshot();
+  });
+
+  describe('gitignore scaffolding', () => {
+    test('creates a .gitignore listing .neon next to the context file', async ({
+      testCliCommand,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('gi_creates');
+      await testCliCommand([
+        'link',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      const giPath = join(ctx, '..', '.gitignore');
+      expect(readFileSync(giPath, 'utf-8')).toBe('.neon\n');
+    });
+
+    test('appends .neon to an existing .gitignore without duplicating', async ({
+      testCliCommand,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('gi_appends');
+      const giPath = join(ctx, '..', '.gitignore');
+      writeFileSync(giPath, 'node_modules\ndist\n');
+      await testCliCommand([
+        'link',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFileSync(giPath, 'utf-8')).toBe('node_modules\ndist\n.neon\n');
+
+      // Re-link in the same dir must not produce a duplicate entry.
+      await testCliCommand([
+        'link',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      expect(readFileSync(giPath, 'utf-8')).toBe('node_modules\ndist\n.neon\n');
+    });
+
+    test('set-context also scaffolds .gitignore via the shared applyContext', async ({
+      testCliCommand,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('gi_set_context');
+      await testCliCommand([
+        'set-context',
+        '--project-id',
+        'test',
+        '--context-file',
+        ctx,
+      ]);
+      const giPath = join(ctx, '..', '.gitignore');
+      expect(readFileSync(giPath, 'utf-8')).toBe('.neon\n');
+    });
   });
 });

--- a/src/commands/link.test.ts
+++ b/src/commands/link.test.ts
@@ -285,6 +285,105 @@ describe('link', () => {
     });
   });
 
+  describe('org-scoped API key behavior', () => {
+    test('agent mode with no orgs available and no projects emits orgKeyLimited needs_org', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('orgkey_empty');
+      await testCliCommand(['link', '--agent', '--context-file', ctx], {
+        mockDir: 'org-key-empty',
+      });
+      removeFile(ctx);
+    });
+
+    test('agent mode auto-detects org from existing projects when org listing is forbidden', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('orgkey_autodetect');
+      await testCliCommand(['link', '--agent', '--context-file', ctx], {
+        mockDir: 'org-key',
+      });
+      removeFile(ctx);
+    });
+
+    test('agent mode falls back to static regions when getActiveRegions is forbidden', async ({
+      testCliCommand,
+      removeFile,
+      tmpContext,
+    }) => {
+      const ctx = tmpContext('orgkey_regions_fallback');
+      await testCliCommand(
+        [
+          'link',
+          '--agent',
+          '--org-id',
+          'org-detected-99887766',
+          '--project-name',
+          'whatever',
+          '--context-file',
+          ctx,
+        ],
+        { mockDir: 'org-key' },
+      );
+      removeFile(ctx);
+    });
+  });
+
+  describe('agent error responses', () => {
+    test('invalid --params JSON yields error JSON, exit 1', async ({
+      runLinkInCi,
+      tmpContext,
+    }) => {
+      const result = await runLinkInCi([
+        'link',
+        '--agent',
+        '--params',
+        'not-valid-json',
+        '--context-file',
+        tmpContext('agent_bad_params'),
+      ]);
+      expect(result.code).toBe(1);
+      const parsed = JSON.parse(result.stdout) as {
+        status: string;
+        code: string;
+        message: string;
+      };
+      expect(parsed.status).toBe('error');
+      expect(parsed.code).toBe('INTERNAL_ERROR');
+      expect(parsed.message).toContain('Failed to parse --params JSON');
+    });
+
+    test('conflicting flags in agent mode yields error JSON, exit 1', async ({
+      runLinkInCi,
+      tmpContext,
+    }) => {
+      const result = await runLinkInCi([
+        'link',
+        '--agent',
+        '--org-id',
+        'org-2',
+        '--project-id',
+        'test',
+        '--project-name',
+        'x',
+        '--context-file',
+        tmpContext('agent_conflict'),
+      ]);
+      expect(result.code).toBe(1);
+      const parsed = JSON.parse(result.stdout) as {
+        status: string;
+        code: string;
+        message: string;
+      };
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('Conflicting inputs');
+    });
+  });
+
   describe('CI guard', () => {
     test('errors out with helpful message when no inputs provided in CI', async ({
       runLinkInCi,

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -114,13 +114,13 @@ export const builder = (argv: yargs.Argv) =>
   });
 
 export const handler = async (props: LinkProps) => {
-  const inputs = parseInputs(props);
-  validateInputs(inputs);
-
   if (props.agent) {
-    await runAgent(props, inputs);
+    await runAgentSafely(props);
     return;
   }
+
+  const inputs = parseInputs(props);
+  validateInputs(inputs);
 
   if (hasEnoughForNonInteractive(inputs)) {
     await runNonInteractive(props, inputs);
@@ -256,7 +256,24 @@ const runInteractive = async (props: LinkProps, inputs: Inputs) => {
     await confirmRelinkIfNeeded(props);
   }
 
-  const orgId = inputs.orgId ?? (await promptOrg(props));
+  const orgResolution = await resolveOrg(props, inputs.orgId);
+  let orgId: string;
+  if (orgResolution.kind === 'resolved') {
+    orgId = orgResolution.orgId;
+    if (orgResolution.autoDetected) {
+      log.info(
+        `Detected organization ${orgId} from your existing projects (organization-scoped API key).`,
+      );
+    }
+  } else if (orgResolution.orgKeyLimited) {
+    throw new Error(
+      'This API key is organization-scoped, so the CLI cannot list your organizations, ' +
+        'and no existing project was found in this org to auto-detect the ID. ' +
+        'Re-run with `--org-id <your_org_id>` (find it in the Neon Console under Settings).',
+    );
+  } else {
+    orgId = await promptOrgFromList(orgResolution.orgs);
+  }
 
   if (inputs.projectId) {
     const branchId = await resolveDefaultBranchId(props, inputs.projectId);
@@ -363,8 +380,7 @@ const confirmRelinkIfNeeded = async (props: LinkProps): Promise<void> => {
   }
 };
 
-const promptOrg = async (props: LinkProps): Promise<string> => {
-  const orgs = await fetchOrganizations(props);
+const promptOrgFromList = async (orgs: Organization[]): Promise<string> => {
   if (!orgs.length) {
     throw new Error(
       `You don't belong to any organizations. Create one in the Neon Console first: https://console.neon.tech/`,
@@ -463,22 +479,26 @@ const promptRegion = async (props: LinkProps): Promise<string> => {
 // Agent mode (JSON state machine)
 // ----------------------------------------------------------------------------
 
-const runAgent = async (props: LinkProps, inputs: Inputs) => {
-  const { orgId, projectId, projectName, regionId } = inputs;
+const runAgentSafely = async (props: LinkProps) => {
+  try {
+    const inputs = parseInputs(props);
+    validateInputs(inputs);
+    await runAgent(props, inputs);
+  } catch (err) {
+    emitAgent(toAgentError(err));
+    process.exit(1);
+  }
+};
 
-  if (!orgId) {
-    const orgs = await fetchOrganizations(props);
-    emitAgent({
-      status: 'needs_org',
-      instruction:
-        orgs.length === 0
-          ? 'The user does not belong to any organizations. Ask them to create one in the Neon Console (https://console.neon.tech/) before linking.'
-          : `Ask the user which of these ${orgs.length} organization${orgs.length === 1 ? '' : 's'} they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.`,
-      options: orgs.map((org) => ({ id: org.id, name: org.name })),
-      next_command_template: 'neonctl link --agent --org-id <org_id>',
-    });
+const runAgent = async (props: LinkProps, inputs: Inputs) => {
+  const { projectId, projectName, regionId } = inputs;
+
+  const orgResolution = await resolveOrg(props, inputs.orgId);
+  if (orgResolution.kind === 'needs_selection') {
+    emitAgent(buildNeedsOrgResponse(orgResolution));
     return;
   }
+  const orgId = orgResolution.orgId;
 
   if (projectId) {
     const branchId = await resolveDefaultBranchId(props, projectId);
@@ -567,11 +587,140 @@ const emitAgent = (response: AgentResponse) => {
 // API helpers
 // ----------------------------------------------------------------------------
 
+const ORG_KEY_LIMITED_FRAGMENT = 'not allowed for organization API keys';
+
+const isOrgKeyLimitedError = (err: unknown): boolean => {
+  if (!isAxiosError(err)) return false;
+  const data = err.response?.data;
+  if (data === undefined || data === null || typeof data !== 'object') {
+    return false;
+  }
+  const message = (data as { message?: unknown }).message;
+  return (
+    typeof message === 'string' && message.includes(ORG_KEY_LIMITED_FRAGMENT)
+  );
+};
+
 const fetchOrganizations = async (
   props: CommonProps,
 ): Promise<Organization[]> => {
   const { data } = await props.apiClient.getCurrentUserOrganizations();
   return data.organizations ?? [];
+};
+
+type OrgResolution =
+  | { kind: 'resolved'; orgId: string; autoDetected: boolean }
+  | {
+      kind: 'needs_selection';
+      orgs: Organization[];
+      orgKeyLimited: boolean;
+    };
+
+/**
+ * Resolves the org id from the explicit flag, falling back to listing user orgs.
+ *
+ * For organization-scoped API keys, `getCurrentUserOrganizations` is forbidden;
+ * in that case we try to auto-detect the org from the first existing project
+ * (since all projects of an org key live in the same org). If no project exists
+ * yet, we return `needs_selection` with `orgKeyLimited: true` so callers can
+ * give a precise instruction to the user.
+ */
+const resolveOrg = async (
+  props: CommonProps,
+  given: string | undefined,
+): Promise<OrgResolution> => {
+  if (given) {
+    return { kind: 'resolved', orgId: given, autoDetected: false };
+  }
+  try {
+    const orgs = await fetchOrganizations(props);
+    return { kind: 'needs_selection', orgs, orgKeyLimited: false };
+  } catch (err) {
+    if (!isOrgKeyLimitedError(err)) {
+      throw err;
+    }
+    log.debug(
+      'getCurrentUserOrganizations not allowed (org-scoped API key); attempting to derive org from existing projects.',
+    );
+  }
+  const detected = await detectOrgIdFromProjects(props);
+  if (detected) {
+    return { kind: 'resolved', orgId: detected, autoDetected: true };
+  }
+  return { kind: 'needs_selection', orgs: [], orgKeyLimited: true };
+};
+
+const detectOrgIdFromProjects = async (
+  props: CommonProps,
+): Promise<string | undefined> => {
+  try {
+    const { data } = await props.apiClient.listProjects({ limit: 1 });
+    return data.projects[0]?.org_id ?? undefined;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.debug('detectOrgIdFromProjects failed: %s', message);
+    return undefined;
+  }
+};
+
+const buildNeedsOrgResponse = (
+  resolution: Extract<OrgResolution, { kind: 'needs_selection' }>,
+): AgentResponse => {
+  if (resolution.orgKeyLimited) {
+    return {
+      status: 'needs_org',
+      instruction:
+        "This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like `org-bitter-breeze-12345678`) and re-run the next_command_template with that --org-id.",
+      options: [],
+      next_command_template: 'neonctl link --agent --org-id <org_id>',
+    };
+  }
+  const orgs = resolution.orgs;
+  return {
+    status: 'needs_org',
+    instruction:
+      orgs.length === 0
+        ? 'The user does not belong to any organizations. Ask them to create one in the Neon Console (https://console.neon.tech/) before linking.'
+        : `Ask the user which of these ${orgs.length} organization${orgs.length === 1 ? '' : 's'} they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.`,
+    options: orgs.map((org) => ({ id: org.id, name: org.name })),
+    next_command_template: 'neonctl link --agent --org-id <org_id>',
+  };
+};
+
+const toAgentError = (
+  err: unknown,
+): Extract<AgentResponse, { status: 'error' }> => {
+  if (isAxiosError(err)) {
+    const status = err.response?.status;
+    const data = err.response?.data;
+    const apiMessage =
+      typeof data === 'object' && data !== null
+        ? (data as { message?: unknown }).message
+        : undefined;
+    const message =
+      typeof apiMessage === 'string' && apiMessage.length > 0
+        ? apiMessage
+        : err.message;
+    let code = 'API_ERROR';
+    if (status === 401 || status === 403) {
+      code = 'AUTH_ERROR';
+    } else if (status !== undefined && status >= 400 && status < 500) {
+      code = 'CLIENT_ERROR';
+    } else if (status !== undefined && status >= 500) {
+      code = 'SERVER_ERROR';
+    } else if (err.code === 'ECONNABORTED') {
+      code = 'TIMEOUT';
+    }
+    return { status: 'error', code, message };
+  }
+  if (err instanceof Error) {
+    return { status: 'error', code: 'INTERNAL_ERROR', message: err.message };
+  }
+  return {
+    status: 'error',
+    code: 'INTERNAL_ERROR',
+    message: String(err),
+  };
 };
 
 const listAllProjects = async (

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,0 +1,728 @@
+import {
+  Branch,
+  Organization,
+  ProjectCreateRequest,
+  ProjectListItem,
+  RegionResponse,
+} from '@neondatabase/api-client';
+import { isAxiosError } from 'axios';
+import prompts, { InitialReturnValue } from 'prompts';
+import yargs from 'yargs';
+
+import { applyContext, readContextFile } from '../context.js';
+import { isCi } from '../env.js';
+import { log } from '../log.js';
+import { CommonProps } from '../types.js';
+import { REGIONS } from './projects.js';
+
+const PROJECTS_LIST_LIMIT = 100;
+
+const CREATE_NEW_SENTINEL = '__create_new__';
+
+type LinkProps = CommonProps & {
+  orgId?: string;
+  projectId?: string;
+  projectName?: string;
+  regionId?: string;
+  params?: string;
+  agent: boolean;
+  yes: boolean;
+};
+
+type Inputs = {
+  orgId?: string;
+  projectId?: string;
+  projectName?: string;
+  regionId?: string;
+};
+
+type AgentOrgOption = { id: string; name: string };
+type AgentProjectOption = { id: string; name: string; region_id?: string };
+type AgentRegionOption = { id: string; name: string; default: boolean };
+type AgentContext = { orgId: string; projectId: string; branchId: string };
+type AgentProject = { id: string; name?: string; region_id?: string };
+
+type AgentResponse =
+  | {
+      status: 'needs_org';
+      instruction: string;
+      options: AgentOrgOption[];
+      next_command_template: string;
+    }
+  | {
+      status: 'needs_project';
+      instruction: string;
+      options: AgentProjectOption[];
+      create_option: { instruction: string; next_command_template: string };
+      next_command_template: string;
+    }
+  | {
+      status: 'needs_project_details';
+      instruction: string;
+      regions: AgentRegionOption[];
+      next_command_template: string;
+    }
+  | {
+      status: 'linked';
+      context_file: string;
+      context: AgentContext;
+      project: AgentProject;
+      message: string;
+    }
+  | { status: 'error'; code: string; message: string };
+
+export const command = 'link';
+export const describe = 'Link the current directory to a Neon project';
+
+export const builder = (argv: yargs.Argv) =>
+  argv.usage('$0 link [options]').options({
+    'org-id': {
+      describe: 'Organization ID to link to',
+      type: 'string',
+    },
+    'project-id': {
+      describe: 'Existing project ID to link to',
+      type: 'string',
+    },
+    'project-name': {
+      describe: 'Name for a new project to create and link to',
+      type: 'string',
+    },
+    'region-id': {
+      describe:
+        'Region ID for a new project (e.g. aws-us-east-2). Required with --project-name.',
+      type: 'string',
+    },
+    params: {
+      describe:
+        'JSON object with link parameters, e.g. \'{"orgId":"...","projectId":"..."}\' or \'{"orgId":"...","projectName":"...","regionId":"..."}\'. Flags take precedence over fields in --params.',
+      type: 'string',
+    },
+    agent: {
+      describe:
+        'Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.',
+      type: 'boolean',
+      default: false,
+    },
+    yes: {
+      alias: 'y',
+      describe:
+        'Skip the "already linked" confirmation in interactive mode and re-link anyway.',
+      type: 'boolean',
+      default: false,
+    },
+  });
+
+export const handler = async (props: LinkProps) => {
+  const inputs = parseInputs(props);
+  validateInputs(inputs);
+
+  if (props.agent) {
+    await runAgent(props, inputs);
+    return;
+  }
+
+  if (hasEnoughForNonInteractive(inputs)) {
+    await runNonInteractive(props, inputs);
+    return;
+  }
+
+  if (isCi()) {
+    log.error(
+      [
+        'Missing inputs and CI environment detected (no TTY for prompts).',
+        '',
+        'Use one of:',
+        '  neonctl link --agent                                                    (JSON state machine for agents)',
+        '  neonctl link --org-id <org> --project-id <project>                      (link to an existing project)',
+        '  neonctl link --org-id <org> --project-name <name> --region-id <region>  (create a new project and link)',
+      ].join('\n'),
+    );
+    process.exit(1);
+    return;
+  }
+
+  await runInteractive(props, inputs);
+};
+
+// ----------------------------------------------------------------------------
+// Input parsing & validation
+// ----------------------------------------------------------------------------
+
+const parseInputs = (props: LinkProps): Inputs => {
+  let fromParams: Inputs = {};
+  if (props.params !== undefined && props.params !== '') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(props.params);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse --params JSON: ${message}`);
+    }
+    fromParams = extractParams(parsed);
+  }
+  return {
+    orgId: props.orgId ?? fromParams.orgId,
+    projectId: props.projectId ?? fromParams.projectId,
+    projectName: props.projectName ?? fromParams.projectName,
+    regionId: props.regionId ?? fromParams.regionId,
+  };
+};
+
+const extractParams = (raw: unknown): Inputs => {
+  if (raw === null || typeof raw !== 'object') {
+    throw new Error('--params must be a JSON object');
+  }
+  const obj = raw as Record<string, unknown>;
+  const pickString = (key: string): string | undefined => {
+    const value = obj[key];
+    if (value === undefined || value === null) return undefined;
+    if (typeof value !== 'string') {
+      throw new Error(`--params.${key} must be a string`);
+    }
+    return value;
+  };
+  return {
+    orgId: pickString('orgId'),
+    projectId: pickString('projectId'),
+    projectName: pickString('projectName'),
+    regionId: pickString('regionId'),
+  };
+};
+
+const validateInputs = (inputs: Inputs): void => {
+  if (inputs.projectId && (inputs.projectName || inputs.regionId)) {
+    throw new Error(
+      'Conflicting inputs: --project-id selects an existing project; --project-name and --region-id describe a new one. Pass only one set.',
+    );
+  }
+};
+
+const hasEnoughForNonInteractive = (inputs: Inputs): boolean => {
+  if (inputs.orgId && inputs.projectId) return true;
+  if (inputs.orgId && inputs.projectName && inputs.regionId) return true;
+  return false;
+};
+
+// ----------------------------------------------------------------------------
+// Non-interactive flag-driven mode
+// ----------------------------------------------------------------------------
+
+const runNonInteractive = async (props: LinkProps, inputs: Inputs) => {
+  const orgId = mustString(inputs.orgId, 'orgId');
+  if (inputs.projectId) {
+    const branchId = await resolveDefaultBranchId(props, inputs.projectId);
+    applyContext(props.contextFile, {
+      orgId,
+      projectId: inputs.projectId,
+      branchId,
+    });
+    printHumanSummary(props, {
+      contextFile: props.contextFile,
+      orgId,
+      projectId: inputs.projectId,
+      branchId,
+      created: false,
+    });
+    return;
+  }
+  const created = await createProject(props, {
+    orgId,
+    name: mustString(inputs.projectName, 'projectName'),
+    regionId: mustString(inputs.regionId, 'regionId'),
+  });
+  applyContext(props.contextFile, {
+    orgId,
+    projectId: created.project.id,
+    branchId: created.branchId,
+  });
+  printHumanSummary(props, {
+    contextFile: props.contextFile,
+    orgId,
+    projectId: created.project.id,
+    branchId: created.branchId,
+    created: true,
+    projectName: created.project.name,
+    regionId: created.project.region_id,
+  });
+};
+
+// ----------------------------------------------------------------------------
+// Interactive mode (TTY)
+// ----------------------------------------------------------------------------
+
+const runInteractive = async (props: LinkProps, inputs: Inputs) => {
+  if (!props.yes) {
+    await confirmRelinkIfNeeded(props);
+  }
+
+  const orgId = inputs.orgId ?? (await promptOrg(props));
+
+  if (inputs.projectId) {
+    const branchId = await resolveDefaultBranchId(props, inputs.projectId);
+    applyContext(props.contextFile, {
+      orgId,
+      projectId: inputs.projectId,
+      branchId,
+    });
+    printHumanSummary(props, {
+      contextFile: props.contextFile,
+      orgId,
+      projectId: inputs.projectId,
+      branchId,
+      created: false,
+    });
+    return;
+  }
+
+  if (inputs.projectName && inputs.regionId) {
+    const created = await createProject(props, {
+      orgId,
+      name: inputs.projectName,
+      regionId: inputs.regionId,
+    });
+    applyContext(props.contextFile, {
+      orgId,
+      projectId: created.project.id,
+      branchId: created.branchId,
+    });
+    printHumanSummary(props, {
+      contextFile: props.contextFile,
+      orgId,
+      projectId: created.project.id,
+      branchId: created.branchId,
+      created: true,
+      projectName: created.project.name,
+      regionId: created.project.region_id,
+    });
+    return;
+  }
+
+  // Need to ask: existing project or create a new one?
+  const projects = await listAllProjects(props, orgId);
+  const action = await promptProjectChoice(projects, inputs.projectName);
+
+  if (action.type === 'existing') {
+    const branchId = await resolveDefaultBranchId(props, action.projectId);
+    applyContext(props.contextFile, {
+      orgId,
+      projectId: action.projectId,
+      branchId,
+    });
+    printHumanSummary(props, {
+      contextFile: props.contextFile,
+      orgId,
+      projectId: action.projectId,
+      branchId,
+      created: false,
+      projectName: action.name,
+      regionId: action.regionId,
+    });
+    return;
+  }
+
+  const projectName =
+    inputs.projectName ?? (await promptProjectName(action.suggestedName));
+  const regionId = inputs.regionId ?? (await promptRegion(props));
+  const created = await createProject(props, {
+    orgId,
+    name: projectName,
+    regionId,
+  });
+  applyContext(props.contextFile, {
+    orgId,
+    projectId: created.project.id,
+    branchId: created.branchId,
+  });
+  printHumanSummary(props, {
+    contextFile: props.contextFile,
+    orgId,
+    projectId: created.project.id,
+    branchId: created.branchId,
+    created: true,
+    projectName: created.project.name,
+    regionId: created.project.region_id,
+  });
+};
+
+const confirmRelinkIfNeeded = async (props: LinkProps): Promise<void> => {
+  const existing = readContextFile(props.contextFile);
+  if (!existing.orgId || !existing.projectId) {
+    return;
+  }
+  const { proceed } = await prompts({
+    onState: onPromptState,
+    type: 'confirm',
+    name: 'proceed',
+    message: `${props.contextFile} is already linked to project ${existing.projectId} (org ${existing.orgId}). Re-link?`,
+    initial: true,
+  });
+  if (!proceed) {
+    process.stdout.write('Aborted. Existing link preserved.\n');
+    process.exit(0);
+  }
+};
+
+const promptOrg = async (props: LinkProps): Promise<string> => {
+  const orgs = await fetchOrganizations(props);
+  if (!orgs.length) {
+    throw new Error(
+      `You don't belong to any organizations. Create one in the Neon Console first: https://console.neon.tech/`,
+    );
+  }
+  const { orgId } = await prompts({
+    onState: onPromptState,
+    type: 'select',
+    name: 'orgId',
+    message: 'Which organization would you like to link?',
+    choices: orgs.map((org) => ({
+      title: `${org.name} (${org.id})`,
+      value: org.id,
+    })),
+    initial: 0,
+  });
+  return orgId;
+};
+
+type ProjectChoice =
+  | {
+      type: 'existing';
+      projectId: string;
+      name?: string;
+      regionId?: string;
+    }
+  | { type: 'create'; suggestedName?: string };
+
+const promptProjectChoice = async (
+  projects: ProjectListItem[],
+  suggestedName?: string,
+): Promise<ProjectChoice> => {
+  const choices = [
+    ...projects.map((project) => ({
+      title: `${project.name} (${project.id})`,
+      value: project.id,
+    })),
+    { title: '+ Create new project', value: CREATE_NEW_SENTINEL },
+  ];
+  const { selection } = await prompts({
+    onState: onPromptState,
+    type: 'select',
+    name: 'selection',
+    message: 'Which project would you like to link?',
+    choices,
+    initial: choices.length === 1 ? 0 : 0,
+  });
+  if (selection === CREATE_NEW_SENTINEL) {
+    return { type: 'create', suggestedName };
+  }
+  const project = projects.find((p) => p.id === selection);
+  return {
+    type: 'existing',
+    projectId: selection,
+    name: project?.name,
+    regionId: project?.region_id,
+  };
+};
+
+const promptProjectName = async (
+  suggestedName: string | undefined,
+): Promise<string> => {
+  const { name } = await prompts({
+    onState: onPromptState,
+    type: 'text',
+    name: 'name',
+    message: 'Name for the new project:',
+    initial: suggestedName,
+    validate: (value: string) =>
+      value && value.trim().length > 0 ? true : 'Project name is required',
+  });
+  return String(name).trim();
+};
+
+const promptRegion = async (props: LinkProps): Promise<string> => {
+  const regions = await fetchRegions(props);
+  const defaultIndex = Math.max(
+    0,
+    regions.findIndex((r) => r.default),
+  );
+  const { regionId } = await prompts({
+    onState: onPromptState,
+    type: 'select',
+    name: 'regionId',
+    message: 'Which region should the new project run in?',
+    choices: regions.map((region) => ({
+      title: `${region.name} (${region.region_id})`,
+      value: region.region_id,
+    })),
+    initial: defaultIndex,
+  });
+  return regionId;
+};
+
+// ----------------------------------------------------------------------------
+// Agent mode (JSON state machine)
+// ----------------------------------------------------------------------------
+
+const runAgent = async (props: LinkProps, inputs: Inputs) => {
+  const { orgId, projectId, projectName, regionId } = inputs;
+
+  if (!orgId) {
+    const orgs = await fetchOrganizations(props);
+    emitAgent({
+      status: 'needs_org',
+      instruction:
+        orgs.length === 0
+          ? 'The user does not belong to any organizations. Ask them to create one in the Neon Console (https://console.neon.tech/) before linking.'
+          : `Ask the user which of these ${orgs.length} organization${orgs.length === 1 ? '' : 's'} they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.`,
+      options: orgs.map((org) => ({ id: org.id, name: org.name })),
+      next_command_template: 'neonctl link --agent --org-id <org_id>',
+    });
+    return;
+  }
+
+  if (projectId) {
+    const branchId = await resolveDefaultBranchId(props, projectId);
+    applyContext(props.contextFile, { orgId, projectId, branchId });
+    emitAgent({
+      status: 'linked',
+      context_file: props.contextFile,
+      context: { orgId, projectId, branchId },
+      project: { id: projectId },
+      message: `Linked ${props.contextFile} to project ${projectId} (org ${orgId}) on branch ${branchId}.`,
+    });
+    return;
+  }
+
+  if (projectName && !regionId) {
+    const regions = await fetchRegions(props);
+    emitAgent({
+      status: 'needs_project_details',
+      instruction: `Ask the user which region to create project "${projectName}" in. After they pick one, re-run the next_command_template with the chosen --region-id value.`,
+      regions: regions.map((region) => ({
+        id: region.region_id,
+        name: region.name,
+        default: region.default,
+      })),
+      next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-name ${shellArg(projectName)} --region-id <region_id>`,
+    });
+    return;
+  }
+
+  if (projectName && regionId) {
+    const created = await createProject(props, {
+      orgId,
+      name: projectName,
+      regionId,
+    });
+    applyContext(props.contextFile, {
+      orgId,
+      projectId: created.project.id,
+      branchId: created.branchId,
+    });
+    emitAgent({
+      status: 'linked',
+      context_file: props.contextFile,
+      context: {
+        orgId,
+        projectId: created.project.id,
+        branchId: created.branchId,
+      },
+      project: {
+        id: created.project.id,
+        name: created.project.name,
+        region_id: created.project.region_id,
+      },
+      message: `Created project ${created.project.id} ("${created.project.name ?? projectName}") in ${created.project.region_id ?? regionId} and linked ${props.contextFile}.`,
+    });
+    return;
+  }
+
+  // orgId is set but no project info — list projects to choose from.
+  const projects = await listAllProjects(props, orgId);
+  emitAgent({
+    status: 'needs_project',
+    instruction:
+      projects.length === 0
+        ? `Organization ${orgId} has no projects yet. Ask the user for a name for the new project, then re-run the create_option.next_command_template.`
+        : `Ask the user whether to link to one of these ${projects.length} existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).`,
+    options: projects.map((project) => ({
+      id: project.id,
+      name: project.name,
+      region_id: project.region_id,
+    })),
+    create_option: {
+      instruction:
+        'To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.',
+      next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-name <name> --region-id <region_id>`,
+    },
+    next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-id <project_id>`,
+  });
+};
+
+const emitAgent = (response: AgentResponse) => {
+  process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+};
+
+// ----------------------------------------------------------------------------
+// API helpers
+// ----------------------------------------------------------------------------
+
+const fetchOrganizations = async (
+  props: CommonProps,
+): Promise<Organization[]> => {
+  const { data } = await props.apiClient.getCurrentUserOrganizations();
+  return data.organizations ?? [];
+};
+
+const listAllProjects = async (
+  props: CommonProps,
+  orgId: string,
+): Promise<ProjectListItem[]> => {
+  const result: ProjectListItem[] = [];
+  let cursor: string | undefined;
+  while (true) {
+    const { data } = await props.apiClient.listProjects({
+      limit: PROJECTS_LIST_LIMIT,
+      org_id: orgId,
+      cursor,
+    });
+    result.push(...data.projects);
+    cursor = data.pagination?.cursor;
+    if (data.projects.length < PROJECTS_LIST_LIMIT) {
+      break;
+    }
+  }
+  return result;
+};
+
+const resolveDefaultBranchId = async (
+  props: CommonProps,
+  projectId: string,
+): Promise<string> => {
+  const { data } = await props.apiClient.listProjectBranches({ projectId });
+  const branch = data.branches.find((b: Branch) => b.default);
+  if (!branch) {
+    throw new Error(
+      `Could not find a default branch for project ${projectId}.`,
+    );
+  }
+  return branch.id;
+};
+
+const fetchRegions = async (props: CommonProps): Promise<RegionResponse[]> => {
+  try {
+    const { data } = await props.apiClient.getActiveRegions();
+    if (data.regions && data.regions.length > 0) {
+      return data.regions;
+    }
+  } catch (err) {
+    if (isAxiosError(err)) {
+      log.debug(
+        'getActiveRegions failed (%s), falling back to the static region list.',
+        err.response?.status ?? err.code ?? err.message,
+      );
+    } else {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug(
+        'getActiveRegions failed (%s), falling back to the static region list.',
+        message,
+      );
+    }
+  }
+  return staticRegionsFallback();
+};
+
+const staticRegionsFallback = (): RegionResponse[] =>
+  REGIONS.map((id) => ({
+    region_id: id,
+    name: id,
+    default: id === 'aws-us-east-2',
+    geo_lat: '',
+    geo_long: '',
+  }));
+
+type CreatedProject = {
+  project: { id: string; name?: string; region_id?: string };
+  branchId: string;
+};
+
+const createProject = async (
+  props: CommonProps,
+  args: { orgId: string; name: string; regionId: string },
+): Promise<CreatedProject> => {
+  const project: ProjectCreateRequest['project'] = {
+    name: args.name,
+    region_id: args.regionId,
+    org_id: args.orgId,
+    branch: {},
+  };
+  const { data } = await props.apiClient.createProject({ project });
+  if (!data.branch?.id) {
+    throw new Error(
+      'Project was created but the API response did not include a default branch id.',
+    );
+  }
+  return {
+    project: {
+      id: data.project.id,
+      name: data.project.name,
+      region_id: data.project.region_id,
+    },
+    branchId: data.branch.id,
+  };
+};
+
+// ----------------------------------------------------------------------------
+// Output helpers
+// ----------------------------------------------------------------------------
+
+type HumanSummary = {
+  contextFile: string;
+  orgId: string;
+  projectId: string;
+  branchId: string;
+  created: boolean;
+  projectName?: string;
+  regionId?: string;
+};
+
+const printHumanSummary = (_props: LinkProps, summary: HumanSummary): void => {
+  const lines: string[] = [];
+  if (summary.created) {
+    lines.push(
+      `Created project ${summary.projectId}${summary.projectName ? ` ("${summary.projectName}")` : ''}${summary.regionId ? ` in ${summary.regionId}` : ''}.`,
+    );
+  }
+  lines.push(`Linked ${summary.contextFile}:`);
+  lines.push(`  orgId:    ${summary.orgId}`);
+  lines.push(`  projectId: ${summary.projectId}`);
+  lines.push(`  branchId:  ${summary.branchId}`);
+  lines.push('');
+  process.stdout.write(`${lines.join('\n')}\n`);
+};
+
+const onPromptState = (state: {
+  value: InitialReturnValue;
+  aborted: boolean;
+  exited: boolean;
+}) => {
+  if (state.aborted) {
+    process.stdout.write('\x1B[?25h');
+    process.stdout.write('\n');
+    process.exit(1);
+  }
+};
+
+const shellArg = (value: string): string => {
+  if (/^[A-Za-z0-9._:/-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+};
+
+const mustString = <T>(value: T | undefined, name: string): T => {
+  if (value === undefined) {
+    throw new Error(`Internal error: expected ${name} to be set.`);
+  }
+  return value;
+};

--- a/src/commands/set_context.ts
+++ b/src/commands/set_context.ts
@@ -1,10 +1,11 @@
 import yargs from 'yargs';
-import { Context, updateContextFile } from '../context.js';
+import { applyContext, Context } from '../context.js';
 import { CommonProps } from '../types.js';
 
 type SetContextProps = {
   projectId?: string;
   orgId?: string;
+  branchId?: string;
 };
 
 export const command = 'set-context';
@@ -19,12 +20,17 @@ export const builder = (argv: yargs.Argv) =>
       describe: 'Organization ID',
       type: 'string',
     },
+    'branch-id': {
+      describe: 'Branch ID',
+      type: 'string',
+    },
   });
 
 export const handler = (props: CommonProps & SetContextProps) => {
   const context: Context = {
     projectId: props.projectId,
     orgId: props.orgId,
+    branchId: props.branchId,
   };
-  updateContextFile(props.contextFile, context);
+  applyContext(props.contextFile, context);
 };

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,9 +1,19 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { currentContextFile } from './context.js';
+import {
+  applyContext,
+  currentContextFile,
+  ensureGitignored,
+} from './context.js';
 
 describe('currentContextFile', () => {
   let workspace: string;
@@ -42,5 +52,89 @@ describe('currentContextFile', () => {
     const sub = join(workspace, 'fresh-sub');
     mkdirSync(sub);
     expect(currentContextFile(sub)).toBe(join(sub, '.neon'));
+  });
+});
+
+describe('ensureGitignored', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-gi-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('creates a .gitignore listing .neon when none exists', () => {
+    const contextFile = join(workspace, '.neon');
+    ensureGitignored(contextFile);
+    const gitignore = readFileSync(join(workspace, '.gitignore'), 'utf-8');
+    expect(gitignore).toBe('.neon\n');
+  });
+
+  test('appends .neon to an existing .gitignore that does not have it', () => {
+    const gi = join(workspace, '.gitignore');
+    writeFileSync(gi, 'node_modules\ndist\n');
+    ensureGitignored(join(workspace, '.neon'));
+    expect(readFileSync(gi, 'utf-8')).toBe('node_modules\ndist\n.neon\n');
+  });
+
+  test('does not duplicate .neon when already present', () => {
+    const gi = join(workspace, '.gitignore');
+    writeFileSync(gi, 'node_modules\n.neon\ndist\n');
+    ensureGitignored(join(workspace, '.neon'));
+    expect(readFileSync(gi, 'utf-8')).toBe('node_modules\n.neon\ndist\n');
+  });
+
+  test('tolerates a .gitignore that has no trailing newline', () => {
+    const gi = join(workspace, '.gitignore');
+    writeFileSync(gi, 'node_modules');
+    ensureGitignored(join(workspace, '.neon'));
+    expect(readFileSync(gi, 'utf-8')).toBe('node_modules\n.neon\n');
+  });
+
+  test('treats surrounding whitespace as part of the line', () => {
+    const gi = join(workspace, '.gitignore');
+    // Trailing spaces around the entry should still count as a match.
+    writeFileSync(gi, '  .neon  \n');
+    ensureGitignored(join(workspace, '.neon'));
+    expect(readFileSync(gi, 'utf-8')).toBe('  .neon  \n');
+  });
+
+  test('does NOT match partial entries like *.neon or foo/.neon', () => {
+    const gi = join(workspace, '.gitignore');
+    writeFileSync(gi, '*.neon\nfoo/.neon\n');
+    ensureGitignored(join(workspace, '.neon'));
+    expect(readFileSync(gi, 'utf-8')).toBe('*.neon\nfoo/.neon\n.neon\n');
+  });
+});
+
+describe('applyContext', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-apply-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('writes the context file AND scaffolds .gitignore', () => {
+    const file = join(workspace, '.neon');
+    applyContext(file, {
+      orgId: 'org-x',
+      projectId: 'proj-y',
+      branchId: 'br-z',
+    });
+    expect(JSON.parse(readFileSync(file, 'utf-8'))).toEqual({
+      orgId: 'org-x',
+      projectId: 'proj-y',
+      branchId: 'br-z',
+    });
+    expect(readFileSync(join(workspace, '.gitignore'), 'utf-8')).toBe(
+      '.neon\n',
+    );
   });
 });

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { currentContextFile } from './context.js';
+
+describe('currentContextFile', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-ctx-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('defaults to <cwd>/.neon when no .neon exists anywhere upward', () => {
+    const sub = join(workspace, 'sub');
+    mkdirSync(sub);
+    expect(currentContextFile(sub)).toBe(join(sub, '.neon'));
+  });
+
+  test('walks up to an existing .neon in a parent directory', () => {
+    writeFileSync(
+      join(workspace, '.neon'),
+      JSON.stringify({ projectId: 'parent-project' }),
+    );
+    const sub = join(workspace, 'nested', 'deeper');
+    mkdirSync(sub, { recursive: true });
+    expect(currentContextFile(sub)).toBe(join(workspace, '.neon'));
+  });
+
+  test('does NOT walk up for unrelated project markers (package.json, .git)', () => {
+    // Regression: previously `currentContextFile` treated `package.json` and
+    // `.git` as project markers and walked up to them, which made
+    // `neonctl link` from a fresh sub-directory inside an existing repo land
+    // its `.neon` at the parent repo's root instead of the cwd.
+    writeFileSync(join(workspace, 'package.json'), '{}');
+    mkdirSync(join(workspace, '.git'));
+    const sub = join(workspace, 'fresh-sub');
+    mkdirSync(sub);
+    expect(currentContextFile(sub)).toBe(join(sub, '.neon'));
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,9 @@
-import { accessSync, readFileSync, writeFileSync } from 'node:fs';
+import { accessSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { normalize, resolve } from 'node:path';
+import { dirname, normalize, resolve } from 'node:path';
 import yargs from 'yargs';
+
+import { log } from './log.js';
 
 export type Context = {
   orgId?: string;
@@ -10,6 +12,7 @@ export type Context = {
 };
 
 const CONTEXT_FILE = '.neon';
+const GITIGNORE_FILE = '.gitignore';
 
 const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
 
@@ -87,7 +90,54 @@ export const updateContextFile = (file: string, context: Context) => {
  * Shared primitive used by `set-context` and `link` to persist context.
  * Mirrors the destructive write semantics of `updateContextFile` —
  * any field not present in `context` is dropped from the file.
+ *
+ * After writing, ensures a `.gitignore` file sits alongside `.neon` and lists
+ * it, so the linked context doesn't accidentally end up in source control.
  */
 export const applyContext = (file: string, context: Context) => {
   updateContextFile(file, context);
+  ensureGitignored(file);
+};
+
+/**
+ * Make sure the `.gitignore` next to `file` lists the file's basename
+ * (currently always `.neon`). Creates the `.gitignore` if it doesn't exist,
+ * or appends `.neon` if it's missing — never duplicates an existing entry.
+ *
+ * Best-effort: a failure here (e.g. read-only filesystem) is logged at debug
+ * level and swallowed; persisting the context file is the primary goal and
+ * must not be blocked by a `.gitignore` write error.
+ */
+export const ensureGitignored = (file: string): void => {
+  try {
+    const dir = dirname(file);
+    const entry = basenameOf(file);
+    const gitignorePath = resolve(dir, GITIGNORE_FILE);
+
+    if (!existsSync(gitignorePath)) {
+      writeFileSync(gitignorePath, `${entry}\n`);
+      return;
+    }
+
+    const current = readFileSync(gitignorePath, 'utf-8');
+    if (hasGitignoreEntry(current, entry)) {
+      return;
+    }
+
+    const needsLeadingNewline = current.length > 0 && !current.endsWith('\n');
+    const addition = `${needsLeadingNewline ? '\n' : ''}${entry}\n`;
+    writeFileSync(gitignorePath, current + addition);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.debug('Failed to update .gitignore next to %s: %s', file, message);
+  }
+};
+
+const basenameOf = (file: string): string => {
+  const parts = file.split(/[\\/]/);
+  return parts[parts.length - 1] || CONTEXT_FILE;
+};
+
+const hasGitignoreEntry = (content: string, entry: string): boolean => {
+  return content.split(/\r?\n/).some((line) => line.trim() === entry);
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,23 +10,37 @@ export type Context = {
 };
 
 const CONTEXT_FILE = '.neon';
-const CHECK_FILES = [CONTEXT_FILE, 'package.json', '.git'];
 
 const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
 
-export const currentContextFile = () => {
-  const cwd = process.cwd();
+/**
+ * Resolve the default `.neon` path for the current working directory.
+ *
+ * Walks UP from `cwd` looking ONLY for an already-existing `.neon` file so
+ * commands run from a sub-directory of a linked project still pick up the
+ * project's context. If no `.neon` is found, the path defaults to
+ * `<cwd>/.neon`, which makes `neonctl link` and `neonctl set-context`
+ * predictable: they always write the context file into the directory they
+ * were invoked from.
+ *
+ * Historically the walk also considered `package.json` and `.git` as project
+ * markers, but that led to surprising behaviour when running `link` from a
+ * fresh sub-directory inside an unrelated repo (the new link would land in
+ * the parent repo's root instead of the cwd).
+ *
+ * `cwd` is overridable so tests can exercise the walk-up without mutating
+ * `process.cwd()` (which would race with other tests running in parallel).
+ */
+export const currentContextFile = (cwd: string = process.cwd()) => {
   let currentDir = cwd;
   const root = normalize('/');
   const home = homedir();
   while (currentDir !== root && currentDir !== home) {
-    for (const file of CHECK_FILES) {
-      try {
-        accessSync(resolve(currentDir, file));
-        return wrapWithContextFile(currentDir);
-      } catch {
-        // ignore
-      }
+    try {
+      accessSync(resolve(currentDir, CONTEXT_FILE));
+      return wrapWithContextFile(currentDir);
+    } catch {
+      // ignore
     }
     currentDir = resolve(currentDir, '..');
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -45,7 +45,7 @@ export const readContextFile = (file: string): Context => {
 export const enrichFromContext = (
   args: yargs.Arguments<{ contextFile: string }>,
 ) => {
-  if (args._[0] === 'set-context') {
+  if (args._[0] === 'set-context' || args._[0] === 'link') {
     return;
   }
   const context = readContextFile(args.contextFile);
@@ -67,4 +67,13 @@ export const enrichFromContext = (
 
 export const updateContextFile = (file: string, context: Context) => {
   writeFileSync(file, JSON.stringify(context, null, 2));
+};
+
+/**
+ * Shared primitive used by `set-context` and `link` to persist context.
+ * Mirrors the destructive write semantics of `updateContextFile` —
+ * any field not present in `context` is dropped from the file.
+ */
+export const applyContext = (file: string, context: Context) => {
+  updateContextFile(file, context);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'set-context',
 
+  'link',
+
   'init',
 
   // aliases


### PR DESCRIPTION
## Summary

Introduces `neonctl link` — a Vercel-style command that binds the current working directory to a Neon project. It picks (or creates) an org, picks (or creates) a project, resolves the project's default branch, and writes `{ "orgId", "projectId", "branchId" }` to a per-project `.neon` file so subsequent commands in that directory auto-resolve their context.

The command is a thin wrapper around the existing `set-context` primitive: both now go through a shared `applyContext` helper, and `set-context` gains a `--branch-id` flag so anything `link` writes can also be set manually.

## Flow

```mermaid
flowchart TD
    Start(["neonctl link"]) --> Mode{Mode}

    Mode -->|"--agent"| Agent[Agent mode]
    Mode -->|"required flags<br/>or --params"| NonInt[Non-interactive mode]
    Mode -->|TTY| Inter[Interactive mode]
    Mode -->|"missing inputs + CI"| CIExit["exit 1 with usage hint"]

    Agent --> ResolveOrg
    Inter --> ResolveOrg
    NonInt --> ResolveOrg

    ResolveOrg["resolveOrg"] --> OrgsCall{"getCurrentUserOrganizations()"}
    OrgsCall -->|"200"| GotList["agent: emit needs_org with options<br/>interactive: prompts.select"]
    OrgsCall -->|"403 org-scoped key"| AutoDetect["listProjects() -><br/>first project's org_id"]
    AutoDetect -->|"found"| Auto["orgId auto-detected"]
    AutoDetect -->|"empty"| Limited["agent: emit needs_org with empty options + hint<br/>interactive: error pointing to --org-id"]

    GotList --> HaveOrg["orgId resolved"]
    Auto --> HaveOrg

    HaveOrg --> ProjSwitch{Have project info?}

    ProjSwitch -->|"--project-id"| FetchBranch["listProjectBranches -> b.default"]
    ProjSwitch -->|"--project-name + --region-id"| CreateNew["createProject -><br/>data.branch.id"]
    ProjSwitch -->|"--project-name only"| NeedRegion["agent: emit needs_project_details<br/>interactive: prompt for region<br/>(getActiveRegions, fallback to static REGIONS)"]
    ProjSwitch -->|"none"| NeedProj["agent: emit needs_project (with create_option)<br/>interactive: prompt to pick or 'create new'"]

    FetchBranch --> Write
    CreateNew --> Write

    Write["applyContext: writeFileSync .neon<br/>{ orgId, projectId, branchId }"] --> Out{Mode}
    Out -->|agent| LinkedJSON["emit status: linked JSON"]
    Out -->|interactive / non-interactive| Summary["print human summary"]
```

## Why

Today users compose `orgs list`, `projects list`/`create`, `branches list`, and `set-context` to associate a directory with a Neon project. AI coding assistants need to script that same dance. `link` collapses it into one intent-clear command with a deterministic JSON contract for agents.

## What's in this PR

- **New** `neonctl link` top-level command with three modes:
  - **Interactive** (default): guided prompts via the `prompts` library, following the existing `selectOrg` / `onPromptState` patterns from `projects create`.
  - **`--agent`**: a deterministic JSON state machine that emits a discriminated `status` object (`needs_org` / `needs_project` / `needs_project_details` / `linked` / `error`) plus `instruction`, structured `options`, and a `next_command_template` string. Never prompts, always exits cleanly with parseable JSON — even on errors.
  - **Non-interactive**: standard flags (`--org-id`, `--project-id`, `--project-name`, `--region-id`) with an optional `--params '<json>'` convenience blob (chosen over `--json` to avoid clashing with the global `-o/--output json`).
- **`set-context`** gains `--branch-id` and routes through the shared `applyContext` helper in `src/context.ts`. No behavior change to existing flags; snapshots unchanged.
- **`enrichFromContext`** now skips `link` (like `set-context`), so `link` always starts from a clean slate.
- **Organization-scoped API keys**: `getCurrentUserOrganizations` and `getActiveRegions` are forbidden for org-scoped keys; `link` auto-detects the org from any existing project (via `listProjects`) and falls back to the static region list. If no projects exist yet, `--agent` returns a `needs_org` with `options: []` and a clear instruction to supply `--org-id` explicitly.
- **Agent error contract**: any unexpected failure in `--agent` mode is reported as JSON to stdout with exit code 1 and a typed `code` (`API_ERROR` / `CLIENT_ERROR` / `AUTH_ERROR` / `SERVER_ERROR` / `TIMEOUT` / `INTERNAL_ERROR`).
- **CI guard**: when no inputs are provided and `CI=true`, the command exits with a message pointing to `--agent` and the explicit flags instead of hanging on prompts.
- **`.gitignore` scaffolding**: whenever `applyContext` writes a `.neon`, a sibling `.gitignore` is also ensured to list `.neon` — creates the file if missing, appends `.neon` if absent, no duplicates, existing entries preserved. Applies to both `link` and `set-context` since they share `applyContext`.
- **`.neon` path resolution**: `currentContextFile()` now only walks up for an existing `.neon` (no longer treats `.git` / `package.json` as project markers). Fresh sub-directories inside another repo now get `.neon` in the cwd instead of leaking it into the parent repo. Sub-directories of a linked project still inherit the parent's link as before.
- **Mocks**: adds `mocks/main/regions/GET.js`, `mocks/org-key/*` and `mocks/org-key-empty/*` so the new code paths are exercised end-to-end without touching the live API.
- **README**: adds `link` to the commands table and a full "Linking a project" section with end-to-end examples for all three modes (including org-scoped key behavior, the path-resolution rule, and the gitignore scaffolding).

## End-to-end examples

### Interactive

```bash
$ neonctl link
? Which organization would you like to link? › Personal Org (org-abc123)
? Which project would you like to link? › + Create new project
? Name for the new project: › my-app
? Which region should the new project run in? › AWS US East (Ohio) (aws-us-east-2)
Created project polished-snowflake-12345678 ("my-app") in aws-us-east-2.
Linked .neon:
  orgId:    org-abc123
  projectId: polished-snowflake-12345678
  branchId:  br-main-branch-87654321
```

### Non-interactive

```bash
# Link to an existing project
neonctl link --org-id org-abc123 --project-id polished-snowflake-12345678

# Create a new project and link
neonctl link --org-id org-abc123 --project-name my-app --region-id aws-us-east-2

# Same payload as one JSON blob (agent-friendly)
neonctl link --params '{"orgId":"org-abc123","projectName":"my-app","regionId":"aws-us-east-2"}'
```

### Agent state machine

```bash
$ neonctl link --agent
{
  "status": "needs_org",
  "instruction": "Ask the user which of these 2 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
  "options": [
    { "id": "org-abc123", "name": "Personal Org" },
    { "id": "org-team",   "name": "Team Org" }
  ],
  "next_command_template": "neonctl link --agent --org-id <org_id>"
}

$ neonctl link --agent --org-id org-abc123
{
  "status": "needs_project",
  "instruction": "Ask the user whether to link to one of these 1 existing projects ...",
  "options": [ { "id": "polished-snowflake-12345678", "name": "my-app" } ],
  "create_option": {
    "instruction": "To create a new project, ask the user for a project name. ...",
    "next_command_template": "neonctl link --agent --org-id org-abc123 --project-name <name> --region-id <region_id>"
  },
  "next_command_template": "neonctl link --agent --org-id org-abc123 --project-id <project_id>"
}

$ neonctl link --agent --org-id org-abc123 --project-name demo
{
  "status": "needs_project_details",
  "instruction": "Ask the user which region to create project \"demo\" in. ...",
  "regions": [
    { "id": "aws-us-east-2", "name": "AWS US East (Ohio)", "default": true },
    { "id": "aws-us-east-1", "name": "AWS US East (N. Virginia)", "default": false }
  ],
  "next_command_template": "neonctl link --agent --org-id org-abc123 --project-name demo --region-id <region_id>"
}

$ neonctl link --agent --org-id org-abc123 --project-id polished-snowflake-12345678
{
  "status": "linked",
  "context_file": "/path/to/cwd/.neon",
  "context": {
    "orgId": "org-abc123",
    "projectId": "polished-snowflake-12345678",
    "branchId": "br-main-branch-87654321"
  },
  "project": { "id": "polished-snowflake-12345678" },
  "message": "Linked /path/to/cwd/.neon to project ..."
}
```

Resulting `.neon`:

```json
{
  "orgId": "org-abc123",
  "projectId": "polished-snowflake-12345678",
  "branchId": "br-main-branch-87654321"
}
```

## Test plan

- [x] **20 new e2e tests** in `src/commands/link.test.ts` covering all three modes, the org-scoped-key paths (auto-detect + `orgKeyLimited`), the regions fallback, agent error responses (bad `--params`, conflicting flags), the CI guard, `.neon` overwrite behavior, the new `.gitignore` scaffolding (create / append / no-duplicate / via `set-context`), and a regression test for `set-context --branch-id`.
- [x] **10 new unit tests** in `src/context.test.ts` covering `currentContextFile` walk-up semantics, `ensureGitignored` (create / append / no-duplicate / trailing newline / whitespace / partial-match), and `applyContext` integration.
- [x] Tests run end-to-end against `emocks` (no `apiClient` mocks) following the established `testCliCommand` pattern in `src/test_utils/fixtures.ts`. New mock dirs: `mocks/org-key/`, `mocks/org-key-empty/`.
- [x] Snapshots are deterministic across runs and machines via a per-test serializer that normalizes the per-run tmpdir prefix to `<TMP>`; each test gets its own sub-directory so `.gitignore` writes don't leak between tests.
- [x] **Full suite: 177 / 177 passing**. `npm run lint` clean.
- [x] Verified end-to-end against the real Neon API with an organization-scoped key (see follow-up comments): all three modes succeed at creating, linking to existing, emitting the expected agent JSON, writing `.neon` in the cwd, and scaffolding `.gitignore` correctly (create new / append idempotently); all test projects deleted afterward.

## Out of scope (potential follow-ups)

- Linking to a specific role / database / compute endpoint (currently only org + project + default branch).
- Deriving `orgId` from `--project-id` alone via a `getProject` call so users could pass just `--project-id` without `--org-id`.
- Surfacing the agent JSON schema as a separate typed contract package.
