### PR TITLE
fix(cli): correct data-api get types and psql -- forwarding

### DIFF
--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -265,7 +265,9 @@ const get = async (props: DataApiProps): Promise<void> => {
   };
 
   if (props.output === 'json' || props.output === 'yaml') {
-    writer(props).end(publicData, { fields: GET_FIELDS });
+    writer(props).end(publicData, {
+      fields: ['url', 'status', 'settings'] as const,
+    });
     return;
   }
   writer(props).end(tableRow, { fields: GET_FIELDS });

--- a/src/utils/middlewares.ts
+++ b/src/utils/middlewares.ts
@@ -9,7 +9,7 @@ export const fillInArgs = (
   acc: string[] = [],
 ) => {
   Object.entries(currentArgs).forEach(([k, v]) => {
-    if (k === '_') {
+    if (k === '_' || k === '--') {
       return;
     }
     // check if the value is an Object


### PR DESCRIPTION
## Summary

  Two fixes that together unblock `main` CI:

  ### 1. TS build error in `data-api get`

  After #465 merged, the `main` build fails:

  src/commands/data_api.ts(268,23): error TS2345:
    Type 'readonly ["url", "status", "db_schemas"]' is not assignable to
    type 'readonly ("url" | "settings" | "status")[]'.

  `GET_FIELDS = ['url', 'status', 'db_schemas']` is shared between the json/yaml branch (which writes `publicData`, no `db_schemas` key — nested under `settings`) and the table branch (which
  writes `tableRow`, flattened). The writer ignores `fields` for json/yaml output, so this is purely a type-side issue. Pass a `publicData`-compatible fields list on that branch.

  ### 2. `psql forwards args after --` test failing

  Once the build is unblocked, the psql `--` forwarding test fails: `Unknown arguments: --.0, --.1`.

  Root cause: `fillInArgs` (utils/middlewares.ts) recursively expands nested object/array values into dot-notation keys. It already skips the yargs-special `_` positional key but not the
  equally-special `--` key produced by `parserConfiguration['populate--']`. So for `neonctl psql main -- -c 'SELECT 1'`, `argv['--'] = ['-c', 'SELECT 1']` gets expanded to `argv['--.0']` /
  `argv['--.1']`. Because the middleware runs with `applyBeforeValidation: true`, yargs' `.strict()` on `psql` then rejects them as unknown.

  Skip `--` alongside `_`.

  ## Test plan

  - [x] `tsc --noEmit` clean (was failing before fix 1)
  - [x] `vitest run` — 163/163 pass (was 162/163 before fix 2; the `psql forwards args after --` test exercises the regression)