### PR TITLE
fix(release): create branch/tag with GitHub App token

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,6 +41,17 @@ jobs:
         with:
           egress-policy: audit
 
+      # GITHUB_TOKEN can't push refs in this repo; use the GitHub App token
+      # (same app the release workflow uses) so the tag push below succeeds.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Diagnostic — log event identity
         # Records actor/sender/ref/sha for post-release forensic auditing.
         env:
@@ -66,6 +77,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          # Persist the App token so `git push` of the tag below is authorized.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse release metadata
         id: parse

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -66,6 +66,19 @@ jobs:
         with:
           egress-policy: audit
 
+      # The default GITHUB_TOKEN cannot create branch refs in this repo, so the
+      # branch/PR is created with a GitHub App token (same app the previous
+      # release workflow used). PRs opened by this token also trigger the
+      # required-check workflows, unlike GITHUB_TOKEN-opened PRs.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Check actor has admin/maintain role
         env:
           GH_TOKEN: ${{ github.token }}
@@ -217,13 +230,12 @@ jobs:
 
       - name: Create signed commit + open PR
         id: cpr
-        # Commits via the GitHub Contents API → produces commits signed by the
-        # github-actions[bot] verified signature. Replaces a plain
-        # `git add && commit && push && gh pr create` (which produces unsigned
-        # commits). Auto-merge is NOT enabled — see PR body for why.
+        # Commits via the GitHub Contents API → produces a verified-signature
+        # commit. Uses the GitHub App token because GITHUB_TOKEN can't create
+        # the branch ref here. Auto-merge is NOT enabled — see PR body for why.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           sign-commits: true
           commit-message: ${{ steps.meta.outputs.commit_message }}
           branch: ${{ steps.meta.outputs.branch }}


### PR DESCRIPTION
## Summary

The two-stage release workflows fail with the default `GITHUB_TOKEN`: `prepare-release.yml` errors at **"Create signed commit + open PR"** with `Reference update failed` ([run](https://github.com/neondatabase/neonctl/actions/runs/26829234287/job/79105477899)), and `post-release.yml`'s tag push would hit the same wall.

Root cause: in this repo, `GITHUB_TOKEN` can't create refs (branch or tag) — confirmed by the failures even with "Allow GitHub Actions to create and approve pull requests" enabled. The commit *objects* are created fine, so `contents: write` is effective; it's ref **creation** that's rejected by policy. The previous semantic-release workflow used a GitHub App token for exactly this reason (the App is a bypass actor for the ref-creation policy; `GITHUB_TOKEN` is not).

## Change

- Generate a GitHub App token via `actions/create-github-app-token` (reusing the existing `GH_APP_ID` / `GH_PRIVATE_KEY` secrets) in both workflows.
- `prepare-release.yml`: pass it to `peter-evans/create-pull-request` instead of `github.token`.
- `post-release.yml`: persist it on `actions/checkout` so the tag `git push` is authorized.
- Read-only steps (actor-role check, PR comment) keep `github.token`.

Bonus: PRs opened by the App token trigger the required-check workflows, which `GITHUB_TOKEN`-opened PRs do not.

## Note

Assumes `GH_APP_ID` / `GH_PRIVATE_KEY` are still present (they were used by the pre-migration `release.yml`). If the run now fails at the **Generate GitHub App token** step, the App install / secrets need re-adding.

## Try it

After merge, dispatch a dry release:

```bash
gh workflow run prepare-release.yml --repo neondatabase/neonctl --ref main -f bump=patch -f beta=false
```

It should now open the release PR instead of failing at ref creation.