### PR TITLE
feat(dev): add `neon dev` to run a function locally with hot reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup": "3.29.4",
     "strip-ansi": "7.1.0",
     "tsx": "4.22.3",
-    "typescript": "4.9.5",
+    "typescript": "5.8.3",
     "typescript-eslint": "8.28.0",
     "vitest": "1.6.1"
   },
@@ -57,11 +57,16 @@
     "esbuild": "0.28.0"
   },
   "dependencies": {
+    "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
+    "@neondatabase/config": "link:../neon-pkgs/packages/config",
+    "@neondatabase/config-runtime": "link:../neon-pkgs/packages/config-runtime",
+    "@neondatabase/env": "link:../neon-pkgs/packages/env",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",
     "chalk": "5.3.0",
+    "chokidar": "5.0.0",
     "cli-table": "0.3.11",
     "cliui": "8.0.1",
     "diff": "5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@hono/node-server':
+        specifier: 2.0.4
+        version: 2.0.4(hono@4.12.23)
       '@neondatabase/api-client':
         specifier: 2.7.1
         version: 2.7.1
+      '@neondatabase/config':
+        specifier: link:../neon-pkgs/packages/config
+        version: link:../neon-pkgs/packages/config
+      '@neondatabase/config-runtime':
+        specifier: link:../neon-pkgs/packages/config-runtime
+        version: link:../neon-pkgs/packages/config-runtime
+      '@neondatabase/env':
+        specifier: link:../neon-pkgs/packages/env
+        version: link:../neon-pkgs/packages/env
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -23,6 +35,9 @@ importers:
       chalk:
         specifier: 5.3.0
         version: 5.3.0
+      chokidar:
+        specifier: 5.0.0
+        version: 5.0.0
       cli-table:
         specifier: 0.3.11
         version: 0.3.11
@@ -149,11 +164,11 @@ importers:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 4.9.5
-        version: 4.9.5
+        specifier: 5.8.3
+        version: 5.8.3
       typescript-eslint:
         specifier: 8.28.0
-        version: 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+        version: 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       vitest:
         specifier: 1.6.1
         version: 1.6.1(@types/node@18.19.41)
@@ -638,6 +653,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1418,6 +1439,10 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -2084,6 +2109,10 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2903,6 +2932,10 @@ packages:
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3314,9 +3347,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.4:
@@ -3667,14 +3700,14 @@ snapshots:
       '@commitlint/types': 17.8.1
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@4.9.5)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@4.9.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5))(typescript@4.9.5)
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -3939,6 +3972,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.1
       yargs: 17.7.2
+
+  '@hono/node-server@2.0.4(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4320,32 +4357,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5))(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
       eslint: 9.29.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.3
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4354,20 +4391,20 @@ snapshots:
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/visitor-keys': 8.28.0
 
-  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       debug: 4.4.3
       eslint: 9.29.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.28.0': {}
 
-  '@typescript-eslint/typescript-estree@8.28.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@8.28.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/visitor-keys': 8.28.0
@@ -4376,19 +4413,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0)
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4786,6 +4823,10 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
@@ -4898,21 +4939,21 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@4.9.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5))(typescript@4.9.5):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@4.9.5)
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.9.5)
-      typescript: 4.9.5
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.8.3)
+      typescript: 5.8.3
 
-  cosmiconfig@8.3.6(typescript@4.9.5):
+  cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.8.3
 
   cpu-features@0.0.10:
     dependencies:
@@ -5561,6 +5602,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.23: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -6330,6 +6373,8 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  readdirp@5.0.0: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -6768,11 +6813,11 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@4.9.5):
+  ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5):
+  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -6786,7 +6831,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -6829,17 +6874,17 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.28.0(eslint@9.29.0)(typescript@4.9.5):
+  typescript-eslint@8.28.0(eslint@9.29.0)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5))(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@4.9.5: {}
+  typescript@5.8.3: {}
 
   ufo@1.6.4: {}
 

--- a/src/commands/__snapshots__/dev.test.ts.snap
+++ b/src/commands/__snapshots__/dev.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dev > exits 1 when --source is missing 1`] = `""`;
+
+exports[`dev > exits 1 when --source points at a file that does not exist 1`] = `""`;

--- a/src/commands/__snapshots__/dev.test.ts.snap
+++ b/src/commands/__snapshots__/dev.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dev > exits 1 when --source is missing 1`] = `""`;
+exports[`dev > exits 1 when --port is given without --source 1`] = `""`;
 
 exports[`dev > exits 1 when --source points at a file that does not exist 1`] = `""`;
+
+exports[`dev > exits 1 when no --source and no neon.ts is found 1`] = `""`;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -163,6 +163,12 @@ export const ensureAuth = async (
     return;
   }
 
+  // `dev` runs a function locally. It injects the selected branch's env vars
+  // when credentials happen to be available, but must never trigger an
+  // interactive login: use an API key or existing stored credentials if
+  // present, otherwise run with no API client (env injection is skipped).
+  const isLocalDev = props._[0] === 'dev';
+
   // Use existing API key or handle auth command
   if (props.apiKey || props._[0] === 'auth') {
     if (props.apiKey) {
@@ -214,6 +220,14 @@ export const ensureAuth = async (
       'Credentials file %s does not exist, starting authentication',
       credentialsPath,
     );
+  }
+
+  // `dev` never launches the interactive browser flow. With no usable
+  // credentials it proceeds without an API client; env injection is skipped
+  // and the function still runs locally.
+  if (isLocalDev) {
+    log.debug('dev: no usable credentials; running without env injection');
+    return;
   }
 
   // Start new auth flow if no valid token exists or refresh failed

--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -4,8 +4,28 @@ import { describe } from 'vitest';
 import { test } from '../test_utils/fixtures';
 
 describe('dev', () => {
-  test('exits 1 when --source is missing', async ({ testCliCommand }) => {
-    await testCliCommand(['dev'], { code: 1 });
+  test('exits 1 when no --source and no neon.ts is found', async ({
+    testCliCommand,
+  }) => {
+    // Runs in the repo root, which has no neon.ts: nothing to serve.
+    await testCliCommand(['dev'], {
+      code: 1,
+      stderr:
+        'ERROR: No --source given and no neon.ts found. Pass --source <path> ' +
+        'to run a single function, or add a neon.ts that declares functions ' +
+        'under `preview.functions`.',
+    });
+  });
+
+  test('exits 1 when --port is given without --source', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(['dev', '--port', '3000'], {
+      code: 1,
+      stderr:
+        'ERROR: --port can only be used with --source. To set ports for the ' +
+        'functions in neon.ts, give each one a `dev.port` in its config.',
+    });
   });
 
   test('exits 1 when --source points at a file that does not exist', async ({

--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -1,0 +1,17 @@
+import { join } from 'node:path';
+import { describe } from 'vitest';
+
+import { test } from '../test_utils/fixtures';
+
+describe('dev', () => {
+  test('exits 1 when --source is missing', async ({ testCliCommand }) => {
+    await testCliCommand(['dev'], { code: 1 });
+  });
+
+  test('exits 1 when --source points at a file that does not exist', async ({
+    testCliCommand,
+  }) => {
+    const missing = join(process.cwd(), 'does-not-exist.ts');
+    await testCliCommand(['dev', '--source', missing], { code: 1 });
+  });
+});

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,0 +1,458 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+import yargs from 'yargs';
+
+import { log } from '../log.js';
+import { bundleEntry } from '../utils/esbuild.js';
+import { resolveDevEnv } from '../dev/env.js';
+import { resolveWatchInputs } from '../dev/inputs.js';
+import { branchIdResolve } from '../utils/enrichers.js';
+import type { CommonProps } from '../types.js';
+
+type DevProps = CommonProps & {
+  source: string;
+  port?: number;
+  projectId?: string;
+  branch?: string;
+  id?: string;
+};
+
+export const command = 'dev';
+export const describe = 'Run a Neon Function locally with a dev server';
+
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 dev --source <path> [options]')
+    .example(
+      '$0 dev --source ./functions/hello.ts',
+      'Serve one function on a free port with hot reload',
+    )
+    .example(
+      '$0 dev --source ./functions/hello.ts --port 3000',
+      'Serve on an explicit port (fails if the port is taken)',
+    )
+    .example(
+      'portless run $0 dev --source ./functions/hello.ts',
+      'Serve through portless (honors the injected PORT)',
+    )
+    .options({
+      source: {
+        describe: 'Path to the function entry module',
+        type: 'string',
+        demandOption: true,
+      },
+      port: {
+        describe:
+          'Port to listen on. Fails if taken. Without it (and without a ' +
+          'PORT env var) a free port is chosen automatically.',
+        type: 'number',
+      },
+    })
+    .strict();
+
+export const handler = async (props: DevProps): Promise<void> => {
+  const source = resolve(process.cwd(), props.source);
+  if (!existsSync(source)) {
+    throw new Error(`Source file not found: ${source}`);
+  }
+
+  const neonEnv = await resolveNeonEnv(props);
+  const childEnv = buildChildEnv(props.port, neonEnv);
+
+  await runDevServer({
+    source,
+    cwd: process.cwd(),
+    runtimePath: resolveRuntimePath(),
+    childEnv,
+  });
+};
+
+/**
+ * Resolve the branch's Neon env vars to inject (see {@link resolveDevEnv}).
+ * Requires an authenticated API client; without one (no credentials), env
+ * injection is silently skipped so the function still runs locally.
+ */
+const resolveNeonEnv = async (
+  props: DevProps,
+): Promise<Record<string, string>> => {
+  if (!props.apiClient || !props.projectId) {
+    log.debug('dev: no API client / project context; skipping env injection');
+    return resolveDevEnv({ cwd: process.cwd() });
+  }
+
+  let branchId: string | undefined;
+  try {
+    const branch = props.branch ?? props.id;
+    branchId = branch
+      ? await branchIdResolve({
+          branch,
+          apiClient: props.apiClient,
+          projectId: props.projectId,
+        })
+      : undefined;
+  } catch (err) {
+    log.debug(
+      'dev: could not resolve branch id: %s',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  return resolveDevEnv({
+    cwd: process.cwd(),
+    projectId: props.projectId,
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+  });
+};
+
+const DEFAULT_PORT_BASE = 8787;
+
+/**
+ * Build the child env. The Neon vars layer over the inherited environment (so
+ * the branch's DATABASE_URL wins over a stale inherited value); a function that
+ * loads its own `.env` at runtime still overrides them. Port resolution:
+ *   1. `--port`              -> explicit, fail if taken
+ *   2. `PORT` env (portless) -> explicit, fail if taken
+ *   3. neither               -> search upward from the default base, never fail
+ */
+const buildChildEnv = (
+  port: number | undefined,
+  neonEnv: Record<string, string>,
+): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...neonEnv };
+  delete env.NEON_DEV_PORT;
+  delete env.NEON_DEV_PORT_BASE;
+
+  if (port !== undefined) {
+    env.NEON_DEV_PORT = String(port);
+    return env;
+  }
+  if (process.env.PORT !== undefined && process.env.PORT !== '') {
+    env.NEON_DEV_PORT = process.env.PORT;
+    return env;
+  }
+  env.NEON_DEV_PORT_BASE = String(DEFAULT_PORT_BASE);
+  return env;
+};
+
+type DevServerOptions = {
+  source: string;
+  cwd: string;
+  runtimePath: string;
+  childEnv: NodeJS.ProcessEnv;
+};
+
+const READY_PATTERN = /neon-dev:ready (\d+)/;
+
+const runDevServer = async (options: DevServerOptions): Promise<void> => {
+  let child: ChildProcess | null = null;
+  let boundPort: number | null = null;
+  let shuttingDown = false;
+  let restartTimer: NodeJS.Timeout | null = null;
+  let everReady = false;
+  let watcher: Watcher | null = null;
+
+  // The bundle and its module resolution root live under the user's
+  // node_modules so the function's npm deps (left external by the bundler)
+  // resolve at runtime. Cleaned up on shutdown.
+  const bundleDir = join(options.cwd, 'node_modules', '.neon-dev');
+
+  const bundleAndStart = async (): Promise<number | null> => {
+    let bundlePath: string;
+    try {
+      bundlePath = await writeBundle(options.source, bundleDir);
+    } catch (err) {
+      log.error(
+        'Failed to bundle %s:\n%s',
+        options.source,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+
+    // Re-sync the watch set after every (re)bundle: imports can be added or
+    // removed between edits, so the precise input list shifts over time.
+    if (watcher) await watcher.sync();
+
+    const next = spawn(process.execPath, [options.runtimePath, bundlePath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.childEnv,
+    });
+    child = next;
+
+    const ready = waitForReady(next);
+    pipeChildOutput(next);
+
+    next.on('exit', (code, signal) => {
+      if (shuttingDown || child !== next) return;
+      if (signal) {
+        log.debug('runtime exited via %s', signal);
+        return;
+      }
+      if (code && code !== 0 && everReady) {
+        log.error('Function exited with code %d (waiting for a change)', code);
+      }
+    });
+
+    const port = await ready;
+    if (port !== null) {
+      boundPort = port;
+      everReady = true;
+    }
+    return port;
+  };
+
+  const restart = (): void => {
+    if (shuttingDown) return;
+    if (restartTimer) clearTimeout(restartTimer);
+    restartTimer = setTimeout(() => {
+      void (async () => {
+        log.info(chalk.dim('Change detected, restarting…'));
+        if (child) await killChild(child);
+        if (shuttingDown) return;
+        const port = await bundleAndStart();
+        if (port !== null) {
+          log.info(chalk.green('Ready') + ` ${urlFor(port)}`);
+        }
+      })();
+    }, 150);
+  };
+
+  // Create the watcher before the first bundle so `bundleAndStart` can sync the
+  // watch set on every run (including the initial one).
+  watcher = await startWatcher(options.source, restart);
+
+  const initialPort = await bundleAndStart();
+  if (initialPort === null) {
+    await watcher.close();
+    throw new Error(
+      'The function failed to start. See the output above for details.',
+    );
+  }
+  printBanner(options.source, boundPort);
+
+  const activeWatcher = watcher;
+  await new Promise<void>((resolveRun) => {
+    const shutdown = (): void => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      if (restartTimer) clearTimeout(restartTimer);
+      void (async () => {
+        await activeWatcher.close();
+        if (child) await killChild(child);
+        rmSync(bundleDir, { recursive: true, force: true });
+        log.info(chalk.dim('Stopped the dev server.'));
+        resolveRun();
+      })();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  });
+};
+
+/**
+ * Bundle the source with the shared esbuild helper and write the output into
+ * `bundleDir` (under the user's node_modules so external deps resolve). Returns
+ * the path to the bundled entry.
+ */
+const writeBundle = async (
+  source: string,
+  bundleDir: string,
+): Promise<string> => {
+  const files = await bundleEntry(source);
+  mkdirSync(bundleDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(bundleDir, name), contents);
+  }
+  return join(bundleDir, 'out.js');
+};
+
+const urlFor = (port: number): string => `http://localhost:${port}`;
+
+const waitForReady = (child: ChildProcess): Promise<number | null> =>
+  new Promise<number | null>((resolveReady) => {
+    let settled = false;
+    let buffer = '';
+    const onData = (chunk: Buffer): void => {
+      buffer += chunk.toString();
+      const match = READY_PATTERN.exec(buffer);
+      if (match && !settled) {
+        settled = true;
+        child.stdout?.off('data', onData);
+        resolveReady(Number(match[1]));
+      }
+    };
+    child.stdout?.on('data', onData);
+    child.once('exit', () => {
+      if (!settled) {
+        settled = true;
+        resolveReady(null);
+      }
+    });
+  });
+
+/**
+ * Forward the child's stdout/stderr to the parent, swallowing the
+ * machine-readable `neon-dev:ready` line.
+ */
+const pipeChildOutput = (child: ChildProcess): void => {
+  const forward = (stream: 'stdout' | 'stderr'): void => {
+    let buffer = '';
+    child[stream]?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (READY_PATTERN.test(line)) continue;
+        process[stream].write(`${line}\n`);
+      }
+    });
+  };
+  forward('stdout');
+  forward('stderr');
+};
+
+const printBanner = (source: string, boundPort: number | null): void => {
+  log.info('');
+  log.info(chalk.green.bold('  Neon Functions dev server'));
+  log.info('');
+  const url = boundPort === null ? chalk.red('not running') : urlFor(boundPort);
+  log.info(`  ${chalk.dim('URL')}     ${url}`);
+  log.info(`  ${chalk.dim('Source')}  ${source}`);
+  log.info('');
+};
+
+type Watcher = {
+  /** Re-derive the watch set and add/remove files to match. */
+  sync: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+const startWatcher = async (
+  source: string,
+  restart: () => void,
+): Promise<Watcher> => {
+  // chokidar is bundled with neonctl; import lazily to keep startup cheap.
+  const { default: chokidar } = await import('chokidar');
+
+  // Precise input watching: watch exactly the files esbuild reads to build the
+  // bundle (entry + every local import) so a single edit triggers exactly one
+  // rebuild. Falls back to directory watching when the input set is unavailable
+  // (packaged binary / esbuild module won't load); `null` signals that case.
+  const initialInputs = await resolveWatchInputs(source);
+
+  if (initialInputs === null) {
+    return startDirectoryWatcher(chokidar, source, restart);
+  }
+  return startInputWatcher(chokidar, source, initialInputs, restart);
+};
+
+type Chokidar = typeof import('chokidar').default;
+
+/**
+ * Watch a precise set of files (the bundle's inputs). `sync` re-derives the set
+ * after each rebuild — adding newly-imported files and unwatching removed ones —
+ * because the import graph can change between edits.
+ */
+const startInputWatcher = async (
+  chokidar: Chokidar,
+  source: string,
+  initialInputs: string[],
+  restart: () => void,
+): Promise<Watcher> => {
+  // Always keep the entry watched even if a transient bundle failure drops it
+  // from the input set, so edits that fix the error are still detected.
+  const watched = new Set<string>([source, ...initialInputs]);
+  const watcher = chokidar.watch([...watched], { ignoreInitial: true });
+  await once(watcher, 'ready');
+  watcher.on('all', () => {
+    restart();
+  });
+
+  const sync = async (): Promise<void> => {
+    const next = await resolveWatchInputs(source);
+    // A failed/unavailable re-resolve keeps the current set rather than dropping
+    // everything — the next successful rebuild re-syncs it.
+    if (next === null) return;
+    const desired = new Set<string>([source, ...next]);
+    for (const file of desired) {
+      if (!watched.has(file)) {
+        watcher.add(file);
+        watched.add(file);
+      }
+    }
+    for (const file of watched) {
+      if (!desired.has(file)) {
+        watcher.unwatch(file);
+        watched.delete(file);
+      }
+    }
+  };
+
+  return { sync, close: () => watcher.close() };
+};
+
+/**
+ * Fallback when the precise input set is unavailable: watch the source's
+ * directory. `ignored` is a path predicate (chokidar 5) matching on path
+ * *segments* (not a substring like '/node_modules/') so the bare `node_modules`
+ * directory event emitted when we write our bundle into node_modules/.neon-dev
+ * is also ignored — otherwise it triggers an endless rebuild loop.
+ */
+const startDirectoryWatcher = async (
+  chokidar: Chokidar,
+  source: string,
+  restart: () => void,
+): Promise<Watcher> => {
+  const watchedDir = dirname(source);
+  const isIgnored = (p: string): boolean => {
+    const segments = p.split(/[/\\]/);
+    return (
+      segments.includes('node_modules') ||
+      segments.includes('.git') ||
+      segments.includes('dist')
+    );
+  };
+  const watcher = chokidar.watch(watchedDir, {
+    ignoreInitial: true,
+    ignored: (path: string) => isIgnored(path),
+  });
+  await once(watcher, 'ready');
+  watcher.on('all', () => {
+    restart();
+  });
+  return { sync: () => Promise.resolve(), close: () => watcher.close() };
+};
+
+const killChild = (child: ChildProcess): Promise<void> => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolveKill) => {
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 2000);
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      resolveKill();
+    });
+    child.kill('SIGTERM');
+  });
+};
+
+/**
+ * Locate the compiled runtime entry (`dist/dev/runtime.js`) relative to this
+ * module (`dist/commands/dev.js`). Run in place by a plain `node` child, which
+ * resolves the runtime's own imports (e.g. `@hono/node-server`) from neonctl's
+ * node_modules.
+ */
+const resolveRuntimePath = (): string => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidate = join(here, '..', 'dev', 'runtime.js');
+  if (!existsSync(candidate)) {
+    throw new Error(`Could not locate the dev runtime at ${candidate}`);
+  }
+  return candidate;
+};

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -9,12 +9,16 @@ import yargs from 'yargs';
 import { log } from '../log.js';
 import { bundleEntry } from '../utils/esbuild.js';
 import { resolveDevEnv } from '../dev/env.js';
+import {
+  resolveFunctionsFromConfig,
+  type PlannedFunction,
+} from '../dev/functions.js';
 import { resolveWatchInputs } from '../dev/inputs.js';
 import { branchIdResolve } from '../utils/enrichers.js';
 import type { CommonProps } from '../types.js';
 
 type DevProps = CommonProps & {
-  source: string;
+  source?: string;
   port?: number;
   projectId?: string;
   branch?: string;
@@ -22,229 +26,376 @@ type DevProps = CommonProps & {
 };
 
 export const command = 'dev';
-export const describe = 'Run a Neon Function locally with a dev server';
+export const describe = 'Run Neon Functions locally with a dev server';
 
 export const builder = (argv: yargs.Argv) =>
   argv
-    .usage('$0 dev --source <path> [options]')
+    .usage('$0 dev [--source <path>] [options]')
     .example(
       '$0 dev --source ./functions/hello.ts',
       'Serve one function on a free port with hot reload',
     )
     .example(
-      '$0 dev --source ./functions/hello.ts --port 3000',
-      'Serve on an explicit port (fails if the port is taken)',
+      '$0 dev',
+      'Serve every function declared in neon.ts (one dev server each)',
     )
     .example(
-      'portless run $0 dev --source ./functions/hello.ts',
-      'Serve through portless (honors the injected PORT)',
+      '$0 dev --source ./functions/hello.ts --port 3000',
+      'Serve one function on an explicit port (fails if the port is taken)',
     )
     .options({
       source: {
-        describe: 'Path to the function entry module',
+        describe:
+          'Path to a single function entry module. Omit to serve every ' +
+          'function declared in neon.ts.',
         type: 'string',
-        demandOption: true,
       },
       port: {
         describe:
-          'Port to listen on. Fails if taken. Without it (and without a ' +
-          'PORT env var) a free port is chosen automatically.',
+          'Port to listen on (single-function mode only, with --source). ' +
+          'Fails if taken. Without it (and without a PORT env var) a free ' +
+          'port is chosen automatically.',
         type: 'number',
       },
     })
     .strict();
 
 export const handler = async (props: DevProps): Promise<void> => {
-  const source = resolve(process.cwd(), props.source);
+  if (props.source !== undefined) {
+    await runSingleSource(props);
+    return;
+  }
+
+  // No --source: --port has no single target to bind, so reject it explicitly
+  // rather than silently ignoring it.
+  if (props.port !== undefined) {
+    throw new Error(
+      '--port can only be used with --source. To set ports for the functions ' +
+        'in neon.ts, give each one a `dev.port` in its config.',
+    );
+  }
+
+  await runFromConfig(props);
+};
+
+/** Single-function mode: serve exactly the `--source` path (legacy behavior). */
+const runSingleSource = async (props: DevProps): Promise<void> => {
+  const source = resolve(process.cwd(), props.source as string);
   if (!existsSync(source)) {
     throw new Error(`Source file not found: ${source}`);
   }
 
-  const neonEnv = await resolveNeonEnv(props);
-  const childEnv = buildChildEnv(props.port, neonEnv);
-
-  await runDevServer({
-    source,
+  const branchId = await resolveBranchId(props);
+  const neonEnv = await resolveDevEnv({
     cwd: process.cwd(),
-    runtimePath: resolveRuntimePath(),
-    childEnv,
+    ...(props.projectId ? { projectId: props.projectId } : {}),
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
   });
+
+  const unit: ServedUnit = {
+    slug: null,
+    source,
+    bundleDir: join(process.cwd(), 'node_modules', '.neon-dev'),
+    childEnv: buildChildEnv(neonEnv, portFromProps(props.port)),
+    label: null,
+  };
+
+  await runSupervisor([unit]);
 };
 
 /**
- * Resolve the branch's Neon env vars to inject (see {@link resolveDevEnv}).
- * Requires an authenticated API client; without one (no credentials), env
- * injection is silently skipped so the function still runs locally.
+ * Multi-function mode: serve every function declared in neon.ts. Requires a neon.ts
+ * (there is no single source to fall back on), one dev server per function.
  */
-const resolveNeonEnv = async (
-  props: DevProps,
-): Promise<Record<string, string>> => {
-  if (!props.apiClient || !props.projectId) {
-    log.debug('dev: no API client / project context; skipping env injection');
-    return resolveDevEnv({ cwd: process.cwd() });
+const runFromConfig = async (props: DevProps): Promise<void> => {
+  const branchId = await resolveBranchId(props);
+  const functions = await resolveFunctionsFromConfig(process.cwd());
+
+  if (functions === null) {
+    throw new Error(
+      'No --source given and no neon.ts found. Pass --source <path> to run a ' +
+        'single function, or add a neon.ts that declares functions under ' +
+        '`preview.functions`.',
+    );
+  }
+  if (functions.length === 0) {
+    throw new Error(
+      'neon.ts has no functions to serve. Add at least one under ' +
+        '`preview.functions`, or pass --source <path>.',
+    );
   }
 
-  let branchId: string | undefined;
+  const neonEnv = await resolveDevEnv({
+    cwd: process.cwd(),
+    ...(props.projectId ? { projectId: props.projectId } : {}),
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+  });
+
+  // Give each search-mode (no dev.port, non-portless) function a distinct search base so
+  // they don't all start probing at the same port. The runtime still walks upward from its
+  // base, so an occupied base self-resolves; the offset just makes startup deterministic.
+  let searchOffset = 0;
+  const units = functions.map((fn) => {
+    const base = DEFAULT_PORT_BASE + searchOffset;
+    if (!fn.portless && fn.port === undefined) searchOffset += 1;
+    return plannedToUnit(fn, neonEnv, base);
+  });
+  await runSupervisor(units);
+};
+
+/**
+ * Resolve the selected branch id from props, if any. Best-effort: a failure here only
+ * means env injection is skipped, so it never throws.
+ */
+const resolveBranchId = async (
+  props: DevProps,
+): Promise<string | undefined> => {
+  if (!props.apiClient || !props.projectId) return undefined;
+  const branch = props.branch ?? props.id;
+  if (!branch) return undefined;
   try {
-    const branch = props.branch ?? props.id;
-    branchId = branch
-      ? await branchIdResolve({
-          branch,
-          apiClient: props.apiClient,
-          projectId: props.projectId,
-        })
-      : undefined;
+    return await branchIdResolve({
+      branch,
+      apiClient: props.apiClient,
+      projectId: props.projectId,
+    });
   } catch (err) {
     log.debug(
       'dev: could not resolve branch id: %s',
       err instanceof Error ? err.message : String(err),
     );
+    return undefined;
   }
-
-  return resolveDevEnv({
-    cwd: process.cwd(),
-    projectId: props.projectId,
-    ...(branchId ? { branchId } : {}),
-    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
-  });
 };
 
 const DEFAULT_PORT_BASE = 8787;
 
+type PortSpec =
+  // Bind exactly this port (fail if taken) via NEON_DEV_PORT.
+  | { mode: 'explicit'; port: number }
+  // Search upward from `from` via NEON_DEV_PORT_BASE.
+  | { mode: 'search'; from: number }
+  // Set no port env at all — let an injected PORT (portless) drive the runtime.
+  | { mode: 'inherit' };
+
+const portFromProps = (port: number | undefined): PortSpec => {
+  if (port !== undefined) return { mode: 'explicit', port };
+  if (process.env.PORT !== undefined && process.env.PORT !== '') {
+    return { mode: 'explicit', port: Number(process.env.PORT) };
+  }
+  return { mode: 'search', from: DEFAULT_PORT_BASE };
+};
+
 /**
- * Build the child env. The Neon vars layer over the inherited environment (so
- * the branch's DATABASE_URL wins over a stale inherited value); a function that
- * loads its own `.env` at runtime still overrides them. Port resolution:
- *   1. `--port`              -> explicit, fail if taken
- *   2. `PORT` env (portless) -> explicit, fail if taken
- *   3. neither               -> search upward from the default base, never fail
+ * Translate a {@link PlannedFunction} into a {@link ServedUnit}. Port rules:
+ *   - portless: portless assigns the port and injects PORT, which the runtime honors — so
+ *     we set no port env (`inherit`) and `dev.port` is ignored. Wrapped with
+ *     `portless <slug>` for a stable `slug.localhost` URL.
+ *   - explicit `dev.port`: bind exactly, fail if taken.
+ *   - no `dev.port`: search for a free port (base coordinated by the caller).
+ * Per-function neon.ts env layers over the shared branch env.
+ */
+const plannedToUnit = (
+  fn: PlannedFunction,
+  branchEnv: Record<string, string>,
+  searchBase: number,
+): ServedUnit => {
+  const port: PortSpec = fn.portless
+    ? { mode: 'inherit' }
+    : fn.port !== undefined
+      ? { mode: 'explicit', port: fn.port }
+      : { mode: 'search', from: searchBase };
+  const childEnv = buildChildEnv({ ...branchEnv, ...fn.env }, port);
+  return {
+    slug: fn.slug,
+    source: fn.source,
+    bundleDir: join(process.cwd(), 'node_modules', '.neon-dev', fn.slug),
+    childEnv,
+    label: fn.slug,
+    ...(fn.portless ? { portless: { slug: fn.slug } } : {}),
+  };
+};
+
+/**
+ * Build a child's env. Neon vars layer over the inherited environment (so the branch's
+ * DATABASE_URL wins over a stale inherited value); a function that loads its own `.env`
+ * at runtime still overrides them. The port spec is encoded for the runtime via
+ * NEON_DEV_PORT (explicit) or NEON_DEV_PORT_BASE (search).
  */
 const buildChildEnv = (
-  port: number | undefined,
   neonEnv: Record<string, string>,
+  port: PortSpec,
 ): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = { ...process.env, ...neonEnv };
   delete env.NEON_DEV_PORT;
   delete env.NEON_DEV_PORT_BASE;
-
-  if (port !== undefined) {
-    env.NEON_DEV_PORT = String(port);
-    return env;
+  if (port.mode === 'explicit') {
+    env.NEON_DEV_PORT = String(port.port);
+  } else if (port.mode === 'search') {
+    env.NEON_DEV_PORT_BASE = String(port.from);
   }
-  if (process.env.PORT !== undefined && process.env.PORT !== '') {
-    env.NEON_DEV_PORT = process.env.PORT;
-    return env;
-  }
-  env.NEON_DEV_PORT_BASE = String(DEFAULT_PORT_BASE);
+  // 'inherit': set neither, so an injected PORT (portless) drives the runtime.
   return env;
 };
 
-type DevServerOptions = {
+/**
+ * One function being served locally. `slug`/`label` are null in single-source mode
+ * (one unnamed server). `portless`, when set, wraps the child with `portless run`.
+ */
+type ServedUnit = {
+  slug: string | null;
   source: string;
-  cwd: string;
-  runtimePath: string;
+  bundleDir: string;
   childEnv: NodeJS.ProcessEnv;
+  label: string | null;
+  portless?: { slug: string };
+};
+
+type RunningUnit = {
+  unit: ServedUnit;
+  child: ChildProcess | null;
+  boundPort: number | null;
+  everReady: boolean;
+  restartTimer: NodeJS.Timeout | null;
+  watcher: Watcher | null;
+  status: 'starting' | 'ready' | 'error';
 };
 
 const READY_PATTERN = /neon-dev:ready (\d+)/;
 
-const runDevServer = async (options: DevServerOptions): Promise<void> => {
-  let child: ChildProcess | null = null;
-  let boundPort: number | null = null;
+/**
+ * Supervise one or more {@link ServedUnit}s: bundle + start each in its own child, watch
+ * its inputs for hot reload, and tear everything down cleanly on shutdown. Units are
+ * independent — one crashing or failing to start does not stop the others (it is shown
+ * as errored and recovered on the next edit). A single SIGINT/SIGTERM shuts all of them
+ * down, tree-killing each child so no descendant (e.g. a portless-wrapped runtime) is
+ * orphaned.
+ */
+const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
+  if (hasPortlessUnit(units)) {
+    assertPortlessAvailable();
+  }
+
+  const runtimePath = resolveRuntimePath();
   let shuttingDown = false;
-  let restartTimer: NodeJS.Timeout | null = null;
-  let everReady = false;
-  let watcher: Watcher | null = null;
 
-  // The bundle and its module resolution root live under the user's
-  // node_modules so the function's npm deps (left external by the bundler)
-  // resolve at runtime. Cleaned up on shutdown.
-  const bundleDir = join(options.cwd, 'node_modules', '.neon-dev');
+  const running: RunningUnit[] = units.map((unit) => ({
+    unit,
+    child: null,
+    boundPort: null,
+    everReady: false,
+    restartTimer: null,
+    watcher: null,
+    status: 'starting',
+  }));
 
-  const bundleAndStart = async (): Promise<number | null> => {
+  const bundleAndStart = async (r: RunningUnit): Promise<void> => {
     let bundlePath: string;
     try {
-      bundlePath = await writeBundle(options.source, bundleDir);
+      bundlePath = await writeBundle(r.unit.source, r.unit.bundleDir);
     } catch (err) {
-      log.error(
-        'Failed to bundle %s:\n%s',
-        options.source,
-        err instanceof Error ? err.message : String(err),
+      r.status = 'error';
+      logUnit(
+        r.unit,
+        chalk.red('bundle failed: ') +
+          (err instanceof Error ? err.message : String(err)),
       );
-      return null;
+      return;
     }
 
-    // Re-sync the watch set after every (re)bundle: imports can be added or
-    // removed between edits, so the precise input list shifts over time.
-    if (watcher) await watcher.sync();
+    if (r.watcher) await r.watcher.sync();
 
-    const next = spawn(process.execPath, [options.runtimePath, bundlePath], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: options.childEnv,
-    });
-    child = next;
+    const next = spawnChild(r.unit, runtimePath, bundlePath);
+    r.child = next;
 
     const ready = waitForReady(next);
-    pipeChildOutput(next);
+    pipeChildOutput(next, r.unit.label);
 
     next.on('exit', (code, signal) => {
-      if (shuttingDown || child !== next) return;
+      if (shuttingDown || r.child !== next) return;
       if (signal) {
-        log.debug('runtime exited via %s', signal);
+        log.debug(
+          'runtime for %s exited via %s',
+          r.unit.slug ?? '(source)',
+          signal,
+        );
         return;
       }
-      if (code && code !== 0 && everReady) {
-        log.error('Function exited with code %d (waiting for a change)', code);
+      if (code && code !== 0 && r.everReady) {
+        r.status = 'error';
+        logUnit(
+          r.unit,
+          chalk.red(`exited with code ${code} (waiting for a change)`),
+        );
       }
     });
 
     const port = await ready;
     if (port !== null) {
-      boundPort = port;
-      everReady = true;
+      r.boundPort = port;
+      r.everReady = true;
+      r.status = 'ready';
+    } else {
+      r.status = 'error';
     }
-    return port;
   };
 
-  const restart = (): void => {
+  const restart = (r: RunningUnit): void => {
     if (shuttingDown) return;
-    if (restartTimer) clearTimeout(restartTimer);
-    restartTimer = setTimeout(() => {
+    if (r.restartTimer) clearTimeout(r.restartTimer);
+    r.restartTimer = setTimeout(() => {
       void (async () => {
-        log.info(chalk.dim('Change detected, restarting…'));
-        if (child) await killChild(child);
+        logUnit(r.unit, chalk.dim('change detected, restarting…'));
+        if (r.child) await killTree(r.child);
         if (shuttingDown) return;
-        const port = await bundleAndStart();
-        if (port !== null) {
-          log.info(chalk.green('Ready') + ` ${urlFor(port)}`);
+        await bundleAndStart(r);
+        if (r.status === 'ready') {
+          logUnit(r.unit, chalk.green('ready') + ` ${urlFor(r.boundPort)}`);
         }
       })();
     }, 150);
   };
 
-  // Create the watcher before the first bundle so `bundleAndStart` can sync the
+  // Create each watcher before its first bundle so bundleAndStart can sync the
   // watch set on every run (including the initial one).
-  watcher = await startWatcher(options.source, restart);
-
-  const initialPort = await bundleAndStart();
-  if (initialPort === null) {
-    await watcher.close();
-    throw new Error(
-      'The function failed to start. See the output above for details.',
-    );
+  for (const r of running) {
+    r.watcher = await startWatcher(r.unit.source, () => {
+      restart(r);
+    });
   }
-  printBanner(options.source, boundPort);
 
-  const activeWatcher = watcher;
+  // Start every unit. They are independent: keep going if one fails.
+  await Promise.all(running.map((r) => bundleAndStart(r)));
+
+  if (running.every((r) => r.status === 'error')) {
+    await Promise.all(running.map((r) => r.watcher?.close()));
+    await Promise.all(
+      running.map((r) => (r.child ? killTree(r.child) : undefined)),
+    );
+    for (const r of running)
+      rmSync(r.unit.bundleDir, { recursive: true, force: true });
+    throw new Error('No function started. See the output above for details.');
+  }
+
+  printBanner(running);
+
   await new Promise<void>((resolveRun) => {
     const shutdown = (): void => {
       if (shuttingDown) return;
       shuttingDown = true;
-      if (restartTimer) clearTimeout(restartTimer);
       void (async () => {
-        await activeWatcher.close();
-        if (child) await killChild(child);
-        rmSync(bundleDir, { recursive: true, force: true });
+        for (const r of running) {
+          if (r.restartTimer) clearTimeout(r.restartTimer);
+        }
+        await Promise.all(running.map((r) => r.watcher?.close()));
+        await Promise.all(
+          running.map((r) => (r.child ? killTree(r.child) : undefined)),
+        );
+        for (const r of running) {
+          rmSync(r.unit.bundleDir, { recursive: true, force: true });
+        }
         log.info(chalk.dim('Stopped the dev server.'));
         resolveRun();
       })();
@@ -254,11 +405,64 @@ const runDevServer = async (options: DevServerOptions): Promise<void> => {
   });
 };
 
+const hasPortlessUnit = (units: ServedUnit[]): boolean =>
+  units.some((u) => u.portless !== undefined);
+
 /**
- * Bundle the source with the shared esbuild helper and write the output into
- * `bundleDir` (under the user's node_modules so external deps resolve). Returns
- * the path to the bundled entry.
+ * Spawn the child for a unit. A portless unit is wrapped as `portless <slug> node
+ * <runtime> <bundle>`: portless assigns a port, injects it as PORT (which the runtime
+ * honors), and exposes the server at `slug.localhost`. A plain unit runs the bundled
+ * output directly under `node`.
+ *
+ * Spawned detached (own process group) so killTree can reap the whole group — important
+ * for the portless case, where the tree is portless -> node runtime.
  */
+const spawnChild = (
+  unit: ServedUnit,
+  runtimePath: string,
+  bundlePath: string,
+): ChildProcess => {
+  if (unit.portless) {
+    return spawn(
+      'portless',
+      [unit.portless.slug, process.execPath, runtimePath, bundlePath],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: unit.childEnv,
+        detached: true,
+      },
+    );
+  }
+  return spawn(process.execPath, [runtimePath, bundlePath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: unit.childEnv,
+    detached: true,
+  });
+};
+
+/** Fail early with an actionable message if a portless unit is requested but the binary is missing. */
+const assertPortlessAvailable = (): void => {
+  const result = spawnSyncCheck('portless');
+  if (!result) {
+    throw new Error(
+      'A function sets `dev.portless: true`, but the `portless` command was not ' +
+        'found on your PATH. Install it globally (e.g. `npm i -g portless`) or ' +
+        'remove `dev.portless` from the function in neon.ts.',
+    );
+  }
+};
+
+const spawnSyncCheck = (bin: string): boolean => {
+  try {
+    // Synchronous, no-side-effect probe: `which`/`where` resolves the binary.
+    const probe = process.platform === 'win32' ? 'where' : 'which';
+    const { status } = spawnSync(probe, [bin]);
+    return status === 0;
+  } catch {
+    return false;
+  }
+};
+
 const writeBundle = async (
   source: string,
   bundleDir: string,
@@ -271,7 +475,8 @@ const writeBundle = async (
   return join(bundleDir, 'out.js');
 };
 
-const urlFor = (port: number): string => `http://localhost:${port}`;
+const urlFor = (port: number | null): string =>
+  port === null ? chalk.red('not running') : `http://localhost:${port}`;
 
 const waitForReady = (child: ChildProcess): Promise<number | null> =>
   new Promise<number | null>((resolveReady) => {
@@ -296,10 +501,12 @@ const waitForReady = (child: ChildProcess): Promise<number | null> =>
   });
 
 /**
- * Forward the child's stdout/stderr to the parent, swallowing the
- * machine-readable `neon-dev:ready` line.
+ * Forward the child's stdout/stderr to the parent, swallowing the machine-readable
+ * `neon-dev:ready` line. When `label` is set (multi-function mode), every line is
+ * prefixed with `[slug]` so concurrent servers' output stays readable.
  */
-const pipeChildOutput = (child: ChildProcess): void => {
+const pipeChildOutput = (child: ChildProcess, label: string | null): void => {
+  const prefix = label ? chalk.dim(`[${label}] `) : '';
   const forward = (stream: 'stdout' | 'stderr'): void => {
     let buffer = '';
     child[stream]?.on('data', (chunk: Buffer) => {
@@ -308,7 +515,7 @@ const pipeChildOutput = (child: ChildProcess): void => {
       buffer = lines.pop() ?? '';
       for (const line of lines) {
         if (READY_PATTERN.test(line)) continue;
-        process[stream].write(`${line}\n`);
+        process[stream].write(`${prefix}${line}\n`);
       }
     });
   };
@@ -316,18 +523,24 @@ const pipeChildOutput = (child: ChildProcess): void => {
   forward('stderr');
 };
 
-const printBanner = (source: string, boundPort: number | null): void => {
+const printBanner = (running: RunningUnit[]): void => {
   log.info('');
   log.info(chalk.green.bold('  Neon Functions dev server'));
   log.info('');
-  const url = boundPort === null ? chalk.red('not running') : urlFor(boundPort);
-  log.info(`  ${chalk.dim('URL')}     ${url}`);
-  log.info(`  ${chalk.dim('Source')}  ${source}`);
+  for (const r of running) {
+    const name = r.unit.label ?? 'function';
+    const url = urlFor(r.boundPort);
+    log.info(`  ${chalk.dim(name.padEnd(20))} ${url}`);
+  }
   log.info('');
 };
 
+const logUnit = (unit: ServedUnit, message: string): void => {
+  const prefix = unit.label ? chalk.dim(`[${unit.label}] `) : '';
+  log.info(`${prefix}${message}`);
+};
+
 type Watcher = {
-  /** Re-derive the watch set and add/remove files to match. */
   sync: () => Promise<void>;
   close: () => Promise<void>;
 };
@@ -336,15 +549,8 @@ const startWatcher = async (
   source: string,
   restart: () => void,
 ): Promise<Watcher> => {
-  // chokidar is bundled with neonctl; import lazily to keep startup cheap.
   const { default: chokidar } = await import('chokidar');
-
-  // Precise input watching: watch exactly the files esbuild reads to build the
-  // bundle (entry + every local import) so a single edit triggers exactly one
-  // rebuild. Falls back to directory watching when the input set is unavailable
-  // (packaged binary / esbuild module won't load); `null` signals that case.
   const initialInputs = await resolveWatchInputs(source);
-
   if (initialInputs === null) {
     return startDirectoryWatcher(chokidar, source, restart);
   }
@@ -353,19 +559,12 @@ const startWatcher = async (
 
 type Chokidar = typeof import('chokidar').default;
 
-/**
- * Watch a precise set of files (the bundle's inputs). `sync` re-derives the set
- * after each rebuild — adding newly-imported files and unwatching removed ones —
- * because the import graph can change between edits.
- */
 const startInputWatcher = async (
   chokidar: Chokidar,
   source: string,
   initialInputs: string[],
   restart: () => void,
 ): Promise<Watcher> => {
-  // Always keep the entry watched even if a transient bundle failure drops it
-  // from the input set, so edits that fix the error are still detected.
   const watched = new Set<string>([source, ...initialInputs]);
   const watcher = chokidar.watch([...watched], { ignoreInitial: true });
   await once(watcher, 'ready');
@@ -375,8 +574,6 @@ const startInputWatcher = async (
 
   const sync = async (): Promise<void> => {
     const next = await resolveWatchInputs(source);
-    // A failed/unavailable re-resolve keeps the current set rather than dropping
-    // everything — the next successful rebuild re-syncs it.
     if (next === null) return;
     const desired = new Set<string>([source, ...next]);
     for (const file of desired) {
@@ -396,13 +593,6 @@ const startInputWatcher = async (
   return { sync, close: () => watcher.close() };
 };
 
-/**
- * Fallback when the precise input set is unavailable: watch the source's
- * directory. `ignored` is a path predicate (chokidar 5) matching on path
- * *segments* (not a substring like '/node_modules/') so the bare `node_modules`
- * directory event emitted when we write our bundle into node_modules/.neon-dev
- * is also ignored — otherwise it triggers an endless rebuild loop.
- */
 const startDirectoryWatcher = async (
   chokidar: Chokidar,
   source: string,
@@ -428,26 +618,53 @@ const startDirectoryWatcher = async (
   return { sync: () => Promise.resolve(), close: () => watcher.close() };
 };
 
-const killChild = (child: ChildProcess): Promise<void> => {
+/**
+ * Terminate a child and every descendant it spawned. The child is started `detached`, so
+ * on POSIX it leads its own process group and a negative-PID signal reaps the group
+ * (covering portless -> neonctl -> node). On Windows there are no POSIX groups, so we
+ * shell out to `taskkill /T` to kill the tree. Escalates SIGTERM -> SIGKILL after 2s.
+ */
+const killTree = (child: ChildProcess): Promise<void> => {
   if (child.exitCode !== null || child.signalCode !== null) {
     return Promise.resolve();
   }
+  const pid = child.pid;
   return new Promise<void>((resolveKill) => {
-    const timeout = setTimeout(() => child.kill('SIGKILL'), 2000);
+    const timeout = setTimeout(() => {
+      forceKill(child, pid);
+    }, 2000);
     child.once('exit', () => {
       clearTimeout(timeout);
       resolveKill();
     });
+    if (pid !== undefined && process.platform !== 'win32') {
+      try {
+        process.kill(-pid, 'SIGTERM');
+        return;
+      } catch {
+        // Fall through to a direct kill if the group is already gone.
+      }
+    }
     child.kill('SIGTERM');
   });
 };
 
-/**
- * Locate the compiled runtime entry (`dist/dev/runtime.js`) relative to this
- * module (`dist/commands/dev.js`). Run in place by a plain `node` child, which
- * resolves the runtime's own imports (e.g. `@hono/node-server`) from neonctl's
- * node_modules.
- */
+const forceKill = (child: ChildProcess, pid: number | undefined): void => {
+  if (pid === undefined) {
+    child.kill('SIGKILL');
+    return;
+  }
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(pid), '/T', '/F']);
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+};
+
 const resolveRuntimePath = (): string => {
   const here = dirname(fileURLToPath(import.meta.url));
   const candidate = join(here, '..', 'dev', 'runtime.js');

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -469,6 +469,11 @@ const writeBundle = async (
 ): Promise<string> => {
   const files = await bundleEntry(source);
   mkdirSync(bundleDir, { recursive: true });
+  // The bundle is ESM (`format: 'esm'`), but it's written into a `.js` file under the
+  // user's node_modules — where Node, finding no `"type"`, would treat `.js` as CommonJS
+  // and throw `Unexpected token 'export'`. Drop a `package.json` marker so Node runs it as
+  // ESM. (A bare `out.mjs` would also work but breaks the `out.js.map` sourcemap link.)
+  writeFileSync(join(bundleDir, 'package.json'), '{"type":"module"}\n');
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(join(bundleDir, name), contents);
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ import * as init from './init.js';
 import * as dataApi from './data_api.js';
 import * as neonAuth from './neon_auth.js';
 import * as functions from './functions.js';
+import * as dev from './dev.js';
 
 export default [
   auth,
@@ -38,4 +39,5 @@ export default [
   init,
   dataApi,
   functions,
+  dev,
 ];

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -1,0 +1,306 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  GetConnectionUriInput,
+  NeonApi,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import { resolveDevEnv } from './env.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-main-00000001';
+
+type FakeOverrides = {
+  /** Override `getNeonAuth`. Defaults to returning `null`. */
+  getNeonAuth?: NeonApi['getNeonAuth'];
+  /** Override `getNeonDataApi`. Defaults to returning `null`. */
+  getNeonDataApi?: NeonApi['getNeonDataApi'];
+  /** Override `listBranches` (e.g. to make it throw for the graceful-degrade case). */
+  listBranches?: NeonApi['listBranches'];
+};
+
+/**
+ * A full {@link NeonApi} implementation backed by fixed in-memory state for one
+ * project + one default branch. Methods that `pullConfig` and `fetchEnv` exercise
+ * return real data; everything else throws `not implemented` so an unexpected call
+ * fails loudly instead of silently passing.
+ */
+class FakeNeonApi implements NeonApi {
+  constructor(private readonly overrides: FakeOverrides = {}) {}
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'dev-project',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranches(projectId: string): Promise<NeonBranchSnapshot[]> {
+    if (this.overrides.listBranches) {
+      return this.overrides.listBranches(projectId);
+    }
+    return [
+      {
+        id: BRANCH_ID,
+        name: 'main',
+        isDefault: true,
+        protected: false,
+      },
+    ];
+  }
+
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-fake-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    const host = input.pooled
+      ? `${BRANCH_ID}-pooler.fake.neon.tech`
+      : `${BRANCH_ID}.fake.neon.tech`;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${host}/${input.databaseName}?sslmode=require`,
+    };
+  }
+
+  async getNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot | null> {
+    if (this.overrides.getNeonAuth) {
+      return this.overrides.getNeonAuth(projectId, branchId);
+    }
+    return null;
+  }
+
+  async enableNeonAuth(): Promise<NeonAuthSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async getNeonDataApi(
+    projectId: string,
+    branchId: string,
+    databaseName: string,
+  ): Promise<NeonDataApiSnapshot | null> {
+    if (this.overrides.getNeonDataApi) {
+      return this.overrides.getNeonDataApi(projectId, branchId, databaseName);
+    }
+    return null;
+  }
+
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+
+  async createBranchBucket(): Promise<NeonBucketSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+
+  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async deployBranchFunction(): Promise<NeonFunctionDeploymentSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+describe('resolveDevEnv', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-dev-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('tier 3: no neon.ts and no project/branch -> {}', async () => {
+    await expect(resolveDevEnv({ cwd })).resolves.toEqual({});
+  });
+
+  it('tier 2: no neon.ts but project + branch -> pooled + unpooled DATABASE_URL', async () => {
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api: new FakeNeonApi(),
+    });
+
+    expect(result.DATABASE_URL).toContain('-pooler.fake.neon.tech');
+    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.DATABASE_URL_UNPOOLED).not.toContain('-pooler.');
+    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+  });
+
+  it('tier 2 with Auth integration present: still only Postgres URLs (auth is not surfaced)', async () => {
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    // Tier 2 derives its config from `pullConfig`, whose `buildPulledBranchConfig`
+    // never emits an `auth` block. `resolveConfig` therefore resolves `authEnabled`
+    // to `false`, so `fetchEnv` never calls `getNeonAuth` and NEON_AUTH_BASE_URL is
+    // not injected — even when a live Neon Auth integration exists on the branch.
+    // Enabling auth requires a tier-1 `neon.ts` policy that returns `auth: {}`
+    // (covered by the tier-1 test below).
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(Object.keys(result).sort()).toEqual([
+      'DATABASE_URL',
+      'DATABASE_URL_UNPOOLED',
+    ]);
+    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+  });
+
+  it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(result.DATABASE_URL).toBeDefined();
+    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+  });
+
+  it('graceful: an api whose listBranches throws -> {} (does not throw)', async () => {
+    const api = new FakeNeonApi({
+      listBranches: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    await expect(
+      resolveDevEnv({
+        cwd,
+        projectId: PROJECT_ID,
+        branchId: BRANCH_ID,
+        api,
+      }),
+    ).resolves.toEqual({});
+  });
+});

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -18,7 +18,7 @@ import type {
   NeonRoleSnapshot,
 } from '@neondatabase/config';
 
-import { resolveDevEnv } from './env.js';
+import { DevEnvMismatchError, resolveDevEnv } from './env.js';
 
 const PROJECT_ID = 'patient-art-12345';
 const BRANCH_ID = 'br-main-00000001';
@@ -232,7 +232,7 @@ describe('resolveDevEnv', () => {
     expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
   });
 
-  it('tier 2 with Auth integration present: still only Postgres URLs (auth is not surfaced)', async () => {
+  it('tier 2 with Auth integration present: surfaces NEON_AUTH_BASE_URL too', async () => {
     const api = new FakeNeonApi({
       getNeonAuth: async () => ({
         projectId: 'auth-project',
@@ -241,12 +241,11 @@ describe('resolveDevEnv', () => {
       }),
     });
 
-    // Tier 2 derives its config from `pullConfig`, whose `buildPulledBranchConfig`
-    // never emits an `auth` block. `resolveConfig` therefore resolves `authEnabled`
-    // to `false`, so `fetchEnv` never calls `getNeonAuth` and NEON_AUTH_BASE_URL is
-    // not injected — even when a live Neon Auth integration exists on the branch.
-    // Enabling auth requires a tier-1 `neon.ts` policy that returns `auth: {}`
-    // (covered by the tier-1 test below).
+    // Tier 2 derives its config from `pullConfig`, which now reverse-engineers the
+    // branch's Auth / Data API enablement into `config.auth` / `config.dataApi`. So
+    // `resolveConfig` sees `authEnabled === true`, `fetchEnv` calls `getNeonAuth`,
+    // and NEON_AUTH_BASE_URL is injected from the branch's live state — without any
+    // neon.ts. This mirrors what the deployed function would receive.
     const result = await resolveDevEnv({
       cwd,
       projectId: PROJECT_ID,
@@ -257,8 +256,9 @@ describe('resolveDevEnv', () => {
     expect(Object.keys(result).sort()).toEqual([
       'DATABASE_URL',
       'DATABASE_URL_UNPOOLED',
+      'NEON_AUTH_BASE_URL',
     ]);
-    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 
   it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
@@ -284,6 +284,65 @@ describe('resolveDevEnv', () => {
 
     expect(result.DATABASE_URL).toBeDefined();
     expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+  });
+
+  it('tier 1 mismatch: neon.ts enables auth the branch lacks -> throws DevEnvMismatchError', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    // The branch has NO Auth integration (default `getNeonAuth` -> null), so
+    // `plan` reports an `enable-auth` create: the policy declares a resource the
+    // branch is missing. `dev` must stop and point the user at `neonctl deploy`.
+    const api = new FakeNeonApi();
+
+    await expect(
+      resolveDevEnv({
+        cwd,
+        projectId: PROJECT_ID,
+        branchId: BRANCH_ID,
+        api,
+      }),
+    ).rejects.toBeInstanceOf(DevEnvMismatchError);
+  });
+
+  it('tier 1 mismatch error: names the missing resource and points at deploy', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+    const api = new FakeNeonApi();
+
+    await expect(
+      resolveDevEnv({ cwd, projectId: PROJECT_ID, branchId: BRANCH_ID, api }),
+    ).rejects.toThrow(/auth.*neonctl deploy/s);
+  });
+
+  it('tier 1 match: neon.ts enables auth the branch already has -> injects, no throw', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    // The branch already has the Auth integration, so `plan` reports no missing
+    // resource and `dev` injects NEON_AUTH_BASE_URL.
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
     expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -1,0 +1,109 @@
+import {
+  defineConfig,
+  loadConfigFromFile,
+  type Config,
+  type NeonApi,
+} from '@neondatabase/config';
+import { pullConfig } from '@neondatabase/config-runtime';
+import { fetchEnv, toEntries } from '@neondatabase/env';
+
+import { log } from '../log.js';
+
+export type DevEnvContext = {
+  cwd: string;
+  projectId?: string;
+  branchId?: string;
+  apiKey?: string;
+  /** Injected NeonApi adapter (tests). Production builds it from `apiKey`. */
+  api?: NeonApi;
+};
+
+/**
+ * Resolve the Neon env vars to inject into a locally-served function, mirroring
+ * what the deployed function would receive for the selected branch (pooled /
+ * direct `DATABASE_URL`, plus Auth / Data API when enabled).
+ *
+ * Tiered, and **always degrades gracefully** — a function must still run with no
+ * Neon account, no `.neon`, and no network:
+ *
+ *   1. a `neon.ts` policy is found -> evaluate it with `fetchEnv`
+ *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
+ *      branch's live state into a config, then `fetchEnv` injects what's enabled
+ *   3. otherwise -> inject nothing
+ *
+ * Any failure logs a warning and returns `{}` rather than throwing.
+ */
+export const resolveDevEnv = async (
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  try {
+    const config = await loadNeonConfig(ctx.cwd);
+
+    if (config) {
+      if (!ctx.projectId || !ctx.branchId) {
+        log.warning(
+          'Found a neon.ts but could not resolve the project/branch to ' +
+            'inject env for. Run `neonctl link` and `neonctl checkout <branch>`.',
+        );
+        return {};
+      }
+      return await fetchAndProject(config, ctx);
+    }
+
+    if (ctx.projectId && ctx.branchId) {
+      const pulled = await pullConfig({
+        projectId: ctx.projectId,
+        branchId: ctx.branchId,
+        ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+        ...(ctx.api ? { api: ctx.api } : {}),
+      });
+      const branchConfig = pulled.config;
+      return await fetchAndProject(
+        defineConfig(() => branchConfig),
+        ctx,
+      );
+    }
+
+    log.debug(
+      'dev: no neon.ts and no project/branch context; skipping env injection',
+    );
+    return {};
+  } catch (err) {
+    log.warning(
+      'Could not inject Neon env vars; the function will run without them: %s',
+      err instanceof Error ? err.message : String(err),
+    );
+    return {};
+  }
+};
+
+const fetchAndProject = async (
+  config: Config,
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  const env = await fetchEnv(config, {
+    projectId: ctx.projectId as string,
+    branchId: ctx.branchId as string,
+    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.api ? { api: ctx.api } : {}),
+  });
+  return toEntries(env);
+};
+
+/**
+ * Load a `neon.ts` policy if one exists on the path from `cwd` up to the repo
+ * root. Returns `null` when there is none (the common "no config" case), and
+ * surfaces real load errors (e.g. a syntax error in an existing file).
+ */
+const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
+  try {
+    const { config } = await loadConfigFromFile({ cwd });
+    return config;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) {
+      return null;
+    }
+    throw err;
+  }
+};

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -4,7 +4,11 @@ import {
   type Config,
   type NeonApi,
 } from '@neondatabase/config';
-import { pullConfig } from '@neondatabase/config-runtime';
+import {
+  plan,
+  pullConfig,
+  type AppliedChange,
+} from '@neondatabase/config-runtime';
 import { fetchEnv, toEntries } from '@neondatabase/env';
 
 import { log } from '../log.js';
@@ -19,19 +23,37 @@ export type DevEnvContext = {
 };
 
 /**
+ * Thrown when a `neon.ts` policy declares a branch-level resource (Neon Auth,
+ * Data API, a bucket, the AI Gateway) that the linked remote branch does not
+ * have yet. Unlike every other failure in {@link resolveDevEnv} — which degrades
+ * to "run without injection" — this is a hard stop: the user's intent (a policy)
+ * cannot be honored, and silently dropping the secret would be more confusing
+ * than refusing to start. The fix is to provision the resource first.
+ */
+export class DevEnvMismatchError extends Error {
+  override readonly name = 'DevEnvMismatchError';
+}
+
+/**
  * Resolve the Neon env vars to inject into a locally-served function, mirroring
  * what the deployed function would receive for the selected branch (pooled /
  * direct `DATABASE_URL`, plus Auth / Data API when enabled).
  *
- * Tiered, and **always degrades gracefully** — a function must still run with no
- * Neon account, no `.neon`, and no network:
+ * Tiered:
  *
- *   1. a `neon.ts` policy is found -> evaluate it with `fetchEnv`
+ *   1. a `neon.ts` policy is found -> the policy is the source of truth for what
+ *      the function *wants*. We first check the policy against the branch's live
+ *      state (`plan`); if the policy declares a resource the branch is missing,
+ *      we stop with a {@link DevEnvMismatchError} pointing the user at
+ *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy and injects.
  *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
- *      branch's live state into a config, then `fetchEnv` injects what's enabled
- *   3. otherwise -> inject nothing
+ *      branch's live state (incl. Auth / Data API enablement) into a config,
+ *      then `fetchEnv` injects what is actually enabled, silently.
+ *   3. otherwise -> inject nothing.
  *
- * Any failure logs a warning and returns `{}` rather than throwing.
+ * Every failure **except** {@link DevEnvMismatchError} degrades gracefully: it
+ * logs a warning and returns `{}` so the function still runs (no Neon account,
+ * no `.neon`, no network). A mismatch is re-thrown for the caller to surface.
  */
 export const resolveDevEnv = async (
   ctx: DevEnvContext,
@@ -47,6 +69,7 @@ export const resolveDevEnv = async (
         );
         return {};
       }
+      await assertPolicyMatchesBranch(config, ctx);
       return await fetchAndProject(config, ctx);
     }
 
@@ -69,6 +92,8 @@ export const resolveDevEnv = async (
     );
     return {};
   } catch (err) {
+    // A policy/branch mismatch is intentional and actionable — surface it.
+    if (err instanceof DevEnvMismatchError) throw err;
     log.warning(
       'Could not inject Neon env vars; the function will run without them: %s',
       err instanceof Error ? err.message : String(err),
@@ -76,6 +101,50 @@ export const resolveDevEnv = async (
     return {};
   }
 };
+
+/**
+ * Tier-1 guard. Dry-run the policy against the branch's live state and stop if
+ * it declares a branch-level resource the branch is missing. Built on `plan` so
+ * it covers every present and future provisionable resource for free: any
+ * `create` action is a resource `neonctl deploy` would provision.
+ *
+ * Functions are deliberately excluded: running an *un*deployed function locally
+ * is the whole point of `neon dev`, so a not-yet-deployed function in the policy
+ * must not block the dev server.
+ */
+const assertPolicyMatchesBranch = async (
+  config: Config,
+  ctx: DevEnvContext,
+): Promise<void> => {
+  const result = await plan(config, {
+    projectId: ctx.projectId as string,
+    branchId: ctx.branchId as string,
+    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.api ? { api: ctx.api } : {}),
+  });
+
+  const missing = result.applied.filter(isMissingResource);
+  if (missing.length === 0) return;
+
+  const names = missing.map((change) => change.identifier).join(', ');
+  throw new DevEnvMismatchError(
+    `Your neon.ts declares ${names} for branch ${ctx.branchId}, but the branch ` +
+      'does not have it yet, so the matching env vars cannot be injected. ' +
+      'Provision it first with `neonctl deploy` (or `neonctl config apply`), ' +
+      'then re-run `neonctl dev`.',
+  );
+};
+
+/**
+ * A planned change that provisions a branch-level resource the branch lacks: a
+ * `create` on a service (Neon Auth, Data API, a bucket, the AI Gateway). Branch
+ * setting drift (`update`) and `noop`s are ignored — they don't block local dev
+ * — and functions are excluded (see {@link assertPolicyMatchesBranch}).
+ */
+const isMissingResource = (change: AppliedChange): boolean =>
+  change.kind === 'service' &&
+  change.action === 'create' &&
+  !change.identifier.startsWith('function:');
 
 const fetchAndProject = async (
   config: Config,

--- a/src/dev/functions.test.ts
+++ b/src/dev/functions.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveFunctionsFromConfig } from './functions.js';
+
+/**
+ * Write a neon.ts and the function source files it references into a temp dir, so
+ * resolveFunctionsFromConfig (which loads + resolves the policy and checks each source
+ * exists on disk) runs against a realistic layout.
+ */
+const writeWorkspace = (
+  cwd: string,
+  neonTs: string,
+  sources: string[],
+): void => {
+  writeFileSync(join(cwd, 'neon.ts'), neonTs);
+  for (const rel of sources) {
+    writeFileSync(
+      join(cwd, rel),
+      'export default { fetch: () => new Response("ok") };\n',
+    );
+  }
+};
+
+describe('resolveFunctionsFromConfig', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-dev-fns-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns null when there is no neon.ts', async () => {
+    await expect(resolveFunctionsFromConfig(cwd)).resolves.toBeNull();
+  });
+
+  it('returns an empty list when neon.ts declares no functions', async () => {
+    writeWorkspace(cwd, 'export default () => ({});\n', []);
+    await expect(resolveFunctionsFromConfig(cwd)).resolves.toEqual([]);
+  });
+
+  it('resolves each function with an absolute source and its dev settings', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: {
+          functions: [
+            { slug: 'hello', name: 'Hello', source: './hello.ts', dev: { port: 8788 } },
+            { slug: 'api', name: 'Api', source: './api.ts', dev: { portless: true } },
+            { slug: 'bare', name: 'Bare', source: './bare.ts' },
+          ],
+        },
+      });\n`,
+      ['hello.ts', 'api.ts', 'bare.ts'],
+    );
+
+    const fns = await resolveFunctionsFromConfig(cwd);
+    expect(fns).not.toBeNull();
+    const bySlug = Object.fromEntries((fns ?? []).map((f) => [f.slug, f]));
+
+    expect(bySlug.hello).toMatchObject({
+      slug: 'hello',
+      name: 'Hello',
+      source: join(cwd, 'hello.ts'),
+      port: 8788,
+      portless: false,
+    });
+    expect(bySlug.api).toMatchObject({
+      slug: 'api',
+      source: join(cwd, 'api.ts'),
+      portless: true,
+    });
+    // portless function gets no port (portless assigns it).
+    expect(bySlug.api.port).toBeUndefined();
+    // bare function: no port, not portless.
+    expect(bySlug.bare.portless).toBe(false);
+    expect(bySlug.bare.port).toBeUndefined();
+  });
+
+  it('throws when a declared function source does not exist on disk', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: { functions: [{ slug: 'gone', name: 'Gone', source: './missing.ts' }] },
+      });\n`,
+      [],
+    );
+    await expect(resolveFunctionsFromConfig(cwd)).rejects.toThrow(
+      /source that does not exist/,
+    );
+  });
+
+  it('carries per-function env through', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: {
+          functions: [
+            { slug: 'e', name: 'E', source: './e.ts', env: { FOO: 'bar' } },
+          ],
+        },
+      });\n`,
+      ['e.ts'],
+    );
+    const fns = await resolveFunctionsFromConfig(cwd);
+    expect(fns?.[0].env).toEqual({ FOO: 'bar' });
+  });
+});

--- a/src/dev/functions.ts
+++ b/src/dev/functions.ts
@@ -1,0 +1,98 @@
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import {
+  loadConfigFromFile,
+  resolveConfig,
+  type Config,
+  type FunctionDevConfig,
+} from '@neondatabase/config';
+
+/**
+ * A function from `neon.ts`, resolved into everything `neon dev` needs to serve it
+ * locally. `source` is absolute (resolved against the `neon.ts` location). `port` is the
+ * function's explicit `dev.port`, or `undefined` to let the supervisor find a free one
+ * (only allowed when not `portless`). `env` is the function's own `neon.ts` env, layered
+ * over the shared branch env per child.
+ */
+export type PlannedFunction = {
+  slug: string;
+  name: string;
+  source: string;
+  port?: number;
+  portless: boolean;
+  env: Record<string, string>;
+};
+
+/**
+ * Load `neon.ts` (if any) and resolve the list of functions it declares into
+ * {@link PlannedFunction}s for `neon dev` to serve. Returns `null` when there is no
+ * `neon.ts` on the path from `cwd` up to the repo root — the caller turns that into a
+ * "no --source and no neon.ts" error.
+ *
+ * `branchName` is used only to evaluate a policy that switches on `branch.name`; the
+ * function list is otherwise branch-independent, so a placeholder is fine when unknown.
+ */
+export const resolveFunctionsFromConfig = async (
+  cwd: string,
+  branchName?: string,
+): Promise<PlannedFunction[] | null> => {
+  const loaded = await loadNeonConfig(cwd);
+  if (!loaded) return null;
+
+  const { config, configDir } = loaded;
+  const resolved = resolveConfig(config, {
+    name: branchName ?? 'local',
+    exists: branchName !== undefined,
+  });
+
+  const functions = resolved.preview?.functions ?? [];
+  return functions.map((fn) => {
+    const source = isAbsolute(fn.source)
+      ? fn.source
+      : resolve(configDir, fn.source);
+    if (!existsSync(source)) {
+      throw new Error(
+        `Function "${fn.slug}" points at a source that does not exist: ${source} ` +
+          `(from neon.ts "${fn.source}"). Fix the source path and re-run.`,
+      );
+    }
+    return {
+      slug: fn.slug,
+      name: fn.name,
+      source,
+      portless: fn.dev?.portless === true,
+      ...(devPort(fn.dev) !== undefined
+        ? { port: devPort(fn.dev) as number }
+        : {}),
+      env: { ...fn.env },
+    };
+  });
+};
+
+/**
+ * Read the `port` off a {@link FunctionDevConfig}. The discriminated union guarantees a
+ * `port` is present whenever `portless` is true, so this is `undefined` only for the
+ * non-portless, port-omitted case (the supervisor then searches for a free port).
+ */
+const devPort = (dev: FunctionDevConfig | undefined): number | undefined =>
+  dev?.port;
+
+type LoadedConfig = { config: Config; configDir: string };
+
+/**
+ * Load a `neon.ts` policy if one exists, returning the loaded config and the directory
+ * it lives in (used to resolve each function's relative `source`). Returns `null` when no
+ * config file is found; surfaces real load errors (e.g. a syntax error).
+ */
+const loadNeonConfig = async (cwd: string): Promise<LoadedConfig | null> => {
+  try {
+    const { config, resolvedPath } = await loadConfigFromFile({ cwd });
+    return { config, configDir: dirname(resolvedPath) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) {
+      return null;
+    }
+    throw err;
+  }
+};

--- a/src/dev/inputs.ts
+++ b/src/dev/inputs.ts
@@ -1,0 +1,83 @@
+import { resolve } from 'node:path';
+
+// esbuild's JS module, narrowed to the metafile-producing call we use. Typed
+// structurally so we never statically import from 'esbuild' (see resolveInputs
+// for why). Mirrors the shape in src/utils/esbuild.ts.
+type EsbuildModule = {
+  build: (opts: Record<string, unknown>) => Promise<{
+    metafile?: { inputs?: Record<string, unknown> };
+  }>;
+};
+
+export type InputDeps = {
+  // @yao-pkg/pkg defines process.pkg inside the packaged binary.
+  isPackaged: () => boolean;
+  loadEsbuild: (name: string) => Promise<EsbuildModule>;
+};
+
+const defaultDeps: InputDeps = {
+  isPackaged: () => (process as { pkg?: unknown }).pkg !== undefined,
+  loadEsbuild: (name) => import(name) as Promise<EsbuildModule>,
+};
+
+/**
+ * Resolve the exact set of files esbuild reads to produce the bundle for
+ * `source` — the entry plus every local module it imports (npm deps are left
+ * external, so they never appear). These are the files the dev watcher should
+ * watch, so a single edit triggers exactly one rebuild.
+ *
+ * Returns absolute paths, or `null` when the precise set cannot be computed —
+ * either inside the packaged binary (which cannot import esbuild as a module;
+ * it shells out to a binary that has no JSON-metafile equivalent here) or on a
+ * platform where the esbuild module won't load. Callers fall back to a coarser
+ * watch in that case.
+ *
+ * This performs a metafile-only pass (`write:false`, `metafile:true`) so it
+ * never emits output; the actual bundle bytes still come from `bundleEntry`.
+ */
+export const resolveWatchInputs = async (
+  source: string,
+  deps: InputDeps = defaultDeps,
+): Promise<string[] | null> => {
+  if (deps.isPackaged()) return null;
+
+  // esbuild is resolved by a COMPUTED specifier, never the literal string
+  // 'esbuild', for the same reason as src/utils/esbuild.ts: rollup and
+  // @yao-pkg/pkg statically scan for literal import()/require() and would pull
+  // esbuild's native Go binary into the bundle/snapshot. Keep it invisible.
+  const name = ['es', 'build'].join('');
+  let esbuild: EsbuildModule;
+  try {
+    esbuild = await deps.loadEsbuild(name);
+  } catch {
+    return null;
+  }
+
+  let metafile: { inputs?: Record<string, unknown> } | undefined;
+  try {
+    // Mirrors bundleEntry's flags so the resolved input graph matches the real
+    // bundle. metafile:true + write:false makes this a pure analysis pass.
+    const result = await esbuild.build({
+      entryPoints: [source],
+      bundle: true,
+      write: false,
+      metafile: true,
+      format: 'esm',
+      platform: 'node',
+      packages: 'external',
+      logLevel: 'silent',
+    });
+    metafile = result.metafile;
+  } catch {
+    // A bundle error here is non-fatal for watching: bundleEntry surfaces the
+    // real diagnostic. Fall back to the coarser watch so edits still rebuild.
+    return null;
+  }
+
+  const inputs = metafile?.inputs;
+  if (!inputs) return null;
+
+  // metafile input keys are paths relative to esbuild's cwd; resolve to absolute
+  // so they compare cleanly against chokidar's watched paths.
+  return Object.keys(inputs).map((p) => resolve(process.cwd(), p));
+};

--- a/src/dev/runtime.test.ts
+++ b/src/dev/runtime.test.ts
@@ -1,0 +1,146 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getRequestListener } from '@hono/node-server';
+
+import {
+  portSelectionFromEnv,
+  resolveFetchHandler,
+  withErrorBoundary,
+  type FetchHandler,
+} from './runtime.js';
+
+describe('resolveFetchHandler', () => {
+  it('picks `export default { fetch }`', async () => {
+    const response = new Response('from fetch object');
+    const handler = resolveFetchHandler({
+      default: { fetch: () => response },
+    });
+    const result = await handler(new Request('http://localhost/'));
+    expect(result).toBe(response);
+  });
+
+  it('picks `export default function`', async () => {
+    const response = new Response('from default function');
+    const handler = resolveFetchHandler({
+      default: () => response,
+    });
+    const result = await handler(new Request('http://localhost/'));
+    expect(result).toBe(response);
+  });
+
+  it('throws a helpful error when no handler is present', () => {
+    expect(() => resolveFetchHandler({})).toThrow(/No request handler found/);
+  });
+
+  it('throws when only a named `handler` export exists (named handler is not supported)', () => {
+    expect(() =>
+      resolveFetchHandler({ handler: () => new Response('named') }),
+    ).toThrow(/No request handler found/);
+  });
+});
+
+describe('withErrorBoundary', () => {
+  it('turns a thrown error into a 500 whose body contains the message', async () => {
+    const boundary = withErrorBoundary(() => {
+      throw new Error('boom from the user handler');
+    });
+    const res = await boundary(new Request('http://localhost/'));
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toContain('boom from the user handler');
+  });
+
+  it('passes a successful response through unchanged', async () => {
+    const ok = new Response('all good', { status: 201 });
+    const boundary = withErrorBoundary(() => ok);
+    const res = await boundary(new Request('http://localhost/'));
+    expect(res).toBe(ok);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('portSelectionFromEnv', () => {
+  it('returns an explicit selection when NEON_DEV_PORT is set', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT: '3000' })).toEqual({
+      mode: 'explicit',
+      port: 3000,
+    });
+  });
+
+  it('searches from the default base when NEON_DEV_PORT is empty', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT: '' })).toEqual({
+      mode: 'search',
+      from: 8787,
+    });
+  });
+
+  it('searches from the default base when NEON_DEV_PORT is unset', () => {
+    expect(portSelectionFromEnv({})).toEqual({ mode: 'search', from: 8787 });
+  });
+
+  it('respects NEON_DEV_PORT_BASE when searching', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT_BASE: '4000' })).toEqual({
+      mode: 'search',
+      from: 4000,
+    });
+  });
+
+  it('throws on an invalid NEON_DEV_PORT', () => {
+    expect(() => portSelectionFromEnv({ NEON_DEV_PORT: 'not-a-port' })).toThrow(
+      /Invalid NEON_DEV_PORT/,
+    );
+  });
+});
+
+describe('getRequestListener round-trip', () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      const toClose = server;
+      server = null;
+      await new Promise<void>((resolve, reject) => {
+        toClose.close((err) => {
+          if (err) reject(err instanceof Error ? err : new Error(String(err)));
+          else resolve();
+        });
+      });
+    }
+  });
+
+  const start = async (handler: FetchHandler): Promise<number> => {
+    const listener = getRequestListener(handler);
+    const created = createServer((incoming, outgoing) => {
+      void listener(incoming, outgoing);
+    });
+    server = created;
+    return new Promise<number>((resolve, reject) => {
+      created.once('error', reject);
+      created.listen(0, () => {
+        resolve((created.address() as AddressInfo).port);
+      });
+    });
+  };
+
+  it('round-trips a request through the runtime helpers', async () => {
+    const handler = withErrorBoundary(
+      resolveFetchHandler({
+        default: {
+          fetch: (req: Request) =>
+            new Response(`hello from ${new URL(req.url).pathname}`, {
+              status: 200,
+              headers: { 'x-neon-dev': 'runtime' },
+            }),
+        },
+      }),
+    );
+
+    const port = await start(handler);
+    const res = await fetch(`http://127.0.0.1:${port}/greet`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-neon-dev')).toBe('runtime');
+    await expect(res.text()).resolves.toBe('hello from /greet');
+  });
+});

--- a/src/dev/runtime.test.ts
+++ b/src/dev/runtime.test.ts
@@ -91,6 +91,25 @@ describe('portSelectionFromEnv', () => {
       /Invalid NEON_DEV_PORT/,
     );
   });
+
+  it('binds an injected PORT (e.g. from portless) when NEON_DEV_PORT is unset', () => {
+    expect(portSelectionFromEnv({ PORT: '4123' })).toEqual({
+      mode: 'explicit',
+      port: 4123,
+    });
+  });
+
+  it('prefers NEON_DEV_PORT over PORT', () => {
+    expect(
+      portSelectionFromEnv({ NEON_DEV_PORT: '3000', PORT: '4123' }),
+    ).toEqual({ mode: 'explicit', port: 3000 });
+  });
+
+  it('throws on an invalid PORT', () => {
+    expect(() => portSelectionFromEnv({ PORT: 'nope' })).toThrow(
+      /Invalid PORT/,
+    );
+  });
 });
 
 describe('getRequestListener round-trip', () => {

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -1,0 +1,201 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { getRequestListener } from '@hono/node-server';
+
+/**
+ * A WHATWG fetch-style handler: takes a Request, returns a Response. The single
+ * shape the local dev server and the deployed Neon Functions runtime both speak.
+ */
+export type FetchHandler = (req: Request) => Response | Promise<Response>;
+
+type UserModule = Record<string, unknown>;
+
+const isFunction = (value: unknown): value is FetchHandler =>
+  typeof value === 'function';
+
+const hasFetchMethod = (
+  value: unknown,
+): value is { fetch: (req: Request) => Response | Promise<Response> } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'fetch' in value &&
+  typeof (value as { fetch: unknown }).fetch === 'function';
+
+/**
+ * Resolve the user's exported handler to a single fetch callback.
+ *
+ * Resolution order (first match wins):
+ *   1. `export default { fetch }`      — Workers / Neon Functions style
+ *   2. `export default function (req)` — bare (async) default function
+ */
+export const resolveFetchHandler = (mod: UserModule): FetchHandler => {
+  const defaultExport = mod.default;
+
+  if (hasFetchMethod(defaultExport)) {
+    const target = defaultExport;
+    return (req) => target.fetch(req);
+  }
+
+  if (isFunction(defaultExport)) {
+    return defaultExport;
+  }
+
+  throw new Error(
+    'No request handler found in the source module. Export one of:\n' +
+      '  export default { fetch(req) { /* ... */ } }\n' +
+      '  export default function (req) { /* ... */ }',
+  );
+};
+
+/**
+ * Wrap a fetch handler so user errors become a 500 response (with the message
+ * in the body during dev) instead of crashing the child process.
+ */
+export const withErrorBoundary = (handler: FetchHandler): FetchHandler => {
+  return async (req) => {
+    try {
+      return await handler(req);
+    } catch (err) {
+      const message =
+        err instanceof Error ? (err.stack ?? err.message) : String(err);
+      process.stderr.write(`Request handler threw an error:\n${message}\n`);
+      return new Response(`Internal Server Error\n\n${message}`, {
+        status: 500,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }
+  };
+};
+
+/**
+ * How the runtime picks its port:
+ *   - `explicit`: bind this exact port and crash on conflict (an explicit choice
+ *     — `--port` or portless's `PORT` — that is taken is an error).
+ *   - `search`: walk upward from `from` until a free port is found; never crash.
+ */
+export type PortSelection =
+  | { mode: 'explicit'; port: number }
+  | { mode: 'search'; from: number };
+
+export type StartRuntimeOptions = {
+  source: string;
+  port: PortSelection;
+  hostname?: string;
+};
+
+const isAddressInUse = (err: unknown): boolean =>
+  typeof err === 'object' &&
+  err !== null &&
+  (err as { code?: unknown }).code === 'EADDRINUSE';
+
+const DEFAULT_SEARCH_BASE = 8787;
+const MAX_SEARCH_STEPS = 100;
+
+const bindPort = async (
+  server: Server,
+  selection: PortSelection,
+  hostname: string | undefined,
+): Promise<number> => {
+  if (selection.mode === 'explicit') {
+    return listen(server, selection.port, hostname);
+  }
+  for (let step = 0; step < MAX_SEARCH_STEPS; step++) {
+    try {
+      return await listen(server, selection.from + step, hostname);
+    } catch (err) {
+      if (!isAddressInUse(err)) throw err;
+    }
+  }
+  throw new Error(
+    `Could not find a free port in ${selection.from}-${
+      selection.from + MAX_SEARCH_STEPS - 1
+    }`,
+  );
+};
+
+const listen = (
+  server: Server,
+  port: number,
+  hostname?: string,
+): Promise<number> =>
+  new Promise<number>((resolveListen, rejectListen) => {
+    const onError = (err: Error): void => {
+      server.off('listening', onListening);
+      rejectListen(err);
+    };
+    const onListening = (): void => {
+      server.off('error', onError);
+      resolveListen((server.address() as AddressInfo).port);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, hostname);
+  });
+
+/**
+ * Load the (already-bundled) user module, build the listener, and start an HTTP
+ * server. Announces the bound port on stdout as `neon-dev:ready <port>` so the
+ * parent can render the URL. Resolves with the bound port.
+ */
+export const startRuntime = async ({
+  source,
+  port,
+  hostname,
+}: StartRuntimeOptions): Promise<number> => {
+  const absoluteSource = resolve(process.cwd(), source);
+  const mod = (await import(pathToFileURL(absoluteSource).href)) as UserModule;
+  const handler = withErrorBoundary(resolveFetchHandler(mod));
+
+  const listener = getRequestListener(handler, { hostname });
+  const server = createServer((incoming, outgoing) => {
+    void listener(incoming, outgoing);
+  });
+
+  const boundPort = await bindPort(server, port, hostname);
+  process.stdout.write(`neon-dev:ready ${boundPort}\n`);
+  return boundPort;
+};
+
+/**
+ * Build a {@link PortSelection} from the environment:
+ *   - `NEON_DEV_PORT` set -> explicit bind (crash if taken)
+ *   - otherwise           -> search upward from `NEON_DEV_PORT_BASE` (or default)
+ */
+export const portSelectionFromEnv = (env: NodeJS.ProcessEnv): PortSelection => {
+  const explicit = env.NEON_DEV_PORT;
+  if (explicit !== undefined && explicit !== '') {
+    const port = Number(explicit);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+      throw new Error(`Invalid NEON_DEV_PORT: "${explicit}"`);
+    }
+    return { mode: 'explicit', port };
+  }
+  const base = Number(env.NEON_DEV_PORT_BASE ?? DEFAULT_SEARCH_BASE);
+  return {
+    mode: 'search',
+    from: Number.isInteger(base) ? base : DEFAULT_SEARCH_BASE,
+  };
+};
+
+const isDirectExecution = (): boolean => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+};
+
+if (isDirectExecution()) {
+  const source = process.env.NEON_DEV_SOURCE ?? process.argv[2];
+  if (!source) {
+    process.stderr.write('neon-dev runtime: missing source path\n');
+    process.exit(1);
+  }
+  startRuntime({ source, port: portSelectionFromEnv(process.env) }).catch(
+    (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`neon-dev runtime failed to start: ${msg}\n`);
+      process.exit(1);
+    },
+  );
+}

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -159,24 +159,35 @@ export const startRuntime = async ({
 };
 
 /**
- * Build a {@link PortSelection} from the environment:
- *   - `NEON_DEV_PORT` set -> explicit bind (crash if taken)
- *   - otherwise           -> search upward from `NEON_DEV_PORT_BASE` (or default)
+ * Build a {@link PortSelection} from the environment. Precedence:
+ *   1. `NEON_DEV_PORT` -> explicit bind (crash if taken). Set by `neon dev` from an
+ *      explicit `--port` / `dev.port`.
+ *   2. `PORT`          -> explicit bind. This is what `portless` injects (and what a bare
+ *      `PORT=3000 neon dev` sets), so the runtime binds the port chosen for it.
+ *   3. otherwise        -> search upward from `NEON_DEV_PORT_BASE` (or the default base).
  */
 export const portSelectionFromEnv = (env: NodeJS.ProcessEnv): PortSelection => {
   const explicit = env.NEON_DEV_PORT;
   if (explicit !== undefined && explicit !== '') {
-    const port = Number(explicit);
-    if (!Number.isInteger(port) || port < 0 || port > 65535) {
-      throw new Error(`Invalid NEON_DEV_PORT: "${explicit}"`);
-    }
-    return { mode: 'explicit', port };
+    return { mode: 'explicit', port: parsePort(explicit, 'NEON_DEV_PORT') };
+  }
+  const injected = env.PORT;
+  if (injected !== undefined && injected !== '') {
+    return { mode: 'explicit', port: parsePort(injected, 'PORT') };
   }
   const base = Number(env.NEON_DEV_PORT_BASE ?? DEFAULT_SEARCH_BASE);
   return {
     mode: 'search',
     from: Number.isInteger(base) ? base : DEFAULT_SEARCH_BASE,
   };
+};
+
+const parsePort = (value: string, varName: string): number => {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid ${varName}: "${value}"`);
+  }
+  return port;
 };
 
 const isDirectExecution = (): boolean => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'init',
 
+  'dev',
+
   // aliases
 ];
 


### PR DESCRIPTION
## `neon dev` — run a Neon Function locally

A **preview** command that runs a single Neon Function on your machine with a hot-reloading dev server, so you can iterate before deploying. The local runtime speaks the same handler contract as the deployed one, and (when you're logged in) injects the selected branch's connection details — so a local function talks to a real Neon branch.

```bash
neon dev --source ./functions/hello.ts
#
#   Neon Functions dev server
#
#   URL     http://localhost:8787
#   Source  /abs/path/functions/hello.ts
```

### Usage

```
neon dev --source <path> [--port <n>] [global options]
```

| Option | Required | Default | Description |
| --- | --- | --- | --- |
| `--source <path>` | yes | — | Path to the function's entry module (`.ts`/`.js`). |
| `--port <n>` | no | auto | Port to listen on. If the port is taken, the command **fails** (an explicit choice that can't be honored is an error). |
| global options | no | — | `--project-id`, `--branch`, `--api-key`, `--output`, `--api-host`, etc. (as with other commands). |

### Supported function shapes

The runtime resolves the handler the same way the deployed Neon Functions runtime does (first match wins):

```ts
// 1. export default { fetch } — Workers / Neon Functions style
export default {
  fetch(req: Request): Response | Promise<Response> {
    return new Response('hello');
  },
};

// 2. export default (async) function (req)
export default function (req: Request): Response {
  return new Response('hello');
}
```

If neither is exported, `dev` prints a clear error listing the accepted shapes. An error thrown by your handler becomes a `500` (with the stack in the body during dev) instead of crashing the server.

### Port selection

| You pass… | Behavior |
| --- | --- |
| `--port <n>` | Binds exactly that port; **fails** if it is already in use. |
| nothing, but `PORT` is set in the env | Binds exactly `PORT`; **fails** if in use. (This is what [portless](https://github.com/vercel-labs/portless) injects.) |
| nothing | Searches upward from `8787` for a free port; **never fails**. |

The chosen port stays stable across hot reloads.

### Database connection (env injection)

`neon dev` injects the selected branch's connection details into the function's environment so it behaves like the deployed one. Resolution is **tiered** and **always degrades gracefully** — a function still runs with no Neon account, no `.neon`, and no network:

1. A `neon.ts` policy is found → its policy decides what's injected for the branch.
2. No `neon.ts`, but a project + branch are known (from `.neon` — set by `neonctl link` / `neonctl checkout` — or `--branch`) → the branch's live state is read and the matching vars are injected.
3. Otherwise → nothing is injected.

| Variable | When |
| --- | --- |
| `DATABASE_URL` | always (pooled connection string) |
| `DATABASE_URL_UNPOOLED` | always (direct connection string) |
| `NEON_AUTH_BASE_URL` | when the branch has Neon Auth enabled |
| `NEON_DATA_API_URL` | when the branch has the Data API enabled |

`dev` uses existing credentials (an API key or a prior `neonctl auth`) when present, but **never launches an interactive login** — with no credentials it just runs without injection. Injected values layer *under* the inherited environment, so a function that loads its own `.env` at runtime still overrides them.

### Hot reload

The command watches exactly the files that go into the bundle (the entry plus the local modules it imports — derived from esbuild's metafile, re-synced after every rebuild), so editing the entry **or** an imported helper restarts the server, while unrelated writes don't. Exactly one restart per change; no restart loops.

### Composes with portless

Because `dev` honors an injected `PORT`, it slots under [portless](https://github.com/vercel-labs/portless) for a stable `name.localhost` URL with zero extra config:

```bash
portless hello neon dev --source ./functions/hello.ts
# -> http://hello.localhost
```

### How it works

`neon dev` bundles your function with esbuild — the same transpiler used for `neon functions deploy` (the shared `bundleEntry`) — into a self-contained module, runs it in a child `node` process, and adapts Node's `req`/`res` to WHATWG `Request`/`Response` via `@hono/node-server`'s `getRequestListener`. No web framework is required in your function, and nothing extra needs to be installed.

---

## Implementation notes

- Bumps **TypeScript 4.9.5 → 5.8.3** (required to consume the `@neondatabase` config/env package types). The whole repo typechecks under 5.8 with no new errors.
- Adds `@hono/node-server` + `chokidar`; reuses the existing `src/utils/esbuild.ts` (`bundleEntry`) and `src/utils/zip.ts`.
- Env injection uses `@neondatabase/config` + `@neondatabase/env` + `@neondatabase/config-runtime`. These are currently **linked (`link:`) from the sibling `neon-pkgs` repo and unpublished**, so this PR is **not mergeable until those packages ship to npm** (then the `link:` specs become published versions).
- `dev` is registered as a no-subcommand verb and is exempt from the interactive auth flow.

## Test plan

- [x] `pnpm lint` (typecheck + eslint + prettier)
- [x] `pnpm test` — full suite green (handler normalization, request round-trip through `getRequestListener`, port-selection logic, env resolution tiers 1/2/3 + graceful degradation against the real config/env packages via a fake `NeonApi`)
- [x] E2E: Tier-3 graceful run (no creds, `DATABASE_URL` null, no login prompt), dependency resolution from the user's `node_modules`, hot reload = exactly **1 restart per edit** (entry and imported helper), stable port across reloads, syntax error → fatal exit 1, clean teardown with no orphaned processes

## Stacking

Base PR of a 2-PR chain. The follow-up (`neon config` / `neon deploy`) is stacked on this branch.
