### PR TITLE
fix(release): use release-pr/ branch prefix to avoid ref collision

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -41,8 +41,7 @@ jobs:
         with:
           egress-policy: audit
 
-      # GITHUB_TOKEN can't push refs in this repo; use the GitHub App token
-      # (same app the release workflow uses) so the tag push below succeeds.
+      # Push the tag under the release App identity (same token as Stage 1).
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
@@ -77,7 +76,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          # Persist the App token so `git push` of the tag below is authorized.
+          # Persist the App token so the tag push uses the release identity.
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Parse release metadata

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -182,7 +182,7 @@ jobs:
             echo "  -f dry-run=false"
             echo "\`\`\`"
             echo ""
-            echo "After publish, verify on [npm](https://www.npmjs.com/package/neonctl) and the [GitHub release](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
+            echo "After publish, verify on [npm](https://www.npmjs.com/package/neonctl)."
             echo "HANDOFF_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -65,10 +65,8 @@ jobs:
         with:
           egress-policy: audit
 
-      # The default GITHUB_TOKEN cannot create branch refs in this repo, so the
-      # branch/PR is created with a GitHub App token (same app the previous
-      # release workflow used). PRs opened by this token also trigger the
-      # required-check workflows, unlike GITHUB_TOKEN-opened PRs.
+      # Open the PR with a GitHub App token: PRs opened by an App token trigger
+      # the required-check workflows, which GITHUB_TOKEN-opened PRs do not.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
@@ -192,10 +190,8 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           BUMP: ${{ inputs.bump }}
         run: |
-          # NOT `release/...`: a protected `release` branch (left over from the
-          # old semantic-release flow) occupies that ref namespace, so git can't
-          # create `release/<x>` under it — the push fails with a directory/file
-          # conflict surfaced as "Reference update failed".
+          # `release-pr/` (not `release/`): a ref can't nest under a same-named
+          # leaf ref, so a `release` branch would block creating `release/<x>`.
           echo "branch=release-pr/neonctl-${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "pr_title=chore: release neonctl@v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "commit_message=chore: release neonctl@v${VERSION}" >> "$GITHUB_OUTPUT"
@@ -234,8 +230,8 @@ jobs:
       - name: Create signed commit + open PR
         id: cpr
         # Commits via the GitHub Contents API → produces a verified-signature
-        # commit. Uses the GitHub App token because GITHUB_TOKEN can't create
-        # the branch ref here. Auto-merge is NOT enabled — see PR body for why.
+        # commit. Uses the App token (above) so the PR triggers required checks.
+        # Auto-merge is NOT enabled — see PR body for why.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,9 +13,8 @@ name: Prepare Release
 #
 # Stage 2 lives in databricks/secure-public-registry-releases-eng and is
 # triggered manually pointing at the tag created by post-release.yml. It
-# checks out the source, installs, builds, packs the npm tarball, builds the
-# native binaries, scans, and publishes via npm OIDC Trusted Publishing +
-# attaches binaries to a GitHub release.
+# checks out the source, installs, builds, packs the npm tarball, scans it,
+# and publishes to npm via OIDC Trusted Publishing.
 
 on:
   workflow_dispatch:
@@ -210,7 +209,7 @@ jobs:
             echo "- Bump kind: \`${BUMP}\`"
             echo ""
             echo "### Next steps"
-            echo "1. Click **Ready for review** to take this PR out of draft (required before merge; also attaches the required checks under your identity)."
+            echo "1. Click **Ready for review** to take this PR out of draft (GitHub won't merge a draft)."
             echo "2. An approver reviews + approves this PR."
             echo "3. Required checks run."
             echo "4. On green, the approver **manually clicks \"Squash and merge\"** in the UI. **Do NOT use auto-merge.**"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -193,7 +193,11 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           BUMP: ${{ inputs.bump }}
         run: |
-          echo "branch=release/neonctl-${RUN_ID}" >> "$GITHUB_OUTPUT"
+          # NOT `release/...`: a protected `release` branch (left over from the
+          # old semantic-release flow) occupies that ref namespace, so git can't
+          # create `release/<x>` under it — the push fails with a directory/file
+          # conflict surfaced as "Reference update failed".
+          echo "branch=release-pr/neonctl-${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "pr_title=chore: release neonctl@v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "commit_message=chore: release neonctl@v${VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,89 +1,43 @@
 # Releasing neonctl
 
-`neonctl` is published to npm via a two-stage hardened pipeline:
+`neonctl` ships to npm via a two-stage pipeline:
 
-| Stage   | Where                                              | What it does                                                                                               |
-| ------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Stage 1 | this repo                                          | Bump version, open release PR, tag the merge, post handoff instructions.                                   |
-| Stage 2 | `databricks/secure-public-registry-releases-eng`\* | Check out the tag, build, scan the artifact, publish via npm OIDC, attach native binaries to a GH release. |
+- **Stage 1 (this repo)** — `prepare-release.yml` bumps the version and opens a release PR; on merge, `post-release.yml` tags the commit and comments the Stage 2 command.
+- **Stage 2 (`databricks/secure-public-registry-releases-eng`)** — checks out the tag, builds, scans the tarball, and publishes to npm via OIDC trusted publishing.
 
-\* Stage 2 publishes from the central `secure-public-registry-releases-eng` repo because its runner pool has the egress + OIDC trust relationship npm requires for [Trusted Publishing](https://docs.npmjs.com/trusted-publishers).
+Stage 2 lives in the central repo because only its runners have the npm publish trust relationship. (External contributors: that repo is internal — open an issue and a maintainer will cut the release.)
 
-> **External contributors:** Stage 2 lives in an internal repo that isn't publicly reachable. If you need a release cut from an outside contribution, open a GitHub issue and a maintainer will run Stage 2.
+## Prerequisites
 
-## Prerequisites (one time)
+- **admin** or **maintain** on `neondatabase/neonctl` (Stage 1).
+- Write access to `databricks/secure-public-registry-releases-eng` (Stage 2).
 
-- Be an **admin or maintain** collaborator on `neondatabase/neonctl` (gates Stage 1).
-- Have write access to `databricks/secure-public-registry-releases-eng` (gates Stage 2 dispatch).
+## Cut a release
 
-## Cutting a release
-
-### 1. Dispatch Stage 1
+**1. Dispatch Stage 1:**
 
 ```bash
-# Use patch, minor, or major for the bump input.
-gh workflow run prepare-release.yml \
-  --repo neondatabase/neonctl \
-  --ref main \
-  -f bump=patch
+gh workflow run prepare-release.yml --repo neondatabase/neonctl --ref main -f bump=patch
 ```
 
-Inputs:
+`bump` is `patch` | `minor` | `major`. For a prerelease, pass `-f version=2.23.0-beta.1` instead. This opens a draft PR titled `chore: release neonctl@vX.Y.Z`.
 
-- `bump` — `patch` | `minor` | `major`. Ignored if `version` is set.
-- `version` — full custom version (e.g. `2.23.0-beta.1`); overrides `bump`. Use this to cut a prerelease.
-- `ref` — branch to release from. Defaults to `main`. Raw SHAs are rejected.
+**2. Merge it:** mark **Ready for review** (drafts can't be merged), approve, wait for checks, then **Squash and merge** by hand — not auto-merge (a human merge is what fires `post-release.yml`). Don't edit the PR title.
 
-The workflow opens a **draft** PR titled `chore: release neonctl@vX.Y.Z`.
+**3. `post-release.yml`** runs automatically: tags `vX.Y.Z` on the merge commit and comments the Stage 2 command.
 
-### 2. Review and merge the release PR
-
-- Click **Ready for review** to take the PR out of draft — GitHub won't let you merge a draft PR.
-- Approve the PR.
-- Wait for required checks.
-- Click **Squash and merge** manually in the UI. **Do not enable auto-merge.**
-
-> Why manual merge? GitHub Actions suppresses downstream `on: push` workflows for pushes caused by `GITHUB_TOKEN` (including auto-merge enabled from a workflow). A human clicking merge attributes the push to that user, so `post-release.yml` fires.
-
-Do not edit the PR title or add `[skip ci]` markers — `post-release.yml` parses the commit subject for the version token.
-
-### 3. `post-release.yml` runs automatically
-
-On the squash-merge push, it:
-
-1. Parses `neonctl@vX.Y.Z` from the commit subject.
-2. Creates and pushes the `vX.Y.Z` git tag on the merge commit.
-3. Comments on the merged PR with the Stage 2 dispatch command.
-
-### 4. Dispatch Stage 2 (npm publish)
-
-Copy the command from the PR comment, or:
+**4. Dispatch Stage 2** (copy from the PR comment, or):
 
 ```bash
-# Dry run first:
 gh workflow run release-neondatabase-neonctl.yml \
   --repo databricks/secure-public-registry-releases-eng \
-  --ref main \
-  -f ref=vX.Y.Z \
-  -f dry-run=true
-
-# Real publish:
-gh workflow run release-neondatabase-neonctl.yml \
-  --repo databricks/secure-public-registry-releases-eng \
-  --ref main \
-  -f ref=vX.Y.Z \
-  -f dry-run=false
+  --ref main -f ref=vX.Y.Z -f dry-run=true   # set dry-run=false to publish for real
 ```
 
-Stage 2 scans the tarball, then publishes to npm and attaches the native binaries (linux x64/arm64, macOS x64, Windows x64) to the GitHub release.
-
-### 5. Verify
-
-- npm: <https://www.npmjs.com/package/neonctl>
-- GitHub release: `https://github.com/neondatabase/neonctl/releases/tag/vX.Y.Z`
+**5. Verify** at <https://www.npmjs.com/package/neonctl>.
 
 ## Recovery
 
-- **Stage 1 PR not yet merged** — close it, fix on `main`, re-dispatch `prepare-release.yml`.
-- **Tag created, Stage 2 not yet run** — delete the bad tag with `git push origin :refs/tags/vX.Y.Z`, then open the original `post-release.yml` run in the Actions tab and click **Re-run all jobs**.
-- **Stage 2 published to npm** — npm versions are immutable. Cut a new patch release rather than reverting.
+- **PR not merged yet** — close it, fix on `main`, re-dispatch `prepare-release.yml`.
+- **Tag created, Stage 2 not run** — `git push origin :refs/tags/vX.Y.Z`, then re-run the `post-release.yml` run from the Actions tab.
+- **Already published** — npm versions are immutable; cut a new patch rather than reverting.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,7 +38,7 @@ The workflow opens a **draft** PR titled `chore: release neonctl@vX.Y.Z`.
 
 ### 2. Review and merge the release PR
 
-- Click **Ready for review** to take the PR out of draft. GitHub blocks merging while it's a draft, and this flip (under your identity, not `GITHUB_TOKEN`) is what makes the required checks attach to the PR.
+- Click **Ready for review** to take the PR out of draft — GitHub won't let you merge a draft PR.
 - Approve the PR.
 - Wait for required checks.
 - Click **Squash and merge** manually in the UI. **Do not enable auto-merge.**


### PR DESCRIPTION
## Summary

`prepare-release.yml` failed at **Create signed commit + open PR** with `Reference update failed` ([example run](https://github.com/neondatabase/neonctl/actions/runs/26830941627/job/79111763297)).

Root cause is a **git ref-namespace collision**, not permissions or a ruleset: a protected **`release`** branch still exists (leftover from the old semantic-release flow, which triggered on `push: branches: [release]`; last commit `chore(release): 2.22.0 [skip ci]`). When `release` exists as a branch, git can't also create `release/neonctl-<run_id>` beneath that path — it's rejected as a directory/file conflict, which the API surfaces as `Reference update failed`. That's why it failed with both `GITHUB_TOKEN` and the App token, and why the identical workflow works in `neondatabase/neon-js` (no bare `release` branch).

## Changes

- Rename the PR branch prefix `release/neonctl-<run_id>` → `release-pr/neonctl-<run_id>`. Non-destructive and self-contained — leaves the protected `release` branch untouched.
- Tighten `RELEASING.md`, and correct it to reflect that Stage 2 publishes to **npm only** — no GitHub release or binary assets. (Same stale claim removed from the `post-release.yml` handoff comment and `prepare-release.yml` header.)

## Try it

After merge:

```bash
gh workflow run prepare-release.yml --repo neondatabase/neonctl --ref main -f bump=patch
```

It should now open the release PR instead of failing at branch creation.

## Follow-up (optional, not required)

The `release` branch is dead now that semantic-release is gone. An admin could delete it as housekeeping (it's protected, so it needs admin), but this PR doesn't depend on that.