### PR TITLE
fix(release): unblock post-release (CI-skip marker) + keep publishing in Stage 2

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,11 +1,13 @@
 name: Post-release (tag + handoff)
 
 # Fires when a prepare-release PR merges. Steps:
-#   1. Parse the squash commit subject for `neonctl@v<ver>`
-#   2. Create the `v<ver>` tag on the merge commit
-#   3. Push the tag
-#   4. Comment on the merged PR with Stage 2 (npm publish) dispatch instructions
-#   5. Write the same instructions to the workflow run summary
+#   1. Parse the version from package.json (cross-checked against the subject)
+#   2. Create + push the `v<ver>` tag on the merge commit
+#   3. Comment on the merged PR with Stage 2 dispatch instructions
+#   4. Write the same instructions to the workflow run summary
+#
+# Artifacts (npm package + GitHub release with CLI binaries) are produced by
+# Stage 2, not here — we don't build/publish artifacts from the public repo.
 #
 # No cross-repo dispatch. Stage 2 is triggered by a human from the PR comment
 # or summary. See prepare-release.yml header for why.
@@ -159,11 +161,11 @@ jobs:
             echo "body<<HANDOFF_EOF"
             echo ":rocket: **Tagged \`${TAG}\` on the merge commit.**"
             echo ""
-            echo "### Stage 2 — publish to npm"
+            echo "### Stage 2 — publish (npm + GitHub release)"
             echo ""
             echo "> :warning: **Provisional:** the workflow filename and input names below are assumed to match the central repo's setup. If Stage 2 uses different names, the dispatch commands need updating in \`.github/workflows/post-release.yml\`."
             echo ""
-            echo "Trigger the publish workflow in \`databricks/secure-public-registry-releases-eng\`:"
+            echo "Stage 2 builds + scans the artifacts and publishes the npm package and the GitHub release (with the CLI binaries). Trigger it in \`databricks/secure-public-registry-releases-eng\`:"
             echo ""
             echo "\`\`\`bash"
             echo "# Dry run (recommended first):"
@@ -181,7 +183,7 @@ jobs:
             echo "  -f dry-run=false"
             echo "\`\`\`"
             echo ""
-            echo "After publish, verify on [npm](https://www.npmjs.com/package/neonctl)."
+            echo "After publish, verify on [npm](https://www.npmjs.com/package/neonctl) and the [GitHub release](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG})."
             echo "HANDOFF_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,8 +13,9 @@ name: Prepare Release
 #
 # Stage 2 lives in databricks/secure-public-registry-releases-eng and is
 # triggered manually pointing at the tag created by post-release.yml. It
-# checks out the source, installs, builds, packs the npm tarball, scans it,
-# and publishes to npm via OIDC Trusted Publishing.
+# builds + scans the artifacts and publishes them (npm package via OIDC
+# Trusted Publishing, plus the GitHub release with the CLI binaries) — we
+# don't build or publish artifacts from this public repo.
 
 on:
   workflow_dispatch:
@@ -209,11 +210,11 @@ jobs:
             echo "2. An approver reviews + approves this PR."
             echo "3. Required checks run."
             echo "4. On green, the approver **manually clicks \"Squash and merge\"** in the UI. **Do NOT use auto-merge.**"
-            echo "5. \`post-release.yml\` fires on the push to \`main\`, tags the squash commit \`${TAG}\`, and comments here with Stage 2 (npm publish) dispatch instructions."
+            echo "5. \`post-release.yml\` fires on the push to \`main\`, tags the squash commit \`${TAG}\`, and comments here with Stage 2 (npm + GitHub release) dispatch instructions."
             echo ""
             echo "> :warning: **Why manual merge?** GitHub Actions suppresses downstream \`on: push\` workflows for pushes caused by \`GITHUB_TOKEN\` (including auto-merge enabled from a workflow). A human clicking merge attributes the push to that user, so \`post-release.yml\` fires."
             echo ""
-            echo "> :warning: **Do not edit this PR's title** and do not add \`[skip ci]\` / \`[ci skip]\` markers — they'd break the commit-subject parser in \`post-release.yml\` or suppress the workflow entirely."
+            echo "> :warning: **Do not edit this PR's title** — \`post-release.yml\` parses the version from the squash commit subject. (This body becomes the squash commit message, so it must not contain CI-skip markers, which would suppress \`post-release.yml\`.)"
             echo ""
             echo "### Recovery"
             echo "- **Before Stage 2 runs:** delete the bad tag with \`git push origin :refs/tags/${TAG}\` and re-run the original \`post-release.yml\` via \"Re-run all jobs\" in the Actions tab."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,10 @@
 
 `neonctl` ships to npm via a two-stage pipeline:
 
-- **Stage 1 (this repo)** — `prepare-release.yml` bumps the version and opens a release PR; on merge, `post-release.yml` tags the commit and comments the Stage 2 command.
-- **Stage 2 (`databricks/secure-public-registry-releases-eng`)** — checks out the tag, builds, scans the tarball, and publishes to npm via OIDC trusted publishing.
+- **Stage 1 (this repo)** — `prepare-release.yml` bumps the version and opens a release PR; on merge, `post-release.yml` tags the commit and hands off to Stage 2.
+- **Stage 2 (`databricks/secure-public-registry-releases-eng`)** — checks out the tag, builds + scans, publishes the npm package via OIDC trusted publishing, and publishes the GitHub release with the CLI binaries attached.
 
-Stage 2 lives in the central repo because only its runners have the npm publish trust relationship. (External contributors: that repo is internal — open an issue and a maintainer will cut the release.)
+All artifacts are built and published from the central repo — we don't build or publish artifacts from this public repo. (External contributors: that repo is internal — open an issue and a maintainer will cut the release.)
 
 ## Prerequisites
 
@@ -34,7 +34,7 @@ gh workflow run release-neondatabase-neonctl.yml \
   --ref main -f ref=vX.Y.Z -f dry-run=true   # set dry-run=false to publish for real
 ```
 
-**5. Verify** at <https://www.npmjs.com/package/neonctl>.
+**5. Verify** on [npm](https://www.npmjs.com/package/neonctl) and the [GitHub release](https://github.com/neondatabase/neonctl/releases).
 
 ## Recovery
 


### PR DESCRIPTION
## Summary

Two release-workflow fixes:

1. **Unblock post-release.** The last release merge (#501) created no tag and ran no workflow. The release PR body generated by `prepare-release.yml` literally contained the `[skip ci]` / `[ci skip]` tokens (in a warning *about* those tokens). On squash-merge GitHub folds the PR body into the commit message, and Actions honors those markers anywhere in a commit message → every push-triggered workflow was suppressed. Reworded so the body stays marker-free.

2. **Keep artifact publishing in Stage 2.** Per the supply-chain rule, artifacts (the npm package and the GitHub release with the CLI binaries) are built/scanned/published from the central repo `databricks/secure-public-registry-releases-eng` — not from this public repo. `post-release.yml` only tags the merge commit and hands off; comments/docs updated to attribute the npm package + GitHub release (with binaries) to Stage 2.

## Notes

- We keep **squash** merging; the bug was the PR-body→commit-message coupling, not squash.
- No recovery needed for the `2.22.1` test bump; the next real release moves past it.
- The GitHub release + binaries (matching the old `release.yml` and the public docs) will be produced by Stage 2 — tracked separately on the central-repo side.

## Try it

After merge, cut a release (`prepare-release.yml` → mark ready → squash-merge) and confirm `post-release.yml` runs and creates the `vX.Y.Z` tag (no longer suppressed).