### PR TITLE
docs(release): point Stage 2 handoff at the real workflow (neonctl.yml)

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -152,31 +152,24 @@ jobs:
         env:
           TAG: ${{ steps.parse.outputs.tag }}
         run: |
-          # TODO(once Stage 2 is live): confirm exact workflow filename + input names
-          # in databricks/secure-public-registry-releases-eng — assumed
-          # `release-neondatabase-neonctl.yml` with inputs `ref` and `dry-run`.
-          # The filename must also match the workflow npm Trusted Publishing is
-          # configured to trust (npmjs.com/package/neonctl?activeTab=code).
           {
             echo "body<<HANDOFF_EOF"
             echo ":rocket: **Tagged \`${TAG}\` on the merge commit.**"
             echo ""
             echo "### Stage 2 — publish (npm + GitHub release)"
             echo ""
-            echo "> :warning: **Provisional:** the workflow filename and input names below are assumed to match the central repo's setup. If Stage 2 uses different names, the dispatch commands need updating in \`.github/workflows/post-release.yml\`."
-            echo ""
             echo "Stage 2 builds + scans the artifacts and publishes the npm package and the GitHub release (with the CLI binaries). Trigger it in \`databricks/secure-public-registry-releases-eng\`:"
             echo ""
             echo "\`\`\`bash"
             echo "# Dry run (recommended first):"
-            echo "gh workflow run release-neondatabase-neonctl.yml \\"
+            echo "gh workflow run neonctl.yml \\"
             echo "  --repo databricks/secure-public-registry-releases-eng \\"
             echo "  --ref main \\"
             echo "  -f ref=${TAG} \\"
             echo "  -f dry-run=true"
             echo ""
             echo "# Real publish:"
-            echo "gh workflow run release-neondatabase-neonctl.yml \\"
+            echo "gh workflow run neonctl.yml \\"
             echo "  --repo databricks/secure-public-registry-releases-eng \\"
             echo "  --ref main \\"
             echo "  -f ref=${TAG} \\"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ gh workflow run prepare-release.yml --repo neondatabase/neonctl --ref main -f bu
 **4. Dispatch Stage 2** (copy from the PR comment, or):
 
 ```bash
-gh workflow run release-neondatabase-neonctl.yml \
+gh workflow run neonctl.yml \
   --repo databricks/secure-public-registry-releases-eng \
   --ref main -f ref=vX.Y.Z -f dry-run=true   # set dry-run=false to publish for real
 ```


### PR DESCRIPTION
## Summary

The Stage 2 dispatch command in `post-release.yml`'s handoff comment and in `RELEASING.md` referenced `release-neondatabase-neonctl.yml`, which doesn't exist. The actual Stage 2 workflow in `databricks/secure-public-registry-releases-eng` is **`neonctl.yml`** (inputs `ref` + `dry-run`). Updates both to the correct filename and drops the now-confirmed "provisional" caveat.

(This was meant to ride along on #502 but landed after it merged, so the fix never reached `main` — hence this follow-up.)

## Try it

After merge, a release's `post-release` handoff comment will show the correct `gh workflow run neonctl.yml …` command.