### PR TITLE
Add Nix flake package for neonctl

### DIFF
--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -1,0 +1,80 @@
+name: Update Nix hashes
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-nix-hashes-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Refresh pnpm dependency hash
+        id: refresh
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          log="$(mktemp)"
+          set +e
+          nix build .#pnpmDeps --print-build-logs 2>&1 | tee "$log"
+          status="${PIPESTATUS[0]}"
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          got_hash="$(
+            sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+\/=]*\).*/\1/p' "$log" | tail -n 1
+          )"
+
+          if [ -z "$got_hash" ]; then
+            echo "nix build failed, but no replacement hash was found in the log" >&2
+            exit "$status"
+          fi
+
+          perl -0pi -e 's/(pnpmDepsHash = ")[^"]+(";\n)/${1}'"$got_hash"'${2}/' flake.nix
+          nix build .#pnpmDeps --print-build-logs
+
+          if git diff --quiet -- flake.nix; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify package
+        shell: bash
+        run: nix flake check --print-build-logs
+
+      - name: Commit refreshed hashes
+        if: steps.refresh.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.nix flake.lock
+          git commit -m "chore: update Nix hashes"
+          git push

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,156 @@
+{
+  description = "Nix package for the Neon CLI";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          inherit (pkgs) lib;
+
+          packageJson = builtins.fromJSON (builtins.readFile ./package.json);
+          nodejs = pkgs.nodejs_26;
+          pnpm = pkgs.pnpm_9.override { inherit nodejs; };
+
+          pnpmDepsHash = "sha256-kwq0bstVMxMK5t2ILerTgz4N6VJ2GORvyw7K07oaOiQ=";
+
+          neonctl = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+            pname = "neonctl";
+            inherit (packageJson) version;
+
+            src = ./.;
+
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              inherit (finalAttrs) pname version src;
+              inherit pnpm;
+              fetcherVersion = 3;
+              hash = pnpmDepsHash;
+            };
+
+            nativeBuildInputs = [
+              nodejs
+              pkgs.makeWrapper
+              pkgs.pnpmConfigHook
+              pnpm
+            ];
+
+            postPatch = ''
+              patchShebangs mocks/bin
+            '';
+
+            buildPhase = ''
+              runHook preBuild
+
+              pnpm run build
+
+              runHook postBuild
+            '';
+
+            doCheck = true;
+            checkPhase = ''
+              runHook preCheck
+
+              export HOME="$(mktemp -d)"
+              export XDG_CONFIG_HOME="$HOME/.config"
+              pnpm run test
+
+              runHook postCheck
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p "$out/bin" "$out/lib/neonctl"
+              cp -R dist node_modules "$out/lib/neonctl/"
+              node <<'EOF'
+              const fs = require("fs");
+              const path = require("path");
+
+              const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+              const modules = path.join(process.env.out, "lib", "neonctl", "node_modules");
+
+              for (const name of Object.keys(pkg.devDependencies ?? {})) {
+                fs.rmSync(path.join(modules, ...name.split("/")), {
+                  recursive: true,
+                  force: true,
+                });
+
+                if (name.startsWith("@")) {
+                  const scopeDir = path.join(modules, name.split("/")[0]);
+                  try {
+                    if (fs.readdirSync(scopeDir).length === 0) {
+                      fs.rmdirSync(scopeDir);
+                    }
+                  } catch (error) {
+                    if (error.code !== "ENOENT") {
+                      throw error;
+                    }
+                  }
+                }
+              }
+
+              fs.rmSync(path.join(modules, ".bin"), { recursive: true, force: true });
+              EOF
+              makeWrapper ${lib.getExe nodejs} "$out/bin/neonctl" \
+                --add-flags "$out/lib/neonctl/dist/cli.js"
+              ln -s "$out/bin/neonctl" "$out/bin/neon"
+
+              runHook postInstall
+            '';
+
+            meta = {
+              description = packageJson.description;
+              homepage = "https://github.com/neondatabase/neonctl";
+              license = lib.licenses.mit;
+              mainProgram = "neonctl";
+              platforms = lib.platforms.linux;
+            };
+          });
+        in
+        {
+          default = neonctl;
+          inherit neonctl;
+          pnpmDeps = neonctl.pnpmDeps;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/neonctl";
+          meta.description = "Neon CLI";
+        };
+        neonctl = self.apps.${system}.default;
+      });
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          neonctl = self.packages.${system}.default;
+        in
+        {
+          default = pkgs.runCommand "neonctl-smoke-test" { nativeBuildInputs = [ neonctl ]; } ''
+            neonctl --version | grep -F "${neonctl.version}"
+            neon --version | grep -F "${neonctl.version}"
+            neonctl --help >/dev/null
+            touch "$out"
+          '';
+        }
+      );
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+    };
+}


### PR DESCRIPTION
## Summary

- Add a Nix flake that packages `neonctl` as a Nix package/app
- Build with `nodejs_26` and pinned pnpm dependencies
- Add a flake check that smoke-tests both `neonctl` and `neon`
- Add GitHub Actions workflow to refresh the pnpm dependency hash only when it becomes stale

## Verification

- `nix build .#neonctl --print-build-logs`
- `nix flake check --print-build-logs`
- `./result/bin/neonctl --version`
- `./result/bin/neon --version`
- `nix run .#neonctl -- --version`

Full Nix build ran the existing test suite successfully: 22 test files, 234 tests.
