### PR TITLE
feat: support for function's env variables update

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ $ cat .neon
 | [me](https://neon.com/docs/reference/cli-me)                               |                                                                                             | Show current user              |
 | [branches](https://neon.com/docs/reference/cli-branches)                   | `list`, `create`, `rename`, `add-compute`, `set-default`, `set-expiration`, `delete`, `get` | Manage branches                |
 | [databases](https://neon.com/docs/reference/cli-databases)                 | `list`, `create`, `delete`                                                                  | Manage databases               |
-| functions                                                                  | `deploy`, `list`, `get`, `delete`                                                           | Manage Neon Functions          |
+| functions                                                                  | `deploy`, `list`, `get`, `delete`, `env add`, `env rm`                                      | Manage Neon Functions          |
 | [roles](https://neon.com/docs/reference/cli-roles)                         | `list`, `create`, `delete`                                                                  | Manage roles                   |
 | [operations](https://neon.com/docs/reference/cli-operations)               | `list`                                                                                      | Manage operations              |
 | [connection-string](https://neon.com/docs/reference/cli-connection-string) |                                                                                             | Get connection string          |

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/GET.js
@@ -3,7 +3,6 @@ let calls = 0;
 const version = (id, status) => ({
   id,
   status,
-  bundle_sha256: `sha-${id}`,
   memory_mib: 256,
   runtime: 'nodejs24',
   created_at: '2026-06-03T00:00:00Z',

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/GET.js
@@ -11,10 +11,10 @@ const version = (id, status) => ({
 
 const fn = (active_deployment) => ({
   function: {
-    id: 'fn-envadd',
-    slug: 'envadd',
-    name: 'Envadd',
-    invocation_url: 'https://envadd.functions.neon.tech',
+    id: 'fn-envadd-nowait',
+    slug: 'envadd-nowait',
+    name: 'Envadd-nowait',
+    invocation_url: 'https://envadd-nowait.functions.neon.tech',
     created_at: '2026-06-03T00:00:00Z',
     active_deployment,
   },
@@ -22,9 +22,8 @@ const fn = (active_deployment) => ({
 
 export default function (req, res) {
   calls += 1;
-  // call 1 = pre-deploy snapshot (prior version 1); call 2 = new version 2
-  // still building; call 3+ = version 2 completed.
+  // call 1 = pre-deploy snapshot (prior version 1); call 2+ = new version 2
+  // building. --no-wait stops at first sight of the new version.
   if (calls === 1) return res.send(fn(version(1, 'completed')));
-  if (calls === 2) return res.send(fn(version(2, 'building')));
-  return res.send(fn(version(2, 'completed')));
+  return res.send(fn(version(2, 'building')));
 }

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/deployments/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd-nowait/deployments/POST.js
@@ -12,7 +12,6 @@ export default function (req, res) {
   req.on('end', () => {
     expect(raw).toContain('name="environment"');
     expect(raw).toContain('{"KEY":"VALUE"}');
-    // env-only redeploy: no bundle/memory/runtime parts.
     expect(raw).not.toContain('name="zip"');
     expect(raw).not.toContain('name="memory_mib"');
     expect(raw).not.toContain('name="runtime"');

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/GET.js
@@ -1,0 +1,36 @@
+const version = (id, status) => ({
+  id,
+  status,
+  bundle_sha256: `sha-${id}`,
+  memory_mib: 256,
+  runtime: 'nodejs24',
+  created_at: '2026-06-03T00:00:00Z',
+});
+
+const fn = (active_deployment) => ({
+  function: {
+    id: 'fn-envadd',
+    slug: 'envadd',
+    name: 'Envadd',
+    invocation_url: 'https://envadd.functions.neon.tech',
+    created_at: '2026-06-03T00:00:00Z',
+    active_deployment,
+  },
+});
+
+// The mock module is import-cached and reused across the file's tests, so per
+// test state lives on globalThis and is reset by the deploy POST. The deploy
+// helper does exactly: one snapshot GET, then the POST, then poll GETs. The
+// snapshot (before the POST has incremented `polls`) reports prior version 1;
+// the first poll reports version 2 still building, then completed.
+export default function (req, res) {
+  const state = (globalThis.__envadd ??= { polls: 0, deploying: false });
+  if (!state.deploying) return res.send(fn(version(1, 'completed')));
+  state.polls += 1;
+  if (state.polls <= 1) return res.send(fn(version(2, 'building')));
+  // Terminal poll: end this cycle so the next test's snapshot sees prior
+  // version 1 again. --no-wait stops before reaching here; it resets on its
+  // own deploy POST.
+  state.deploying = false;
+  return res.send(fn(version(2, 'completed')));
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/GET.js
@@ -3,7 +3,6 @@ let calls = 0;
 const version = (id, status) => ({
   id,
   status,
-  bundle_sha256: `sha-${id}`,
   memory_mib: 256,
   runtime: 'nodejs24',
   created_at: '2026-06-03T00:00:00Z',

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/deployments/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envadd/deployments/POST.js
@@ -1,0 +1,26 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  expect(req.headers['content-type']).toMatch(
+    /^multipart\/form-data; boundary=/,
+  );
+  let raw = '';
+  req.setEncoding('latin1');
+  req.on('data', (chunk) => {
+    raw += chunk;
+  });
+  req.on('end', () => {
+    expect(raw).toContain('name="environment"');
+    expect(raw).toContain('{"KEY":"VALUE"}');
+    // env-only redeploy: no bundle/memory/runtime parts.
+    expect(raw).not.toContain('name="zip"');
+    expect(raw).not.toContain('name="memory_mib"');
+    expect(raw).not.toContain('name="runtime"');
+    // Start a fresh deploy cycle for the paired GET mock: version 2 begins
+    // building now, independent of any state left by an earlier test.
+    globalThis.__envadd = { polls: 0, deploying: true };
+    res.status(201).send({
+      operation: { id: 'op-1', action: 'deploy_function', status: 'running' },
+    });
+  });
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/GET.js
@@ -3,7 +3,6 @@ let calls = 0;
 const version = (id, status) => ({
   id,
   status,
-  bundle_sha256: `sha-${id}`,
   memory_mib: 256,
   runtime: 'nodejs24',
   created_at: '2026-06-03T00:00:00Z',

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/GET.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/GET.js
@@ -1,0 +1,28 @@
+let calls = 0;
+
+const version = (id, status) => ({
+  id,
+  status,
+  bundle_sha256: `sha-${id}`,
+  memory_mib: 256,
+  runtime: 'nodejs24',
+  created_at: '2026-06-03T00:00:00Z',
+});
+
+const fn = (active_deployment) => ({
+  function: {
+    id: 'fn-envrm',
+    slug: 'envrm',
+    name: 'Envrm',
+    invocation_url: 'https://envrm.functions.neon.tech',
+    created_at: '2026-06-03T00:00:00Z',
+    active_deployment,
+  },
+});
+
+export default function (req, res) {
+  calls += 1;
+  if (calls === 1) return res.send(fn(version(1, 'completed')));
+  if (calls === 2) return res.send(fn(version(2, 'building')));
+  return res.send(fn(version(2, 'completed')));
+}

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/deployments/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/deployments/POST.js
@@ -12,7 +12,10 @@ export default function (req, res) {
   req.on('end', () => {
     expect(raw).toContain('name="environment"');
     expect(raw).toContain('{"KEY":""}');
+    // env-only redeploy: no bundle/memory/runtime parts.
     expect(raw).not.toContain('name="zip"');
+    expect(raw).not.toContain('name="memory_mib"');
+    expect(raw).not.toContain('name="runtime"');
     res.status(201).send({
       operation: { id: 'op-1', action: 'deploy_function', status: 'running' },
     });

--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/deployments/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/envrm/deployments/POST.js
@@ -1,0 +1,20 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  expect(req.headers['content-type']).toMatch(
+    /^multipart\/form-data; boundary=/,
+  );
+  let raw = '';
+  req.setEncoding('latin1');
+  req.on('data', (chunk) => {
+    raw += chunk;
+  });
+  req.on('end', () => {
+    expect(raw).toContain('name="environment"');
+    expect(raw).toContain('{"KEY":""}');
+    expect(raw).not.toContain('name="zip"');
+    res.status(201).send({
+      operation: { id: 'op-1', action: 'deploy_function', status: 'running' },
+    });
+  });
+}

--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -93,7 +93,6 @@ exports[`functions > deploy requires at least one option 1`] = `""`;
 exports[`functions > env add --no-wait stops after triggering 1`] = `
 "id: 2
 status: building
-bundle_sha256: sha-2
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
@@ -107,7 +106,6 @@ exports[`functions > env add rejects an invalid slug 1`] = `""`;
 exports[`functions > env add triggers an env-only redeploy and waits 1`] = `
 "id: 2
 status: completed
-bundle_sha256: sha-2
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
@@ -119,7 +117,6 @@ exports[`functions > env rm rejects an invalid slug 1`] = `""`;
 exports[`functions > env rm sends an empty value to drop the key 1`] = `
 "id: 2
 status: completed
-bundle_sha256: sha-2
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z

--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -114,6 +114,8 @@ created_at: 2026-06-03T00:00:00Z
 "
 `;
 
+exports[`functions > env rm rejects an invalid slug 1`] = `""`;
+
 exports[`functions > env rm sends an empty value to drop the key 1`] = `
 "id: 2
 status: completed

--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -90,6 +90,30 @@ exports[`functions > deploy rejects malformed --env 1`] = `""`;
 
 exports[`functions > deploy requires at least one option 1`] = `""`;
 
+exports[`functions > env add --no-wait stops after triggering 1`] = `
+"id: 2
+status: building
+bundle_sha256: sha-2
+memory_mib: 256
+runtime: nodejs24
+created_at: 2026-06-03T00:00:00Z
+"
+`;
+
+exports[`functions > env add rejects an empty value (use rm to delete) 1`] = `""`;
+
+exports[`functions > env add rejects an invalid slug 1`] = `""`;
+
+exports[`functions > env add triggers an env-only redeploy and waits 1`] = `
+"id: 2
+status: completed
+bundle_sha256: sha-2
+memory_mib: 256
+runtime: nodejs24
+created_at: 2026-06-03T00:00:00Z
+"
+`;
+
 exports[`functions > get (table) 1`] = `
 "function
 ┌─────────┬─────────┬─────────────────────────────────────┬──────────────────────┐

--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -114,6 +114,16 @@ created_at: 2026-06-03T00:00:00Z
 "
 `;
 
+exports[`functions > env rm sends an empty value to drop the key 1`] = `
+"id: 2
+status: completed
+bundle_sha256: sha-2
+memory_mib: 256
+runtime: nodejs24
+created_at: 2026-06-03T00:00:00Z
+"
+`;
+
 exports[`functions > get (table) 1`] = `
 "function
 ┌─────────┬─────────┬─────────────────────────────────────┬──────────────────────┐

--- a/src/commands/functions.test.ts
+++ b/src/commands/functions.test.ts
@@ -634,6 +634,31 @@ describe('functions', () => {
     );
   });
 
+  test('env rm sends an empty value to drop the key', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'rm',
+        'envrm',
+        'KEY',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        env: { NEON_FUNCTIONS_POLL_INTERVAL_MS: '1' },
+        stderr:
+          'INFO: Function deployment triggered for function envrm. ' +
+          'INFO: Function deployment envrm/2 completed.',
+      },
+    );
+  });
+
   // esbuild's diagnostic text is environment-specific, so assert the exit code
   // and the empty stdout snapshot only - not the stderr string.
   test('deploy fails cleanly when bundling fails', async ({

--- a/src/commands/functions.test.ts
+++ b/src/commands/functions.test.ts
@@ -659,6 +659,28 @@ describe('functions', () => {
     );
   });
 
+  test('env rm rejects an invalid slug', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'rm',
+        'Bad_Slug',
+        'KEY',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        code: 1,
+        stderr:
+          'ERROR: Invalid function slug "Bad_Slug". Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.',
+      },
+    );
+  });
+
   // esbuild's diagnostic text is environment-specific, so assert the exit code
   // and the empty stdout snapshot only - not the stderr string.
   test('deploy fails cleanly when bundling fails', async ({

--- a/src/commands/functions.test.ts
+++ b/src/commands/functions.test.ts
@@ -614,7 +614,7 @@ describe('functions', () => {
         'functions',
         'env',
         'add',
-        'envadd',
+        'envadd-nowait',
         'KEY',
         'VALUE',
         '--no-wait',
@@ -627,8 +627,8 @@ describe('functions', () => {
         mockDir: 'single_org',
         env: { NEON_FUNCTIONS_POLL_INTERVAL_MS: '1' },
         stderr:
-          'INFO: Function deployment triggered for function envadd. ' +
-          'INFO: Check status with: neonctl functions get envadd ' +
+          'INFO: Function deployment triggered for function envadd-nowait. ' +
+          'INFO: Check status with: neonctl functions get envadd-nowait ' +
           '--project-id test-project-123456 --branch br-main-branch-123456',
       },
     );

--- a/src/commands/functions.test.ts
+++ b/src/commands/functions.test.ts
@@ -532,6 +532,108 @@ describe('functions', () => {
     );
   });
 
+  test('env add triggers an env-only redeploy and waits', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'add',
+        'envadd',
+        'KEY',
+        'VALUE',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        env: { NEON_FUNCTIONS_POLL_INTERVAL_MS: '1' },
+        stderr:
+          'INFO: Function deployment triggered for function envadd. ' +
+          'INFO: Function deployment envadd/2 completed.',
+      },
+    );
+  });
+
+  test('env add rejects an invalid slug', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'add',
+        'Bad_Slug',
+        'KEY',
+        'VALUE',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        code: 1,
+        stderr:
+          'ERROR: Invalid function slug "Bad_Slug". Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.',
+      },
+    );
+  });
+
+  test('env add rejects an empty value (use rm to delete)', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'add',
+        'envadd',
+        'KEY',
+        '',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        code: 1,
+        stderr:
+          'ERROR: Refusing to set an empty value. To remove a variable, use: neonctl functions env rm <slug> <key>.',
+      },
+    );
+  });
+
+  test('env add --no-wait stops after triggering', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'env',
+        'add',
+        'envadd',
+        'KEY',
+        'VALUE',
+        '--no-wait',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        env: { NEON_FUNCTIONS_POLL_INTERVAL_MS: '1' },
+        stderr:
+          'INFO: Function deployment triggered for function envadd. ' +
+          'INFO: Check status with: neonctl functions get envadd ' +
+          '--project-id test-project-123456 --branch br-main-branch-123456',
+      },
+    );
+  });
+
   // esbuild's diagnostic text is environment-specific, so assert the exit code
   // and the empty stdout snapshot only - not the stderr string.
   test('deploy fails cleanly when bundling fails', async ({

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -79,7 +79,10 @@ export const builder = (argv: yargs.Argv) =>
               choices: ['nodejs24'],
             },
             env: {
-              describe: 'Environment variable as KEY=VALUE (repeatable)',
+              describe:
+                'Environment variable as KEY=VALUE (repeatable). Variables are ' +
+                'inherited from the previous deployment; pass --env only for the ' +
+                'variables you want to add or change.',
               type: 'string',
               array: true,
             },

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -16,8 +16,8 @@ import {
   deleteFunction,
   getFunction,
   listFunctions,
-  NeonFunctionDeployment,
 } from '../functions_api.js';
+import { deployFunction, DEPLOYMENT_FIELDS } from '../functions_deploy.js';
 
 const FUNCTION_FIELDS = [
   'slug',
@@ -26,28 +26,10 @@ const FUNCTION_FIELDS = [
   'created_at',
 ] as const;
 
-const DEPLOYMENT_FIELDS = [
-  'id',
-  'status',
-  'runtime',
-  'memory_mib',
-  'created_at',
-] as const;
-
 const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$/;
 const SLUG_HELP =
   'Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.';
 const MEMORY_CHOICES = [256, 512, 1024, 2048, 4096, 8192];
-
-// Overridable so tests can poll fast; defaults to 2s in real use.
-const POLL_INTERVAL_MS =
-  Number(process.env.NEON_FUNCTIONS_POLL_INTERVAL_MS) || 2000;
-
-// Upper bound on --wait polling so the CLI never hangs (e.g. if our deployment
-// never becomes active_deployment). Overridable so tests can time out fast;
-// defaults to 10 minutes in real use.
-const POLL_TIMEOUT_MS =
-  Number(process.env.NEON_FUNCTIONS_POLL_TIMEOUT_MS) || 600_000;
 
 export const command = 'functions';
 export const describe = 'Manage Neon Functions';
@@ -164,17 +146,6 @@ const parseEnv = (entries: string[] | undefined): string | undefined => {
   return JSON.stringify(map);
 };
 
-const statusHint = (slug: string, projectId: string, branchId: string) =>
-  `Check status with: neonctl functions get ${slug} --project-id ${projectId} --branch ${branchId}`;
-
-// A poll error worth retrying: a network error (no HTTP response), a 5xx, or a
-// 404 from eventual consistency. Anything else (e.g. 401/403) is surfaced.
-const isTransient = (err: unknown): boolean =>
-  isAxiosError(err) &&
-  (err.response === undefined ||
-    err.response.status === 404 ||
-    err.response.status >= 500);
-
 const deploy = async (props: DeployProps) => {
   // At least one deploy option must be passed (--wait is excluded: it controls
   // output, not what gets deployed).
@@ -213,109 +184,15 @@ const deploy = async (props: DeployProps) => {
   const zip = zipBundle(await bundleEntry(source));
   const branchId = await branchIdFromProps(props);
 
-  // Snapshot the active version before deploy so we can detect the new one
-  // afterward. A missing function (404) or no active version → undefined.
-  let before: number | undefined;
-  try {
-    const fn = await getFunction(
-      props.apiClient,
-      props.projectId,
-      branchId,
-      props.slug,
-    );
-    before = fn.active_deployment?.id;
-  } catch (err: unknown) {
-    if (!(isAxiosError(err) && err.response?.status === 404)) throw err;
-  }
-
-  await retryOnLock(() =>
-    createDeployment(props.apiClient, props.projectId, branchId, props.slug, {
-      zip,
-      memoryMib,
-      runtime,
-      environment,
-    }),
-  );
-  log.info(`Function deployment triggered for function ${props.slug}.`);
-
-  // Best-effort interrupt: a Ctrl-C lands at the next poll boundary. (No
-  // automated test; mirrors the resolution branches below, verified manually.)
-  let interrupted = false;
-  const onSignal = () => {
-    interrupted = true;
-  };
-  process.once('SIGINT', onSignal);
-  process.once('SIGTERM', onSignal);
-
-  // Poll until a NEW active version appears (id greater than the snapshot, or
-  // any version if there was none). --no-wait stops there; --wait stops at a
-  // terminal status. Bounded by POLL_TIMEOUT_MS so it never hangs.
-  let resolved: NeonFunctionDeployment | undefined;
-  const deadline = Date.now() + POLL_TIMEOUT_MS;
-  try {
-    while (!interrupted && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-      if (interrupted) break;
-      // The deploy already succeeded server-side; tolerate transient poll
-      // failures and retry on the next interval. Surface anything else.
-      let dep: NeonFunctionDeployment | undefined;
-      try {
-        dep = (
-          await getFunction(
-            props.apiClient,
-            props.projectId,
-            branchId,
-            props.slug,
-          )
-        ).active_deployment;
-      } catch (err: unknown) {
-        if (isTransient(err)) continue;
-        throw err;
-      }
-      const isNew =
-        dep !== undefined && (before === undefined || dep.id > before);
-      if (isNew && dep) {
-        resolved = dep;
-        if (!props.wait) break;
-        if (dep.status === 'completed' || dep.status === 'failed') break;
-      }
-    }
-  } finally {
-    process.removeListener('SIGINT', onSignal);
-    process.removeListener('SIGTERM', onSignal);
-  }
-
-  if (interrupted) {
-    log.info(statusHint(props.slug, props.projectId, branchId));
-    if (resolved) writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
-    return;
-  }
-
-  if (resolved === undefined) {
-    log.info(statusHint(props.slug, props.projectId, branchId));
-    throw new Error(
-      `Timed out waiting for the deployment of ${props.slug} to start. It may still be in progress.`,
-    );
-  }
-
-  writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
-
-  if (!props.wait) {
-    log.info(statusHint(props.slug, props.projectId, branchId));
-    return;
-  }
-  if (resolved.status === 'completed') {
-    log.info(`Function deployment ${props.slug}/${resolved.id} completed.`);
-    return;
-  }
-  if (resolved.status === 'failed') {
-    throw new Error(`Function deployment ${props.slug}/${resolved.id} failed.`);
-  }
-
-  // --wait, new version appeared but the deadline hit before it finished.
-  log.info(statusHint(props.slug, props.projectId, branchId));
-  throw new Error(
-    `Timed out waiting for function deployment ${props.slug}/${resolved.id} to finish. It may still be building.`,
+  await deployFunction(props, branchId, props.slug, props.wait, () =>
+    retryOnLock(() =>
+      createDeployment(props.apiClient, props.projectId, branchId, props.slug, {
+        zip,
+        memoryMib,
+        runtime,
+        environment,
+      }),
+    ),
   );
 };
 

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -32,6 +32,13 @@ const SLUG_HELP =
   'Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.';
 const MEMORY_CHOICES = [256, 512, 1024, 2048, 4096, 8192];
 
+// Cheap, offline slug validation - fail before any network round-trip.
+const assertValidSlug = (slug: string) => {
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new Error(`Invalid function slug "${slug}". ${SLUG_HELP}`);
+  }
+};
+
 export const command = 'functions';
 export const describe = 'Manage Neon Functions';
 export const aliases = ['function'];
@@ -229,10 +236,7 @@ const deploy = async (props: DeployProps) => {
     );
   }
 
-  // Cheap, offline validation first - fail before any network round-trip.
-  if (!SLUG_PATTERN.test(props.slug)) {
-    throw new Error(`Invalid function slug "${props.slug}". ${SLUG_HELP}`);
-  }
+  assertValidSlug(props.slug);
 
   const path = props.path ?? '.';
   const entry = props.entry ?? 'index.ts';
@@ -271,9 +275,7 @@ type EnvAddProps = BranchScopeProps & {
 };
 
 const envAdd = async (props: EnvAddProps) => {
-  if (!SLUG_PATTERN.test(props.slug)) {
-    throw new Error(`Invalid function slug "${props.slug}". ${SLUG_HELP}`);
-  }
+  assertValidSlug(props.slug);
   // An empty value is the server's delete signal; route that through `rm`
   // explicitly rather than silently dropping the key on an `add`.
   if (props.value === '') {
@@ -304,9 +306,7 @@ type EnvRmProps = BranchScopeProps & {
 };
 
 const envRm = async (props: EnvRmProps) => {
-  if (!SLUG_PATTERN.test(props.slug)) {
-    throw new Error(`Invalid function slug "${props.slug}". ${SLUG_HELP}`);
-  }
+  assertValidSlug(props.slug);
   const branchId = await branchIdFromProps(props);
   await deployFunction(props, branchId, props.slug, props.wait, () =>
     retryOnLock(() =>

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -154,6 +154,31 @@ export const builder = (argv: yargs.Argv) =>
                 }),
             (args) => envAdd(args as any),
           )
+          .command(
+            ['rm <slug> <key>', 'remove <slug> <key>'],
+            'Remove an environment variable. Changing environment variables triggers a redeployment of the function. ' +
+              'Removal sends an empty value for the key, which drops it from the environment.',
+            (yargs) =>
+              yargs
+                .positional('slug', {
+                  describe: 'Function slug',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .positional('key', {
+                  describe: 'Environment variable name to remove',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .options({
+                  wait: {
+                    describe: 'Wait for the redeployment to finish building',
+                    type: 'boolean',
+                    default: true,
+                  },
+                }),
+            (args) => envRm(args as any),
+          )
           .demandCommand(1),
       (args) => args as any,
     );
@@ -263,6 +288,32 @@ const envAdd = async (props: EnvAddProps) => {
         props.slug,
         {
           [props.key]: props.value,
+        },
+      ),
+    ),
+  );
+};
+
+type EnvRmProps = BranchScopeProps & {
+  slug: string;
+  key: string;
+  wait: boolean;
+};
+
+const envRm = async (props: EnvRmProps) => {
+  if (!SLUG_PATTERN.test(props.slug)) {
+    throw new Error(`Invalid function slug "${props.slug}". ${SLUG_HELP}`);
+  }
+  const branchId = await branchIdFromProps(props);
+  await deployFunction(props, branchId, props.slug, props.wait, () =>
+    retryOnLock(() =>
+      createEnvDeployment(
+        props.apiClient,
+        props.projectId,
+        branchId,
+        props.slug,
+        {
+          [props.key]: '',
         },
       ),
     ),

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -13,6 +13,7 @@ import { bundleEntry } from '../utils/esbuild.js';
 import { writer } from '../writer.js';
 import {
   createDeployment,
+  createEnvDeployment,
   deleteFunction,
   getFunction,
   listFunctions,
@@ -117,6 +118,47 @@ export const builder = (argv: yargs.Argv) =>
           demandOption: true,
         }),
       (args) => deleteFn(args as any),
+    )
+    .command(
+      ['env', 'environment'],
+      "Manage a function's environment variables",
+      (yargs) =>
+        yargs
+          .usage('$0 functions env <sub-command> [options]')
+          .command(
+            'add <slug> <key> <value>',
+            'Set an environment variable. Changing environment variables triggers a redeployment of the function.',
+            (yargs) =>
+              yargs
+                .positional('slug', {
+                  describe: 'Function slug',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .positional('key', {
+                  describe: 'Environment variable name',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .positional('value', {
+                  describe: 'Environment variable value',
+                  type: 'string',
+                  demandOption: true,
+                })
+                .options({
+                  wait: {
+                    describe: 'Wait for the redeployment to finish building',
+                    type: 'boolean',
+                    default: true,
+                  },
+                }),
+            (args) => envAdd(args as any),
+          )
+          .demandCommand(1),
+      // demandCommand(1) makes yargs require a sub-command, so this group
+      // handler is never reached.
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
     );
 
 export const handler = (args: yargs.Argv) => {
@@ -192,6 +234,40 @@ const deploy = async (props: DeployProps) => {
         runtime,
         environment,
       }),
+    ),
+  );
+};
+
+type EnvAddProps = BranchScopeProps & {
+  slug: string;
+  key: string;
+  value: string;
+  wait: boolean;
+};
+
+const envAdd = async (props: EnvAddProps) => {
+  if (!SLUG_PATTERN.test(props.slug)) {
+    throw new Error(`Invalid function slug "${props.slug}". ${SLUG_HELP}`);
+  }
+  // An empty value is the server's delete signal; route that through `rm`
+  // explicitly rather than silently dropping the key on an `add`.
+  if (props.value === '') {
+    throw new Error(
+      'Refusing to set an empty value. To remove a variable, use: neonctl functions env rm <slug> <key>.',
+    );
+  }
+  const branchId = await branchIdFromProps(props);
+  await deployFunction(props, branchId, props.slug, props.wait, () =>
+    retryOnLock(() =>
+      createEnvDeployment(
+        props.apiClient,
+        props.projectId,
+        branchId,
+        props.slug,
+        {
+          [props.key]: props.value,
+        },
+      ),
     ),
   );
 };

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -155,10 +155,7 @@ export const builder = (argv: yargs.Argv) =>
             (args) => envAdd(args as any),
           )
           .demandCommand(1),
-      // demandCommand(1) makes yargs require a sub-command, so this group
-      // handler is never reached.
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      () => {},
+      (args) => args as any,
     );
 
 export const handler = (args: yargs.Argv) => {

--- a/src/functions_api.ts
+++ b/src/functions_api.ts
@@ -102,3 +102,27 @@ export const createDeployment = async (
     secure: true,
   });
 };
+
+// Trigger a redeployment that only changes environment variables. The server
+// inherits the previous deployment's bundle, memory, and runtime, and merges
+// this map into its environment; an empty-string value deletes that key.
+export const createEnvDeployment = async (
+  apiClient: ApiClient,
+  projectId: string,
+  branchId: string,
+  slug: string,
+  environment: Record<string, string>,
+): Promise<void> => {
+  const form = new FormData();
+  form.append('environment', JSON.stringify(environment));
+
+  await apiClient.request<unknown>({
+    path: `${functionsPath(projectId, branchId)}/${encodeURIComponent(
+      slug,
+    )}/deployments`,
+    method: 'POST',
+    type: ContentType.FormData,
+    body: form,
+    secure: true,
+  });
+};

--- a/src/functions_deploy.ts
+++ b/src/functions_deploy.ts
@@ -1,0 +1,136 @@
+import { isAxiosError } from 'axios';
+
+import { log } from './log.js';
+import { BranchScopeProps } from './types.js';
+import { writer } from './writer.js';
+import { getFunction, NeonFunctionDeployment } from './functions_api.js';
+
+export const DEPLOYMENT_FIELDS = [
+  'id',
+  'status',
+  'runtime',
+  'memory_mib',
+  'created_at',
+] as const;
+
+// Overridable so tests can poll fast; defaults to 2s in real use.
+const POLL_INTERVAL_MS =
+  Number(process.env.NEON_FUNCTIONS_POLL_INTERVAL_MS) || 2000;
+
+// Upper bound on --wait polling so the CLI never hangs (e.g. if our deployment
+// never becomes active_deployment). Overridable so tests can time out fast;
+// defaults to 10 minutes in real use.
+const POLL_TIMEOUT_MS =
+  Number(process.env.NEON_FUNCTIONS_POLL_TIMEOUT_MS) || 600_000;
+
+const statusHint = (slug: string, projectId: string, branchId: string) =>
+  `Check status with: neonctl functions get ${slug} --project-id ${projectId} --branch ${branchId}`;
+
+// A poll error worth retrying: a network error (no HTTP response), a 5xx, or a
+// 404 from eventual consistency. Anything else (e.g. 401/403) is surfaced.
+const isTransient = (err: unknown): boolean =>
+  isAxiosError(err) &&
+  (err.response === undefined ||
+    err.response.status === 404 ||
+    err.response.status >= 500);
+
+// Snapshot the active version, run `trigger` (the deployment POST), then poll
+// until a NEW active version appears. --no-wait stops at first sight of it;
+// --wait stops at a terminal status. Bounded by POLL_TIMEOUT_MS so it never
+// hangs. Shared by `deploy` and the `env` subcommands; only `trigger` differs.
+export const deployFunction = async (
+  props: BranchScopeProps,
+  branchId: string,
+  slug: string,
+  wait: boolean,
+  trigger: () => Promise<void>,
+): Promise<void> => {
+  // Snapshot the active version before deploy so we can detect the new one
+  // afterward. A missing function (404) or no active version → undefined.
+  let before: number | undefined;
+  try {
+    const fn = await getFunction(
+      props.apiClient,
+      props.projectId,
+      branchId,
+      slug,
+    );
+    before = fn.active_deployment?.id;
+  } catch (err: unknown) {
+    if (!(isAxiosError(err) && err.response?.status === 404)) throw err;
+  }
+
+  await trigger();
+  log.info(`Function deployment triggered for function ${slug}.`);
+
+  // Best-effort interrupt: a Ctrl-C lands at the next poll boundary.
+  let interrupted = false;
+  const onSignal = () => {
+    interrupted = true;
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  let resolved: NeonFunctionDeployment | undefined;
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  try {
+    while (!interrupted && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      if (interrupted) break;
+      // The deploy already succeeded server-side; tolerate transient poll
+      // failures and retry on the next interval. Surface anything else.
+      let dep: NeonFunctionDeployment | undefined;
+      try {
+        dep = (
+          await getFunction(props.apiClient, props.projectId, branchId, slug)
+        ).active_deployment;
+      } catch (err: unknown) {
+        if (isTransient(err)) continue;
+        throw err;
+      }
+      const isNew =
+        dep !== undefined && (before === undefined || dep.id > before);
+      if (isNew && dep) {
+        resolved = dep;
+        if (!wait) break;
+        if (dep.status === 'completed' || dep.status === 'failed') break;
+      }
+    }
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+  }
+
+  if (interrupted) {
+    log.info(statusHint(slug, props.projectId, branchId));
+    if (resolved) writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
+    return;
+  }
+
+  if (resolved === undefined) {
+    log.info(statusHint(slug, props.projectId, branchId));
+    throw new Error(
+      `Timed out waiting for the deployment of ${slug} to start. It may still be in progress.`,
+    );
+  }
+
+  writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
+
+  if (!wait) {
+    log.info(statusHint(slug, props.projectId, branchId));
+    return;
+  }
+  if (resolved.status === 'completed') {
+    log.info(`Function deployment ${slug}/${resolved.id} completed.`);
+    return;
+  }
+  if (resolved.status === 'failed') {
+    throw new Error(`Function deployment ${slug}/${resolved.id} failed.`);
+  }
+
+  // --wait, new version appeared but the deadline hit before it finished.
+  log.info(statusHint(slug, props.projectId, branchId));
+  throw new Error(
+    `Timed out waiting for function deployment ${slug}/${resolved.id} to finish. It may still be building.`,
+  );
+};


### PR DESCRIPTION

  ## Why?

  Function environment variables could only be set at deploy time. Users need to add or remove individual env vars on an already-deployed function without re-bundling and
  re-uploading the source.

  ## What?

  - **`neon functions env add <slug> <key> <value>`** (`src/commands/functions.ts`): new subcommand that sets a single environment variable on a function via an env-only
  redeployment. Refuses an empty value (points the user at `env rm` instead).
  - **`neon functions env rm <slug> <key>`** (`src/commands/functions.ts`): new subcommand that removes a single environment variable (sends an empty-string value, which
  the server treats as a delete).
  - **`createEnvDeployment`** (`src/functions_api.ts`): new API helper that POSTs to `…/functions/<slug>/deployments` with only an `environment` form field. The server
  inherits the previous deployment's bundle, memory, and runtime and merges the map in.
  - Both subcommands support **`--wait`** to block on the redeployment finishing.
  - **Refactor** (`src/functions_deploy.ts`): extracted the deploy poll loop and helpers (`deployFunction`, `DEPLOYMENT_FIELDS`, poll interval/timeout, `statusHint`,
  transient-error handling) out of `functions.ts` so deploy and env redeployments share one wait path.
  - **Refactor** (`src/commands/functions.ts`): extracted shared `assertValidSlug` validation used by deploy, env add, and env rm.
  - **Docs** (`README.md`): documented `env add`/`env rm` and noted env inheritance on deploy.
  - **Tests/mocks** (`src/commands/functions.test.ts`, `__snapshots__`, `mocks/`): coverage for env add/rm (including invalid-slug and env-only POST assertions) and
  snapshot updates.
