### PR TITLE
feat(config): add config status|plan|apply and deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,63 @@ $ cat .neon
 
 **`.gitignore` scaffolding**: when `.neon` is **created** for the first time, the CLI also makes sure a `.gitignore` sits alongside it listing `.neon`. If `.gitignore` doesn't exist it's created with a single `.neon` line; if it does exist, `.neon` is appended only when missing (no duplicates, your other entries are left alone). On subsequent updates to an existing `.neon`, `.gitignore` is left untouched — so if you deliberately un-ignore `.neon` (e.g. to commit shared context), the entry is not re-added on every command.
 
+## Config as code (`config` / `deploy`)
+
+Describe a branch's desired state in a `neon.ts` policy and reconcile it from the CLI — the Neon equivalent of `terraform status` / `plan` / `apply`. The policy is a function of the branch it's being evaluated for; you switch on the branch (`name`, `isDefault`, …) and return the config you want (auth, Data API, compute settings, TTL, protection, and Preview features like Functions and buckets):
+
+```ts
+// neon.ts
+import { defineConfig } from '@neondatabase/config/v1';
+
+export default defineConfig((branch) => {
+  if (branch.isDefault) {
+    return { protected: true, auth: {} };
+  }
+  return { parent: 'main', ttl: '7d' };
+});
+```
+
+Three sub-commands plus a top-level alias drive it:
+
+```bash
+# Inspect the branch's live Neon state (read-only — never mutates)
+neon config status
+
+# Dry-run diff: show exactly what `apply` would change
+neon config plan
+
+# Reconcile the policy against the branch
+neon config apply
+
+# `neon deploy` is an alias for `neon config apply`
+neon deploy
+```
+
+**Project & branch resolution** follows the same chain as the rest of the CLI, each entry winning over the next:
+
+1. `--project-id <id>` flag
+2. `projectId` from the closest `.neon` file (found by walking up from the current directory — see "Where `.neon` lives" above)
+3. If still unresolved and the API key maps to exactly one project, that project is auto-detected
+
+The branch is chosen with `--branch <id|name>`; without it the project's default branch is used. The policy itself is found by walking up from the current directory for a `neon.ts`, or pass `--config <path>` to point at one explicitly.
+
+**Apply-only flags** (also available on `deploy`):
+
+- `--update-existing` — auto-confirm overriding existing remote settings on the branch. Without it, drift on settings already present remotely (compute, TTL, `protected`) is reported as a **conflict** and `apply` makes no changes until you resolve it or pass this flag.
+- `--allow-protected` — auto-confirm applying to a branch Neon marks as protected. Without it, `apply` refuses to touch a protected branch.
+
+**Output**: `status` prints the project, branch, and reverse-engineered config; `plan` / `apply` print the planned/applied changes and any conflicts as tables. Pass `--output json` (or `--output yaml`) to emit the full machine-readable result (`PushResult`) for piping into other tools or CI.
+
+```bash
+# CI gate: fail the build if the branch has drifted from the policy
+neon config plan --project-id polished-snowflake-12345678 --output json
+
+# Reconcile a feature branch, overriding any manual tweaks made in the console
+neon deploy --branch my-feature --update-existing
+```
+
+Function deploys declared under `preview.functions` are bundled by neonctl's own esbuild helper and uploaded as part of `apply`, so the policy stays declarative and the packaged CLI never has to embed esbuild's native binary.
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                 | Description                    |
@@ -287,6 +344,8 @@ $ cat .neon
 | [set-context](https://neon.com/docs/reference/cli-set-context)             |                                                                                             | Set context for session        |
 | checkout                                                                   |                                                                                             | Pin a branch in `.neon`        |
 | [link](https://neon.com/docs/reference/cli-link)                           |                                                                                             | Link a directory to a project  |
+| config                                                                     | `status`, `plan`, `apply`                                                                   | Drive a branch from `neon.ts`  |
+| deploy                                                                     |                                                                                             | Alias for `config apply`       |
 | [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                             | Generate a completion script   |
 
 ## Global options

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,0 +1,366 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NeonApi } from '@neondatabase/config-runtime';
+import type {
+  CreateBucketInput,
+  DeployFunctionInput,
+  GetConnectionUriInput,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import type { ConfigProps } from './config.js';
+import { applyCmd, planCmd, status } from './config.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-snowy-frost-12345';
+const BRANCH_NAME = 'main';
+
+/**
+ * Full {@link NeonApi} implementation backed by fixed in-memory state for one
+ * project + one default branch. The handful of methods that `inspect` / `plan` /
+ * `apply` exercise return real data; everything else throws so an unexpected call
+ * fails loudly instead of silently passing. `enableNeonAuth` records its calls so
+ * a test can assert `apply` actually mutated remote state.
+ */
+class FakeNeonApi implements NeonApi {
+  readonly enableNeonAuthCalls: { projectId: string; branchId: string }[] = [];
+  readonly deployBranchFunctionCalls: {
+    projectId: string;
+    branchId: string;
+    slug: string;
+    input: DeployFunctionInput;
+  }[] = [];
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'dev-project',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranches(): Promise<NeonBranchSnapshot[]> {
+    return [
+      {
+        id: BRANCH_ID,
+        name: BRANCH_NAME,
+        isDefault: true,
+        protected: false,
+      },
+    ];
+  }
+
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-fake-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${BRANCH_ID}.fake.neon.tech/${input.databaseName}?sslmode=require`,
+    };
+  }
+
+  async getNeonAuth(): Promise<NeonAuthSnapshot | null> {
+    return null;
+  }
+
+  async enableNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot> {
+    this.enableNeonAuthCalls.push({ projectId, branchId });
+    return {
+      projectId: 'auth-project',
+      jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+      baseUrl: 'https://auth.fake.neon.tech',
+    };
+  }
+
+  async getNeonDataApi(): Promise<NeonDataApiSnapshot | null> {
+    return null;
+  }
+
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+
+  async createBranchBucket(
+    projectId: string,
+    branchId: string,
+    input: CreateBucketInput,
+  ): Promise<NeonBucketSnapshot> {
+    void projectId;
+    void branchId;
+    return { name: input.name, accessLevel: input.accessLevel ?? 'private' };
+  }
+
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+
+  async createBranchFunction(
+    projectId: string,
+    branchId: string,
+    input: { slug: string; name: string },
+  ): Promise<NeonFunctionSnapshot> {
+    void projectId;
+    void branchId;
+    return {
+      id: `fn-${input.slug}`,
+      slug: input.slug,
+      name: input.name,
+      invocationUrl: `https://${input.slug}.${BRANCH_ID}.fake.neon.tech`,
+    };
+  }
+
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async deployBranchFunction(
+    projectId: string,
+    branchId: string,
+    slug: string,
+    input: DeployFunctionInput,
+  ): Promise<NeonFunctionDeploymentSnapshot> {
+    this.deployBranchFunctionCalls.push({ projectId, branchId, slug, input });
+    return { id: 1, status: 'completed' };
+  }
+
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+/**
+ * Minimal stand-in for the neonctl `Api` client. Only `listProjectBranches` is
+ * exercised (by `branchIdFromProps`, to resolve the branch name to its id);
+ * anything else is absent and would throw if touched.
+ */
+const fakeApiClient = {
+  listProjectBranches: async () => ({
+    data: {
+      branches: [
+        {
+          id: BRANCH_ID,
+          name: BRANCH_NAME,
+          default: true,
+        },
+      ],
+    },
+  }),
+};
+
+/** Capture writer output (the writer respects `props.out`). */
+const captureOut = (): { stream: PassThrough; read: () => string } => {
+  const stream = new PassThrough();
+  let buffer = '';
+  stream.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+  });
+  return { stream, read: () => buffer };
+};
+
+const baseProps = (
+  api: FakeNeonApi,
+  out: PassThrough,
+): ConfigProps & { runtimeApi: NeonApi; out: PassThrough } => ({
+  apiClient: fakeApiClient as never,
+  apiKey: '',
+  apiHost: 'https://console.neon.tech/api/v2',
+  contextFile: '',
+  output: 'json',
+  projectId: PROJECT_ID,
+  branch: BRANCH_NAME,
+  runtimeApi: api,
+  out,
+});
+
+describe('config commands', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-config-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  const writeConfig = (body: string): string => {
+    const path = join(cwd, 'neon.ts');
+    writeFileSync(path, body);
+    return path;
+  };
+
+  it('status returns the live project + branch state', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    await status(baseProps(api, stream));
+
+    const parsed = JSON.parse(read());
+    expect(parsed.project.id).toBe(PROJECT_ID);
+    expect(parsed.branch.id).toBe(BRANCH_ID);
+    expect(parsed.branch.name).toBe(BRANCH_NAME);
+  });
+
+  it('plan is a dry run whose applied list includes the auth service change', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+    const config = writeConfig('export default () => ({ auth: {} });\n');
+
+    await planCmd({ ...baseProps(api, stream), config });
+
+    const result = JSON.parse(read());
+    expect(result.dryRun).toBe(true);
+    const authChange = result.applied.find(
+      (change: { identifier: string }) => change.identifier === 'auth',
+    );
+    expect(authChange).toBeDefined();
+    expect(authChange.kind).toBe('service');
+    // A dry run never mutates remote state.
+    expect(api.enableNeonAuthCalls).toHaveLength(0);
+  });
+
+  it('apply actually enables Neon Auth and is not a dry run', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+    const config = writeConfig('export default () => ({ auth: {} });\n');
+
+    await applyCmd({ ...baseProps(api, stream), config });
+
+    const result = JSON.parse(read());
+    expect(result.dryRun).toBe(false);
+    expect(api.enableNeonAuthCalls).toHaveLength(1);
+    expect(api.enableNeonAuthCalls[0]).toEqual({
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+    });
+  });
+
+  it("apply deploys a function via neonctl's own bundler", async () => {
+    const api = new FakeNeonApi();
+    const { stream } = captureOut();
+
+    // A real handler module on disk: applyCmd's injected bundler (bundleEntry +
+    // zipBundle) actually runs esbuild against this source and zips the output, so
+    // it must be valid TypeScript that esbuild can bundle.
+    const source = join(cwd, 'hello.ts');
+    writeFileSync(
+      source,
+      "export default { fetch() { return new Response('ok'); } };\n",
+    );
+    const config = writeConfig(
+      `export default () => ({ preview: { functions: [{ slug: 'hello', name: 'Hello', source: ${JSON.stringify(
+        source,
+      )} }] } });\n`,
+    );
+
+    await applyCmd({ ...baseProps(api, stream), config });
+
+    // The function was new (listBranchFunctions returns []), so apply both creates
+    // it and deploys code to it. We assert the deploy carried a real bundle.
+    expect(api.deployBranchFunctionCalls).toHaveLength(1);
+    const call = api.deployBranchFunctionCalls[0];
+    expect(call.projectId).toBe(PROJECT_ID);
+    expect(call.branchId).toBe(BRANCH_ID);
+    expect(call.slug).toBe('hello');
+
+    // The bundle must be the real ZIP produced by neonctl's bundleEntry + zipBundle
+    // (NOT config-runtime's own esbuild default bundler). A non-empty Uint8Array
+    // whose first two bytes are the ZIP local-file-header magic ("PK") proves a real
+    // archive was built by neonctl's injected FunctionBundler.
+    const { bundle } = call.input;
+    expect(bundle).toBeInstanceOf(Uint8Array);
+    expect(bundle.byteLength).toBeGreaterThan(0);
+    expect(bundle[0]).toBe(0x50); // 'P'
+    expect(bundle[1]).toBe(0x4b); // 'K'
+  });
+});

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,237 @@
+import yargs from 'yargs';
+import {
+  apply,
+  inspect,
+  loadConfigFromFile,
+  plan,
+  type Config,
+  type ConflictReport,
+  type FunctionBundler,
+  type NeonApi,
+  type PushResult,
+} from '@neondatabase/config-runtime';
+
+import { log } from '../log.js';
+import { BranchScopeProps } from '../types.js';
+import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+import { bundleEntry } from '../utils/esbuild.js';
+import { zipBundle } from '../utils/zip.js';
+import { writer } from '../writer.js';
+
+/**
+ * Bundle a function with neonctl's OWN bundler (the shared esbuild helper) so the
+ * config-runtime never has to import esbuild itself. Injecting this keeps esbuild
+ * out of config-runtime's static module graph — and therefore out of the packaged
+ * neonctl snapshot, which resolves esbuild dynamically at deploy time.
+ */
+const neonctlBundler: FunctionBundler = async (fn) =>
+  zipBundle(await bundleEntry(fn.source));
+
+const INSPECT_FIELDS = ['project', 'branch', 'config'] as const;
+const APPLIED_FIELDS = ['action', 'kind', 'identifier', 'details'] as const;
+const CONFLICT_FIELDS = [
+  'identifier',
+  'field',
+  'current',
+  'desired',
+  'reason',
+] as const;
+
+export type ConfigProps = BranchScopeProps & {
+  /** Explicit path to a neon.ts policy. When omitted, loadConfigFromFile walks up from cwd. */
+  config?: string;
+  /** Auto-confirm overriding existing remote settings (apply only). */
+  updateExisting?: boolean;
+  /** Auto-confirm applying to a protected branch (apply only). */
+  allowProtected?: boolean;
+  /** Injected NeonApi adapter (tests). Production omits it so the real adapter is built from credentials. */
+  runtimeApi?: NeonApi;
+};
+
+/** Apply-only flags, exported so `deploy` can reuse the exact same surface. */
+export const applyFlags = {
+  'update-existing': {
+    describe: 'Auto-confirm overriding existing remote settings on the branch',
+    type: 'boolean',
+    default: false,
+  },
+  'allow-protected': {
+    describe: 'Auto-confirm applying to a branch marked protected on Neon',
+    type: 'boolean',
+    default: false,
+  },
+} as const;
+
+export const command = 'config';
+export const describe = 'Manage a branch with a neon.ts policy';
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 config <sub-command> [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+    })
+    .middleware(fillSingleProject as any)
+    .command(
+      'status',
+      "Show the branch's live Neon state",
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+        }),
+      (args) => status(args as any),
+    )
+    .command(
+      'plan',
+      'Show what `config apply` would change (dry run)',
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+        }),
+      (args) => planCmd(args as any),
+    )
+    .command(
+      'apply',
+      'Apply a neon.ts policy to the branch',
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+          ...applyFlags,
+        }),
+      (args) => applyCmd(args as any),
+    );
+
+export const handler = (args: yargs.Argv) => {
+  return args;
+};
+
+const loadConfig = async (props: ConfigProps): Promise<Config> => {
+  const { config } = await loadConfigFromFile({
+    ...(props.config ? { path: props.config } : {}),
+  });
+  return config;
+};
+
+export const status = async (props: ConfigProps): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const live = await inspect({
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+  writer(props).end(live, { fields: INSPECT_FIELDS });
+};
+
+export const planCmd = async (props: ConfigProps): Promise<void> => {
+  const config = await loadConfig(props);
+  const branchId = await branchIdFromProps(props);
+  // `plan` is a dry run that never bundles, so its options don't accept (or need)
+  // an injected bundler — only `apply` does (it uses neonctlBundler).
+  const result = await plan(config, {
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+  reportPushResult(props, result, 'plan');
+};
+
+export const applyCmd = async (props: ConfigProps): Promise<void> => {
+  const config = await loadConfig(props);
+  const branchId = await branchIdFromProps(props);
+  const result = await apply(config, {
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+    ...(props.updateExisting ? { updateExisting: true } : {}),
+    ...(props.allowProtected ? { allowProtectedBranch: true } : {}),
+    bundleFunction: neonctlBundler,
+  });
+  reportPushResult(props, result, 'apply');
+};
+
+type ReportMode = 'plan' | 'apply';
+
+/**
+ * Render a {@link PushResult}. JSON/YAML output emits the raw result verbatim so it
+ * can be piped; the human-readable path renders the actual changes (dropping noops)
+ * and any blocking conflicts as tables, or a "nothing to do" line when both are empty.
+ */
+const reportPushResult = (
+  props: ConfigProps,
+  result: PushResult,
+  mode: ReportMode,
+): void => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(result, { fields: [] });
+    return;
+  }
+
+  const changes = result.applied
+    .filter((change) => change.action !== 'noop')
+    .map((change) => ({
+      action: change.action,
+      kind: change.kind,
+      identifier: change.identifier,
+      details: change.details ? JSON.stringify(change.details) : '',
+    }));
+  const conflicts = result.conflicts.map((conflict: ConflictReport) => ({
+    identifier: conflict.identifier,
+    field: conflict.field,
+    current: stringify(conflict.current),
+    desired: stringify(conflict.desired),
+    reason: conflict.reason,
+  }));
+
+  if (changes.length === 0 && conflicts.length === 0) {
+    log.info(
+      `No changes — branch ${result.branchName} already matches the policy.`,
+    );
+    return;
+  }
+
+  const out = writer(props);
+  if (changes.length > 0) {
+    out.write(changes, {
+      fields: APPLIED_FIELDS,
+      title: mode === 'plan' ? 'Planned changes' : 'Applied changes',
+    });
+  }
+  if (conflicts.length > 0) {
+    out.write(conflicts, { fields: CONFLICT_FIELDS, title: 'Conflicts' });
+  }
+  out.end();
+
+  if (conflicts.length > 0) {
+    log.info(
+      'Resolve the conflicts above, or re-run with --update-existing to override the current remote settings.',
+    );
+  }
+};
+
+const stringify = (value: unknown): string =>
+  value === undefined
+    ? ''
+    : typeof value === 'string'
+      ? value
+      : JSON.stringify(value);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,0 +1,30 @@
+import yargs from 'yargs';
+
+import { fillSingleProject } from '../utils/enrichers.js';
+import { applyCmd, applyFlags, type ConfigProps } from './config.js';
+
+export const command = 'deploy';
+export const describe =
+  'Apply a neon.ts policy to a branch (alias for `config apply`)';
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 deploy [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+      config: {
+        describe: 'Path to a neon.ts policy (defaults to walking up from cwd)',
+        type: 'string',
+      },
+      ...applyFlags,
+    })
+    .middleware(fillSingleProject as any)
+    .strict();
+
+export const handler = (props: ConfigProps) => applyCmd(props);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,8 @@ import * as dataApi from './data_api.js';
 import * as neonAuth from './neon_auth.js';
 import * as functions from './functions.js';
 import * as dev from './dev.js';
+import * as config from './config.js';
+import * as deploy from './deploy.js';
 
 export default [
   auth,
@@ -40,4 +42,6 @@ export default [
   dataApi,
   functions,
   dev,
+  config,
+  deploy,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'dev',
 
+  'deploy',
+
   // aliases
 ];
 


### PR DESCRIPTION
## `neon config` / `neon deploy` — config as code

**Preview** commands that drive a [`neon.ts`](https://neon.com) branch policy against the Neon Platform — the Neon equivalent of `terraform status` / `plan` / `apply`. A `neon.ts` describes what a branch should look like (settings + Preview features); these commands diff it against the branch's live state and reconcile it.

```bash
neon config status     # show the branch's live config (read-only)
neon config plan       # show what apply would change (dry run)
neon config apply      # apply the policy to the branch
neon deploy            # alias for `config apply`
```

### Commands & usage

```
neon config status [options]
neon config plan   [options]
neon config apply  [options]
neon deploy        [options]      # = config apply
```

**Common options** (all subcommands + `deploy`):

| Option | Default | Description |
| --- | --- | --- |
| `--project-id <id>` | from `.neon` / auto | Project to target. Auto-resolved when you have a single project or a linked `.neon`. |
| `--branch <name\|id>` | default branch | Branch to target (name or `br-…` id). |
| `--config <path>` | walk up from cwd | Path to the `neon.ts` policy. Defaults to the nearest one found walking up from the working directory. |
| `--output json\|yaml` | table | Emit the full machine-readable result instead of the table view. |

**`apply` / `deploy` only:**

| Flag | Default | Description |
| --- | --- | --- |
| `--update-existing` | `false` | Apply changes to **existing** branch settings (TTL, `protected`, compute) instead of reporting them as conflicts. |
| `--allow-protected` | `false` | Allow applying to a branch Neon marks as **protected**. |

Project/branch resolve the same way as other neonctl commands: explicit flag → `.neon` context (written by `neonctl link` / `neonctl checkout`) → auto-resolution.

### What each command does

- **`config status`** → reads the branch's live Neon state (project + branch metadata and the reverse-engineered `BranchConfig`) and prints it. Read-only, no mutations.
- **`config plan`** → computes exactly what `apply` would change, **without mutating anything** (dry run). Shows the planned changes and any blocking drift.
- **`config apply`** (and **`deploy`**) → reconciles the `neon.ts` policy against the branch: branch settings (TTL, `protected`, compute) and Preview features (functions, buckets, Neon Auth, Data API, AI Gateway). Drift on existing settings is reported as a **conflict** and left untouched unless you pass `--update-existing`; a protected branch is refused unless you pass `--allow-protected`.

### Output

The default **table** view lists the applied/planned changes (action, kind, identifier, details) and, separately, any **conflicts** (field, current, desired, reason) with a hint to re-run with `--update-existing`. When there's nothing to do it prints `No changes — branch <name> already matches the policy.` Pass `--output json` (or `yaml`) on any of them to get the full `PushResult` for scripting.

### Examples

```bash
# Preview changes for the current branch from ./neon.ts
neon config plan

# Apply, overriding existing settings, to a specific branch
neon config apply --branch preview --update-existing

# Deploy (alias) using an explicit policy path, as JSON
neon deploy --config ./infra/neon.ts --output json

# Read the live config of a branch
neon config status --branch main
```

### Function deploys without esbuild in the binary

When a policy includes `preview.functions`, `apply` bundles each function's source and deploys it. neonctl injects **its own** esbuild bundler into `@neondatabase/config-runtime` (via a `bundleFunction` seam), so the runtime never imports esbuild itself — which keeps esbuild's native binary **out of the packaged single-file CLI snapshot**. (At deploy time the packaged binary resolves esbuild dynamically; the npm install bundles in-process. Same code path as `neon functions deploy`.)

---

## Implementation notes

- Built on `@neondatabase/config-runtime`'s `inspect` / `plan` / `apply` operations; `deploy` is a thin alias that calls `config apply`.
- The `bundleFunction` injection seam is added in a companion `neon-pkgs` change (`feat(config-runtime): make the function bundler injectable`). Verified: `apply` produces a real ZIP archive (`PK` magic bytes) via neonctl's `bundleEntry` + `zipBundle`, and the packaged binary stays esbuild-free.
- **Stacked on the `neon dev` PR** (#499): it inherits the shared TypeScript 5.8 bump and the linked `@neondatabase/config` / `env` / `config-runtime` packages. **Not mergeable until those packages publish** (then `link:` → published versions). Review/merge after #499.

## Test plan

- [x] `pnpm lint` (typecheck + eslint + prettier)
- [x] `pnpm test` — full suite green, incl. config-command tests against the **real** config-runtime via a fake `NeonApi`: `status` reads live state; `plan` is `dryRun:true` with the expected change and no mutation; `apply` invokes the platform (e.g. `enableNeonAuth`) and, for a policy with `preview.functions`, calls `deployBranchFunction` with a **non-empty ZIP bundle produced by neonctl's own bundler** (not config-runtime's esbuild)
- [x] Verified the packaged-binary build does not pull esbuild's native binary into the snapshot
