### PR TITLE
fix(functions): tighten function slug regex to ^[a-z0-9]{1,20}$

### DIFF
--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -84,6 +84,8 @@ exports[`functions > deploy errors when the entry file is missing 1`] = `""`;
 
 exports[`functions > deploy fails cleanly when bundling fails 1`] = `""`;
 
+exports[`functions > deploy rejects a hyphenated slug 1`] = `""`;
+
 exports[`functions > deploy rejects an invalid slug 1`] = `""`;
 
 exports[`functions > deploy rejects malformed --env 1`] = `""`;

--- a/src/commands/functions.test.ts
+++ b/src/commands/functions.test.ts
@@ -310,7 +310,7 @@ describe('functions', () => {
       [
         'functions',
         'deploy',
-        'my-func',
+        'myfunc',
         '--path',
         fnDir,
         '--no-wait',
@@ -347,7 +347,30 @@ describe('functions', () => {
         mockDir: 'single_org',
         code: 1,
         stderr:
-          'ERROR: Invalid function slug "Bad_Slug". Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.',
+          'ERROR: Invalid function slug "Bad_Slug". Use 1-20 lowercase letters and digits (no hyphens or other characters).',
+      },
+    );
+  });
+
+  test('deploy rejects a hyphenated slug', async ({ testCliCommand }) => {
+    await testCliCommand(
+      [
+        'functions',
+        'deploy',
+        'my-func',
+        '--path',
+        fnDir,
+        '--no-wait',
+        '--project-id',
+        'test-project-123456',
+        '--branch',
+        'main',
+      ],
+      {
+        mockDir: 'single_org',
+        code: 1,
+        stderr:
+          'ERROR: Invalid function slug "my-func". Use 1-20 lowercase letters and digits (no hyphens or other characters).',
       },
     );
   });
@@ -401,7 +424,7 @@ describe('functions', () => {
       [
         'functions',
         'deploy',
-        'my-func',
+        'myfunc',
         '--path',
         emptyDir,
         '--no-wait',
@@ -427,7 +450,7 @@ describe('functions', () => {
       [
         'functions',
         'deploy',
-        'my-func',
+        'myfunc',
         '--project-id',
         'test-project-123456',
         '--branch',
@@ -543,7 +566,7 @@ describe('functions', () => {
       [
         'functions',
         'deploy',
-        'my-func',
+        'myfunc',
         '--path',
         badDir,
         '--no-wait',

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -34,9 +34,9 @@ const DEPLOYMENT_FIELDS = [
   'created_at',
 ] as const;
 
-const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$/;
+const SLUG_PATTERN = /^[a-z0-9]{1,20}$/;
 const SLUG_HELP =
-  'Use 1-40 lowercase letters, digits, and hyphens; it must start and end with a letter or digit.';
+  'Use 1-20 lowercase letters and digits (no hyphens or other characters).';
 const MEMORY_CHOICES = [256, 512, 1024, 2048, 4096, 8192];
 
 // Overridable so tests can poll fast; defaults to 2s in real use.
@@ -72,7 +72,7 @@ export const builder = (argv: yargs.Argv) =>
       (yargs) =>
         yargs
           .positional('slug', {
-            describe: 'Function slug (lowercase DNS label)',
+            describe: 'Function slug (1-20 lowercase letters and digits)',
             type: 'string',
             demandOption: true,
           })


### PR DESCRIPTION
## Summary

Corrects the function-slug validation in `neon functions deploy` to match the Neon Functions API rule.

- **Before:** `^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$` (lowercase DNS label, hyphens allowed, up to 40 chars).
- **After:** `^[a-z0-9]{1,20}$` (1–20 lowercase letters and digits, no hyphens).

### What changed

- `SLUG_PATTERN` and the `SLUG_HELP` message in `src/commands/functions.ts`.
- The `deploy <slug>` positional `describe` ("lowercase DNS label" → "1-20 lowercase letters and digits").
- Tests: switched the arbitrary `my-func` slug used in `deploy` error-path tests to `myfunc` (deploy validates the slug before those errors fire), and added a test asserting a hyphenated slug is rejected. `get`/`delete` do not validate the slug, so their hyphenated mock fixtures are intentionally left untouched.

This is a standalone fix off `main`, independent of the `neon dev` / `config` PR stack. The matching change in `@neondatabase/config` (the `neon.ts` slug schema) ships in neondatabase/neon-pkgs#168.

## Test plan

- `pnpm typecheck` — green
- `pnpm build` — green
- `pnpm exec vitest run src/commands/functions.test.ts` — 24/24 (incl. the new hyphen-rejection case)
- `eslint` + `prettier --check` on changed files — clean