### PR TITLE
feat(env): add `neon env pull` to write branch env vars to a .env file

### DIFF
--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -1,0 +1,245 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NeonApi } from '@neondatabase/config';
+import type {
+  GetConnectionUriInput,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import { pull, type EnvPullProps } from './env.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-snowy-frost-12345';
+const BRANCH_NAME = 'main';
+
+type FakeOverrides = {
+  getNeonAuth?: NeonApi['getNeonAuth'];
+};
+
+/**
+ * Minimal {@link NeonApi} for one project + default branch, with the methods `pullConfig`
+ * and `fetchEnv` exercise (env-pull's tier-2 path). Auth defaults to off; override to test
+ * the NEON_AUTH_BASE_URL pull.
+ */
+class FakeNeonApi implements NeonApi {
+  constructor(private readonly overrides: FakeOverrides = {}) {}
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'p',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranches(): Promise<NeonBranchSnapshot[]> {
+    return [
+      { id: BRANCH_ID, name: BRANCH_NAME, isDefault: true, protected: false },
+    ];
+  }
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    const host = input.pooled
+      ? `${BRANCH_ID}-pooler.fake.neon.tech`
+      : `${BRANCH_ID}.fake.neon.tech`;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${host}/${input.databaseName}?sslmode=require`,
+    };
+  }
+  async getNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot | null> {
+    if (this.overrides.getNeonAuth) {
+      return this.overrides.getNeonAuth(projectId, branchId);
+    }
+    return null;
+  }
+  async enableNeonAuth(): Promise<NeonAuthSnapshot> {
+    throw new Error('not implemented');
+  }
+  async getNeonDataApi(): Promise<NeonDataApiSnapshot | null> {
+    return null;
+  }
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+  async createBranchBucket(): Promise<NeonBucketSnapshot> {
+    throw new Error('not implemented');
+  }
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
+    throw new Error('not implemented');
+  }
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async deployBranchFunction(): Promise<NeonFunctionDeploymentSnapshot> {
+    throw new Error('not implemented');
+  }
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+/** Stand-in for the neonctl Api client; only branch resolution is exercised. */
+const fakeApiClient = {
+  listProjectBranches: async () => ({
+    data: {
+      branches: [{ id: BRANCH_ID, name: BRANCH_NAME, default: true }],
+    },
+  }),
+};
+
+const baseProps = (api: FakeNeonApi, cwd: string): EnvPullProps => ({
+  apiClient: fakeApiClient as never,
+  apiKey: '',
+  apiHost: 'https://console.neon.tech/api/v2',
+  contextFile: '',
+  output: 'table',
+  projectId: PROJECT_ID,
+  branch: BRANCH_NAME,
+  cwd,
+  runtimeApi: api,
+});
+
+describe('env pull', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-env-pull-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('writes Neon vars into .env.local when no .env exists', async () => {
+    await pull(baseProps(new FakeNeonApi(), cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    expect(content).toMatch(/^DATABASE_URL=/m);
+    expect(content).toMatch(/^DATABASE_URL_UNPOOLED=/m);
+    expect(content).toContain('-pooler.fake.neon.tech');
+    // Auth is off by default, so NEON_AUTH_BASE_URL is not written.
+    expect(content).not.toContain('NEON_AUTH_BASE_URL');
+  });
+
+  it('includes NEON_AUTH_BASE_URL when the branch has Auth enabled', async () => {
+    // A neon.ts that enables auth, plus a branch that actually has the integration.
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    await pull(baseProps(api, cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    expect(content).toMatch(
+      /^NEON_AUTH_BASE_URL=https:\/\/auth\.fake\.neon\.tech$/m,
+    );
+  });
+
+  it('updates an existing .env in place, preserving other keys', async () => {
+    writeFileSync(
+      join(cwd, '.env'),
+      '# app\nAPP_NAME=demo\nDATABASE_URL=postgres://stale\n',
+    );
+
+    await pull(baseProps(new FakeNeonApi(), cwd));
+
+    // Existing .env is used (not .env.local) and unrelated keys survive.
+    const content = readFileSync(join(cwd, '.env'), 'utf8');
+    expect(content).toContain('# app');
+    expect(content).toContain('APP_NAME=demo');
+    expect(content).toContain('-pooler.fake.neon.tech');
+    expect(content).not.toContain('postgres://stale');
+  });
+
+  it('writes to an explicit --file', async () => {
+    await pull({ ...baseProps(new FakeNeonApi(), cwd), file: '.env.preview' });
+    const content = readFileSync(join(cwd, '.env.preview'), 'utf8');
+    expect(content).toMatch(/^DATABASE_URL=/m);
+  });
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,112 @@
+import yargs from 'yargs';
+
+import { type NeonApi } from '@neondatabase/config';
+import { NEON_ENV_VAR_KEYS } from '@neondatabase/env';
+
+import { log } from '../log.js';
+import { BranchScopeProps } from '../types.js';
+import { resolveNeonEnvVars } from '../dev/env.js';
+import { mergeEnvFile, resolveEnvFilePath } from '../env_file.js';
+import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+
+export type EnvPullProps = BranchScopeProps & {
+  /** Target dotenv file. Defaults to an existing `.env`, else `.env.local`. */
+  file?: string;
+  /** Working directory to resolve neon.ts / write the .env file in. Defaults to cwd (tests). */
+  cwd?: string;
+  /** Injected NeonApi adapter (tests). Production builds it from credentials. */
+  runtimeApi?: NeonApi;
+};
+
+export const command = 'env';
+export const describe = "Manage a branch's Neon env variables locally";
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 env <sub-command> [options]')
+    .options({
+      'project-id': { describe: 'Project ID', type: 'string' },
+      branch: { describe: 'Branch ID or name', type: 'string' },
+    })
+    .middleware(fillSingleProject as any)
+    .command(
+      'pull',
+      "Write the branch's Neon env variables to a local .env file",
+      (yargs) =>
+        yargs
+          .usage('$0 env pull [options]')
+          .options({
+            file: {
+              describe:
+                'Target .env file to write. Defaults to an existing .env, ' +
+                'otherwise .env.local. Only Neon variables are updated; other ' +
+                'lines are preserved.',
+              type: 'string',
+            },
+          })
+          .example(
+            '$0 env pull',
+            "Write the linked branch's Neon vars into .env.local (or .env if present)",
+          )
+          .example(
+            '$0 env pull --branch preview --file .env.preview',
+            'Pull a specific branch into a specific file',
+          ),
+      (args) => pull(args as any),
+    )
+    .demandCommand(1);
+
+export const handler = (args: yargs.Argv) => args;
+
+/** Every OS-level env var name `@neondatabase/env` can emit, used only for reporting. */
+const NEON_VAR_NAMES = Object.values(NEON_ENV_VAR_KEYS).flatMap((group) =>
+  Object.values(group),
+);
+
+export const pull = async (props: EnvPullProps): Promise<void> => {
+  const cwd = props.cwd ?? process.cwd();
+  const branchId = await branchIdFromProps(props);
+
+  // Reuse `neon dev`'s tiered resolver (neon.ts policy -> plan gate -> fetchEnv, else
+  // pullConfig -> fetchEnv). Unlike dev, an unresolved context or failure is surfaced —
+  // `env pull` is an explicit action, so it should error rather than write nothing.
+  const vars = await resolveNeonEnvVars({
+    cwd,
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+
+  const neonVars = pickNeonVars(vars);
+  if (Object.keys(neonVars).length === 0) {
+    log.info(
+      'No Neon env variables to pull for this branch (no DATABASE_URL or ' +
+        'enabled Auth / Data API).',
+    );
+    return;
+  }
+
+  const targetPath = resolveEnvFilePath(cwd, props.file);
+  const { written } = mergeEnvFile(targetPath, neonVars);
+  log.info(
+    'Pulled %d Neon variable%s into %s: %s',
+    written.length,
+    written.length === 1 ? '' : 's',
+    targetPath,
+    written.join(', '),
+  );
+};
+
+/**
+ * Keep only the recognized Neon variables from the resolved set, so a stray inherited
+ * value never lands in the user's `.env` file. (Today `resolveNeonEnvVars` only emits Neon
+ * vars, but filtering keeps the contract explicit and future-proof.)
+ */
+const pickNeonVars = (vars: Record<string, string>): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const name of NEON_VAR_NAMES) {
+    const value = vars[name];
+    if (value !== undefined) out[name] = value;
+  }
+  return out;
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,6 +20,7 @@ import * as functions from './functions.js';
 import * as dev from './dev.js';
 import * as config from './config.js';
 import * as deploy from './deploy.js';
+import * as env from './env.js';
 
 export default [
   auth,
@@ -44,4 +45,5 @@ export default [
   dev,
   config,
   deploy,
+  env,
 ];

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -35,65 +35,87 @@ export class DevEnvMismatchError extends Error {
 }
 
 /**
- * Resolve the Neon env vars to inject into a locally-served function, mirroring
- * what the deployed function would receive for the selected branch (pooled /
- * direct `DATABASE_URL`, plus Auth / Data API when enabled).
+ * Signals that no project/branch context could be resolved, so there is nothing to
+ * resolve env from. `resolveDevEnv` degrades on this (dev runs without injection);
+ * `env pull` surfaces it (an explicit pull needs a branch).
+ */
+export class MissingBranchContextError extends Error {
+  override readonly name = 'MissingBranchContextError';
+}
+
+/**
+ * Resolve the branch's Neon env vars (pooled / direct `DATABASE_URL`, plus Auth /
+ * Data API when enabled) into a `{ KEY: value }` map. Shared by `neon dev` (which
+ * injects them) and `neon env pull` (which writes them to a `.env` file).
  *
  * Tiered:
  *
- *   1. a `neon.ts` policy is found -> the policy is the source of truth for what
- *      the function *wants*. We first check the policy against the branch's live
- *      state (`plan`); if the policy declares a resource the branch is missing,
- *      we stop with a {@link DevEnvMismatchError} pointing the user at
- *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy and injects.
+ *   1. a `neon.ts` policy is found -> the policy is the source of truth. We first
+ *      check it against the branch's live state (`plan`); if it declares a resource
+ *      the branch is missing, we stop with a {@link DevEnvMismatchError} pointing at
+ *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy.
  *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
- *      branch's live state (incl. Auth / Data API enablement) into a config,
- *      then `fetchEnv` injects what is actually enabled, silently.
- *   3. otherwise -> inject nothing.
+ *      branch's live state (incl. Auth / Data API enablement) into a config, then
+ *      `fetchEnv` resolves what is actually enabled.
+ *   3. otherwise -> throw {@link MissingBranchContextError}.
  *
- * Every failure **except** {@link DevEnvMismatchError} degrades gracefully: it
- * logs a warning and returns `{}` so the function still runs (no Neon account,
- * no `.neon`, no network). A mismatch is re-thrown for the caller to surface.
+ * Unlike {@link resolveDevEnv}, this never swallows errors — callers decide how to
+ * handle them.
+ */
+export const resolveNeonEnvVars = async (
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  const config = await loadNeonConfig(ctx.cwd);
+
+  if (config) {
+    if (!ctx.projectId || !ctx.branchId) {
+      throw new MissingBranchContextError(
+        'Found a neon.ts but could not resolve the project/branch. ' +
+          'Run `neonctl link` and `neonctl checkout <branch>`, or pass ' +
+          '--project-id / --branch.',
+      );
+    }
+    await assertPolicyMatchesBranch(config, ctx);
+    return await fetchAndProject(config, ctx);
+  }
+
+  if (ctx.projectId && ctx.branchId) {
+    const pulled = await pullConfig({
+      projectId: ctx.projectId,
+      branchId: ctx.branchId,
+      ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+      ...(ctx.api ? { api: ctx.api } : {}),
+    });
+    return await fetchAndProject(
+      defineConfig(() => pulled.config),
+      ctx,
+    );
+  }
+
+  throw new MissingBranchContextError(
+    'No project/branch context found. Link a branch (`neonctl link` / ' +
+      '`neonctl checkout`) or pass --project-id and --branch.',
+  );
+};
+
+/**
+ * `neon dev`'s env resolver: {@link resolveNeonEnvVars} with graceful degradation.
+ * A missing branch context or any failure (no Neon account, no `.neon`, no network)
+ * logs a warning and returns `{}` so the function still runs locally; only a
+ * {@link DevEnvMismatchError} (policy declares a resource the branch lacks) is
+ * re-thrown for the caller to surface.
  */
 export const resolveDevEnv = async (
   ctx: DevEnvContext,
 ): Promise<Record<string, string>> => {
   try {
-    const config = await loadNeonConfig(ctx.cwd);
-
-    if (config) {
-      if (!ctx.projectId || !ctx.branchId) {
-        log.warning(
-          'Found a neon.ts but could not resolve the project/branch to ' +
-            'inject env for. Run `neonctl link` and `neonctl checkout <branch>`.',
-        );
-        return {};
-      }
-      await assertPolicyMatchesBranch(config, ctx);
-      return await fetchAndProject(config, ctx);
-    }
-
-    if (ctx.projectId && ctx.branchId) {
-      const pulled = await pullConfig({
-        projectId: ctx.projectId,
-        branchId: ctx.branchId,
-        ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
-        ...(ctx.api ? { api: ctx.api } : {}),
-      });
-      const branchConfig = pulled.config;
-      return await fetchAndProject(
-        defineConfig(() => branchConfig),
-        ctx,
-      );
-    }
-
-    log.debug(
-      'dev: no neon.ts and no project/branch context; skipping env injection',
-    );
-    return {};
+    return await resolveNeonEnvVars(ctx);
   } catch (err) {
-    // A policy/branch mismatch is intentional and actionable — surface it.
     if (err instanceof DevEnvMismatchError) throw err;
+    if (err instanceof MissingBranchContextError) {
+      log.debug('dev: %s; skipping env injection', err.message);
+      return {};
+    }
     log.warning(
       'Could not inject Neon env vars; the function will run without them: %s',
       err instanceof Error ? err.message : String(err),

--- a/src/env_file.test.ts
+++ b/src/env_file.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mergeEnvContent, resolveEnvFilePath } from './env_file.js';
+
+describe('mergeEnvContent', () => {
+  it('writes keys into an empty file with a trailing newline', () => {
+    const { content, written } = mergeEnvContent('', {
+      DATABASE_URL: 'postgres://x',
+    });
+    expect(content).toBe('DATABASE_URL=postgres://x\n');
+    expect(written).toEqual(['DATABASE_URL']);
+  });
+
+  it('updates an existing key in place, preserving position and other lines', () => {
+    const original = [
+      '# my env',
+      'FOO=bar',
+      'DATABASE_URL=postgres://old',
+      'BAZ=qux',
+      '',
+    ].join('\n');
+    const { content } = mergeEnvContent(original, {
+      DATABASE_URL: 'postgres://new',
+    });
+    expect(content).toBe(
+      ['# my env', 'FOO=bar', 'DATABASE_URL=postgres://new', 'BAZ=qux'].join(
+        '\n',
+      ) + '\n',
+    );
+  });
+
+  it('appends new keys after existing content', () => {
+    const original = 'FOO=bar\n';
+    const { content, written } = mergeEnvContent(original, {
+      DATABASE_URL: 'postgres://x',
+      NEON_AUTH_BASE_URL: 'https://auth',
+    });
+    expect(content).toBe(
+      [
+        'FOO=bar',
+        'DATABASE_URL=postgres://x',
+        'NEON_AUTH_BASE_URL=https://auth',
+      ].join('\n') + '\n',
+    );
+    expect(written).toEqual(['DATABASE_URL', 'NEON_AUTH_BASE_URL']);
+  });
+
+  it('preserves comments and blank lines, and a leading `export`', () => {
+    const original = [
+      '# header',
+      '',
+      'export DATABASE_URL=old',
+      '# trailing comment',
+    ].join('\n');
+    const { content } = mergeEnvContent(original, { DATABASE_URL: 'new' });
+    // The `export ` form is matched for the key, replaced with the canonical KEY=value.
+    expect(content).toContain('# header');
+    expect(content).toContain('# trailing comment');
+    expect(content).toContain('DATABASE_URL=new');
+  });
+
+  it('quotes values that contain special characters', () => {
+    const { content } = mergeEnvContent('', {
+      DATABASE_URL: 'postgres://u:p w@h/db?x=1',
+    });
+    expect(content).toBe('DATABASE_URL="postgres://u:p w@h/db?x=1"\n');
+  });
+
+  it('is a no-op for empty updates', () => {
+    const original = 'FOO=bar\n';
+    const { content, written } = mergeEnvContent(original, {});
+    expect(content).toBe(original);
+    expect(written).toEqual([]);
+  });
+
+  it('does not accumulate trailing blank lines across merges', () => {
+    const first = mergeEnvContent('', { A: '1' }).content;
+    const second = mergeEnvContent(first, { B: '2' }).content;
+    expect(second).toBe('A=1\nB=2\n');
+  });
+});
+
+describe('resolveEnvFilePath', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-envfile-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('uses an explicit --file when given', () => {
+    expect(resolveEnvFilePath(cwd, '.env.preview')).toBe(
+      join(cwd, '.env.preview'),
+    );
+  });
+
+  it('defaults to .env.local when no .env exists', () => {
+    expect(resolveEnvFilePath(cwd)).toBe(join(cwd, '.env.local'));
+  });
+
+  it('uses an existing .env when present (vercel-style)', () => {
+    writeFileSync(join(cwd, '.env'), 'EXISTING=1\n');
+    expect(resolveEnvFilePath(cwd)).toBe(join(cwd, '.env'));
+  });
+});

--- a/src/env_file.ts
+++ b/src/env_file.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Default dotenv file `env pull` writes to: `.env` when one already exists in the working
+ * directory (update where secrets already live), otherwise `.env.local` — matching the
+ * `vercel env pull` convention. An explicit `--file` always wins over this.
+ */
+export const resolveEnvFilePath = (cwd: string, file?: string): string => {
+  if (file) return join(cwd, file);
+  if (existsSync(join(cwd, '.env'))) return join(cwd, '.env');
+  return join(cwd, '.env.local');
+};
+
+/**
+ * Merge `updates` into the dotenv content at `path`, preserving every other line
+ * (comments, blank lines, unrelated keys) and the file's existing order. Keys present in
+ * both are updated in place; keys only in `updates` are appended. A non-existent file is
+ * treated as empty. Returns the list of keys that were written (for reporting).
+ */
+export const mergeEnvFile = (
+  path: string,
+  updates: Record<string, string>,
+): { written: string[] } => {
+  const original = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const { content, written } = mergeEnvContent(original, updates);
+  writeFileSync(path, content);
+  return { written };
+};
+
+/**
+ * Pure core of {@link mergeEnvFile}: takes the current file content and the updates, and
+ * returns the new content plus which keys were written. Kept side-effect-free so it can be
+ * unit-tested without touching the filesystem.
+ */
+export const mergeEnvContent = (
+  original: string,
+  updates: Record<string, string>,
+): { content: string; written: string[] } => {
+  const keys = Object.keys(updates);
+  if (keys.length === 0) return { content: original, written: [] };
+
+  const remaining = new Set(keys);
+  const lines = original === '' ? [] : original.split('\n');
+
+  // Update keys in place where they already appear, so their position and any surrounding
+  // comments are preserved.
+  const updatedLines = lines.map((line) => {
+    const key = parseKey(line);
+    if (key !== null && remaining.has(key)) {
+      remaining.delete(key);
+      return formatLine(key, updates[key]);
+    }
+    return line;
+  });
+
+  // Append keys that weren't already present, in the order they were given.
+  const appended = keys
+    .filter((key) => remaining.has(key))
+    .map((key) => formatLine(key, updates[key]));
+
+  const body = trimTrailingBlank(updatedLines);
+  const content = [...body, ...appended].join('\n');
+  return {
+    // A dotenv file ends with a trailing newline.
+    content: content === '' ? '' : `${content}\n`,
+    written: keys,
+  };
+};
+
+/**
+ * Extract the variable name from a dotenv line, or `null` for comments / blank lines / any
+ * line that isn't a `KEY=value` assignment. Tolerates a leading `export ` and surrounding
+ * whitespace, matching common `.env` styles.
+ */
+const parseKey = (line: string): string | null => {
+  const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
+  return match ? match[1] : null;
+};
+
+/**
+ * Render a `KEY=value` line. The value is wrapped in double quotes when it contains
+ * characters that would otherwise break parsing (spaces, `#`, quotes, `=`), with inner
+ * quotes/backslashes escaped — Neon connection strings and URLs are safe either way, but
+ * quoting defensively avoids surprises for tools that re-parse the file.
+ */
+const formatLine = (key: string, value: string): string => {
+  const needsQuotes = /[\s#"'=]/.test(value);
+  if (!needsQuotes) return `${key}=${value}`;
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `${key}="${escaped}"`;
+};
+
+/** Drop trailing blank lines so we don't accumulate them across repeated merges. */
+const trimTrailingBlank = (lines: string[]): string[] => {
+  const out = [...lines];
+  while (out.length > 0 && out[out.length - 1]?.trim() === '') out.pop();
+  return out;
+};


### PR DESCRIPTION
## `neon env pull` — pull a branch's Neon env into a local `.env`

A **preview** command that writes the selected branch's Neon variables to a local dotenv file — the same env `neon dev` injects at runtime, persisted to disk for your own tooling. Think `vercel env pull`, for Neon.

```
neon env pull [options]
```

| Option | Default | Description |
| --- | --- | --- |
| `--branch <name\|id>` | default / `.neon` | Branch to pull from. |
| `--project-id <id>` | `.neon` / auto | Project to target. |
| `--file <path>` | existing `.env`, else `.env.local` | Target dotenv file. |
| global options | — | `--api-key`, `--output`, etc. |

### What it writes

The branch's Neon variables, and only those — everything else in the file is left untouched:

- `DATABASE_URL` (pooled) and `DATABASE_URL_UNPOOLED` (direct) — always
- `NEON_AUTH_BASE_URL` — when the branch has Neon Auth enabled
- `NEON_DATA_API_URL` — when the branch has the Data API enabled

### Resolution (mirrors `neon dev`)

The same tiered resolver `neon dev` uses, extracted into a shared `resolveNeonEnvVars`:

1. **`neon.ts` present** → the policy is the source of truth. It's first checked against the branch (`plan`); if the policy declares a branch-level resource the branch is missing, the command stops and points you at `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy.
2. **no `neon.ts`, branch known** → `pullConfig` reads the branch's live state (incl. Auth / Data API enablement), then `fetchEnv` resolves what's actually enabled.
3. **no branch context** → fails with a clear message (unlike `dev`, an explicit pull doesn't silently no-op).

`resolveDevEnv` is now a thin graceful wrapper over that core; `env pull` surfaces errors instead of degrading.

### File semantics (like `vercel env pull`)

- Default target: an existing `.env` in cwd (so secrets update where they already live), otherwise `.env.local`. `--file` overrides.
- **Merge, not replace**: only the `NEON_*` keys are updated — comments, blank lines, and unrelated keys are preserved; existing keys are updated in place; new keys are appended. Values are quoted when they contain characters that would break dotenv parsing.

## Implementation notes

- Extracted `resolveNeonEnvVars` from `src/dev/env.ts` (the proven dev resolver) + new `MissingBranchContextError`.
- New pure `src/env_file.ts` (`mergeEnvContent` / `mergeEnvFile` / `resolveEnvFilePath`), unit-tested without touching the filesystem.
- New `src/commands/env.ts` (`env pull`), registered in the command list. Branch/project resolution via the shared `fillSingleProject` / `branchIdFromProps` helpers, like `config`.
- **Stacked on #513** (`config`/`deploy`), which is stacked on #499 (`dev`). Inherits the linked `@neondatabase/*` packages; not mergeable until those publish.

## Test plan

- `pnpm lint` (typecheck + eslint + prettier) — clean
- `pnpm test` (relevant suites): `env_file` (merge: new file, in-place update, append, comment/blank/`export` preservation, quoting, trailing-blank dedupe; default-file resolution) and `env pull` (writes `.env.local`; uses an existing `.env`; includes `NEON_AUTH_BASE_URL` when Auth is enabled; honors `--file`) against the real `@neondatabase/env` via a fake `NeonApi`. The existing `dev/env` suite still passes (resolver refactor preserved).