### PR TITLE
feat(functions): drop --memory-mib from deploy command

### DIFF
--- a/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/redeploy/deployments/POST.js
+++ b/mocks/single_org/projects/test-project-123456/branches/br-main-branch-123456/functions/redeploy/deployments/POST.js
@@ -12,7 +12,6 @@ export default function (req, res) {
   req.on('end', () => {
     expect(raw).toContain('name="zip"; filename="bundle.zip"');
     expect(raw).toContain('PK'); // ZIP local-file-header magic
-    expect(raw).toContain('name="memory_mib"');
     expect(raw).toContain('name="runtime"');
     res.status(201).send({
       operation: { id: 'op-1', action: 'deploy_function', status: 'running' },

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -37,7 +37,6 @@ const DEPLOYMENT_FIELDS = [
 const SLUG_PATTERN = /^[a-z0-9]{1,20}$/;
 const SLUG_HELP =
   'Use 1-20 lowercase letters and digits (no hyphens or other characters).';
-const MEMORY_CHOICES = [256, 512, 1024, 2048, 4096, 8192];
 
 // Overridable so tests can poll fast; defaults to 2s in real use.
 const POLL_INTERVAL_MS =
@@ -84,11 +83,6 @@ export const builder = (argv: yargs.Argv) =>
             entry: {
               describe: 'Entry file to bundle, relative to --path',
               type: 'string',
-            },
-            'memory-mib': {
-              describe: 'Memory in MiB',
-              type: 'number',
-              choices: MEMORY_CHOICES,
             },
             runtime: {
               describe: 'Function runtime',
@@ -145,7 +139,6 @@ type DeployProps = BranchScopeProps & {
   slug: string;
   path?: string;
   entry?: string;
-  memoryMib?: number;
   runtime?: string;
   env?: string[];
   wait: boolean;
@@ -182,7 +175,6 @@ const deploy = async (props: DeployProps) => {
     props.path !== undefined ||
     props.entry !== undefined ||
     props.env !== undefined ||
-    props.memoryMib !== undefined ||
     props.runtime !== undefined;
   if (!hasOption) {
     throw new Error(
@@ -198,7 +190,6 @@ const deploy = async (props: DeployProps) => {
 
   const path = props.path ?? '.';
   const entry = props.entry ?? 'index.ts';
-  const memoryMib = props.memoryMib ?? 256;
   const runtime = props.runtime ?? 'nodejs24';
 
   const environment = parseEnv(props.env);
@@ -231,7 +222,6 @@ const deploy = async (props: DeployProps) => {
   await retryOnLock(() =>
     createDeployment(props.apiClient, props.projectId, branchId, props.slug, {
       zip,
-      memoryMib,
       runtime,
       environment,
     }),

--- a/src/functions_api.ts
+++ b/src/functions_api.ts
@@ -72,7 +72,6 @@ export const deleteFunction = async (
 
 export type DeployParams = {
   zip: Uint8Array;
-  memoryMib: number;
   runtime: string;
   environment?: string; // JSON-encoded string-to-string map
 };
@@ -86,7 +85,6 @@ export const createDeployment = async (
 ): Promise<void> => {
   const form = new FormData();
   form.append('zip', new Blob([params.zip]), 'bundle.zip');
-  form.append('memory_mib', String(params.memoryMib));
   form.append('runtime', params.runtime);
   if (params.environment) form.append('environment', params.environment);
 


### PR DESCRIPTION
The deploy endpoint no longer accepts memory_mib in its request body (neon-cloud #7318): the platform assigns memory itself, so the field was accepted-but-ignored. Remove the request-side option from the CLI.

memory_mib stays as an output: the deployment response still reports the platform-assigned memory, so DEPLOYMENT_FIELDS and the response type are unchanged.

Co-authored-by: Isaac