### PR TITLE
feat: neon dev + config (status/plan/apply/deploy) + env pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,63 @@ $ cat .neon
 
 **`.gitignore` scaffolding**: when `.neon` is **created** for the first time, the CLI also makes sure a `.gitignore` sits alongside it listing `.neon`. If `.gitignore` doesn't exist it's created with a single `.neon` line; if it does exist, `.neon` is appended only when missing (no duplicates, your other entries are left alone). On subsequent updates to an existing `.neon`, `.gitignore` is left untouched — so if you deliberately un-ignore `.neon` (e.g. to commit shared context), the entry is not re-added on every command.
 
+## Config as code (`config` / `deploy`)
+
+Describe a branch's desired state in a `neon.ts` policy and reconcile it from the CLI — the Neon equivalent of `terraform status` / `plan` / `apply`. The policy is a function of the branch it's being evaluated for; you switch on the branch (`name`, `isDefault`, …) and return the config you want (auth, Data API, compute settings, TTL, protection, and Preview features like Functions and buckets):
+
+```ts
+// neon.ts
+import { defineConfig } from '@neondatabase/config/v1';
+
+export default defineConfig((branch) => {
+  if (branch.isDefault) {
+    return { protected: true, auth: {} };
+  }
+  return { parent: 'main', ttl: '7d' };
+});
+```
+
+Three sub-commands plus a top-level alias drive it:
+
+```bash
+# Inspect the branch's live Neon state (read-only — never mutates)
+neon config status
+
+# Dry-run diff: show exactly what `apply` would change
+neon config plan
+
+# Reconcile the policy against the branch
+neon config apply
+
+# `neon deploy` is an alias for `neon config apply`
+neon deploy
+```
+
+**Project & branch resolution** follows the same chain as the rest of the CLI, each entry winning over the next:
+
+1. `--project-id <id>` flag
+2. `projectId` from the closest `.neon` file (found by walking up from the current directory — see "Where `.neon` lives" above)
+3. If still unresolved and the API key maps to exactly one project, that project is auto-detected
+
+The branch is chosen with `--branch <id|name>`; without it the project's default branch is used. The policy itself is found by walking up from the current directory for a `neon.ts`, or pass `--config <path>` to point at one explicitly.
+
+**Apply-only flags** (also available on `deploy`):
+
+- `--update-existing` — auto-confirm overriding existing remote settings on the branch. Without it, drift on settings already present remotely (compute, TTL, `protected`) is reported as a **conflict** and `apply` makes no changes until you resolve it or pass this flag.
+- `--allow-protected` — auto-confirm applying to a branch Neon marks as protected. Without it, `apply` refuses to touch a protected branch.
+
+**Output**: `status` prints the project, branch, and reverse-engineered config; `plan` / `apply` print the planned/applied changes and any conflicts as tables. Pass `--output json` (or `--output yaml`) to emit the full machine-readable result (`PushResult`) for piping into other tools or CI.
+
+```bash
+# CI gate: fail the build if the branch has drifted from the policy
+neon config plan --project-id polished-snowflake-12345678 --output json
+
+# Reconcile a feature branch, overriding any manual tweaks made in the console
+neon deploy --branch my-feature --update-existing
+```
+
+Function deploys declared under `preview.functions` are bundled by neonctl's own esbuild helper and uploaded as part of `apply`, so the policy stays declarative and the packaged CLI never has to embed esbuild's native binary.
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                 | Description                    |
@@ -287,6 +344,8 @@ $ cat .neon
 | [set-context](https://neon.com/docs/reference/cli-set-context)             |                                                                                             | Set context for session        |
 | checkout                                                                   |                                                                                             | Pin a branch in `.neon`        |
 | [link](https://neon.com/docs/reference/cli-link)                           |                                                                                             | Link a directory to a project  |
+| config                                                                     | `status`, `plan`, `apply`                                                                   | Drive a branch from `neon.ts`  |
+| deploy                                                                     |                                                                                             | Alias for `config apply`       |
 | [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                             | Generate a completion script   |
 
 ## Global options

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "link:../neon-pkgs/packages/config",
-    "@neondatabase/config-runtime": "link:../neon-pkgs/packages/config-runtime",
-    "@neondatabase/env": "link:../neon-pkgs/packages/env",
+    "@neondatabase/config": "0.4.0",
+    "@neondatabase/config-runtime": "0.4.0",
+    "@neondatabase/env": "0.3.0",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup": "3.29.4",
     "strip-ansi": "7.1.0",
     "tsx": "4.22.3",
-    "typescript": "4.9.5",
+    "typescript": "5.8.3",
     "typescript-eslint": "8.28.0",
     "vitest": "1.6.1"
   },
@@ -57,11 +57,16 @@
     "esbuild": "0.28.0"
   },
   "dependencies": {
+    "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
+    "@neondatabase/config": "link:../neon-pkgs/packages/config",
+    "@neondatabase/config-runtime": "link:../neon-pkgs/packages/config-runtime",
+    "@neondatabase/env": "link:../neon-pkgs/packages/env",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",
     "chalk": "5.3.0",
+    "chokidar": "5.0.0",
     "cli-table": "0.3.11",
     "cliui": "8.0.1",
     "diff": "5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@hono/node-server':
+        specifier: 2.0.4
+        version: 2.0.4(hono@4.12.23)
       '@neondatabase/api-client':
         specifier: 2.7.1
         version: 2.7.1
+      '@neondatabase/config':
+        specifier: link:../neon-pkgs/packages/config
+        version: link:../neon-pkgs/packages/config
+      '@neondatabase/config-runtime':
+        specifier: link:../neon-pkgs/packages/config-runtime
+        version: link:../neon-pkgs/packages/config-runtime
+      '@neondatabase/env':
+        specifier: link:../neon-pkgs/packages/env
+        version: link:../neon-pkgs/packages/env
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -23,6 +35,9 @@ importers:
       chalk:
         specifier: 5.3.0
         version: 5.3.0
+      chokidar:
+        specifier: 5.0.0
+        version: 5.0.0
       cli-table:
         specifier: 0.3.11
         version: 0.3.11
@@ -149,11 +164,11 @@ importers:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
-        specifier: 4.9.5
-        version: 4.9.5
+        specifier: 5.8.3
+        version: 5.8.3
       typescript-eslint:
         specifier: 8.28.0
-        version: 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+        version: 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       vitest:
         specifier: 1.6.1
         version: 1.6.1(@types/node@18.19.41)
@@ -638,6 +653,12 @@ packages:
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1418,6 +1439,10 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -2084,6 +2109,10 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2903,6 +2932,10 @@ packages:
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3314,9 +3347,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.4:
@@ -3667,14 +3700,14 @@ snapshots:
       '@commitlint/types': 17.8.1
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@4.9.5)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@4.9.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5))(typescript@4.9.5)
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -3939,6 +3972,10 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.1
       yargs: 17.7.2
+
+  '@hono/node-server@2.0.4(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4320,32 +4357,32 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5))(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
       eslint: 9.29.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.3
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4354,20 +4391,20 @@ snapshots:
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/visitor-keys': 8.28.0
 
-  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       debug: 4.4.3
       eslint: 9.29.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.28.0': {}
 
-  '@typescript-eslint/typescript-estree@8.28.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@8.28.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/visitor-keys': 8.28.0
@@ -4376,19 +4413,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.28.0(eslint@9.29.0)(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0)
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
-      '@typescript-eslint/typescript-estree': 8.28.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4786,6 +4823,10 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chownr@3.0.0: {}
@@ -4898,21 +4939,21 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@4.9.5))(ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5))(typescript@4.9.5):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@4.9.5)
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@4.9.5)
-      typescript: 4.9.5
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.8.3)
+      typescript: 5.8.3
 
-  cosmiconfig@8.3.6(typescript@4.9.5):
+  cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.8.3
 
   cpu-features@0.0.10:
     dependencies:
@@ -5561,6 +5602,8 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.23: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -6330,6 +6373,8 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  readdirp@5.0.0: {}
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -6768,11 +6813,11 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@4.9.5):
+  ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@20.5.1)(typescript@4.9.5):
+  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -6786,7 +6831,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -6829,17 +6874,17 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.28.0(eslint@9.29.0)(typescript@4.9.5):
+  typescript-eslint@8.28.0(eslint@9.29.0)(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@4.9.5))(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
       eslint: 9.29.0
-      typescript: 4.9.5
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@4.9.5: {}
+  typescript@5.8.3: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       '@neondatabase/config':
-        specifier: link:../neon-pkgs/packages/config
-        version: link:../neon-pkgs/packages/config
+        specifier: 0.4.0
+        version: 0.4.0
       '@neondatabase/config-runtime':
-        specifier: link:../neon-pkgs/packages/config-runtime
-        version: link:../neon-pkgs/packages/config-runtime
+        specifier: 0.4.0
+        version: 0.4.0
       '@neondatabase/env':
-        specifier: link:../neon-pkgs/packages/env
-        version: link:../neon-pkgs/packages/env
+        specifier: 0.3.0
+        version: 0.3.0
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -135,7 +135,7 @@ importers:
         version: 3.0.4
       eslint:
         specifier: 9.29.0
-        version: 9.29.0
+        version: 9.29.0(jiti@2.7.0)
       express:
         specifier: 4.19.2
         version: 4.19.2
@@ -168,7 +168,7 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: 8.28.0
-        version: 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+        version: 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
       vitest:
         specifier: 1.6.1
         version: 1.6.1(@types/node@18.19.41)
@@ -310,6 +310,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
@@ -319,6 +325,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -334,6 +346,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.0':
     resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
     engines: {node: '>=18'}
@@ -343,6 +361,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -358,6 +382,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
@@ -367,6 +397,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -382,6 +418,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
@@ -391,6 +433,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -406,6 +454,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
@@ -415,6 +469,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -430,6 +490,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
@@ -439,6 +505,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -454,6 +526,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
@@ -463,6 +541,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -478,6 +562,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
@@ -487,6 +577,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -502,11 +598,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
@@ -520,11 +628,23 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.0':
     resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
@@ -538,11 +658,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.0':
     resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
@@ -553,6 +685,12 @@ packages:
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -568,6 +706,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
@@ -580,6 +724,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
@@ -589,6 +739,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -727,6 +883,19 @@ packages:
 
   '@neondatabase/api-client@2.7.1':
     resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
+
+  '@neondatabase/config-runtime@0.4.0':
+    resolution: {integrity: sha512-2dzMM9bsF3McVaQ6fKcygtSu1tObWsQnJEginfB4HqizyX2ClIGbRho795ErLXy+GenV+BXsDPjlU+k1EE3FPw==}
+    engines: {node: '>=22'}
+
+  '@neondatabase/config@0.4.0':
+    resolution: {integrity: sha512-FX9AByNtuF4RL+iaJq86VzNkrmn5Qu9Gv+sEscoxKYHkMKrlAtYa6pF+G2N6Gm9JyD6/91gm0wS7bhHftehAUQ==}
+    engines: {node: '>=22'}
+
+  '@neondatabase/env@0.3.0':
+    resolution: {integrity: sha512-5EHuhhnIa8KFMk5ROYo6w13Ewe2sezIYWvh+MkXOOqSh1OMiBNE0/qhx9nWjngoB/dDhiw7IfN/MAE47CdLAgA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1781,6 +1950,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.0:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
@@ -2293,6 +2467,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -3567,6 +3745,9 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
@@ -3762,10 +3943,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
@@ -3774,10 +3961,16 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
@@ -3786,10 +3979,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
@@ -3798,10 +3997,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -3810,10 +4015,16 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
@@ -3822,10 +4033,16 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
@@ -3834,10 +4051,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -3846,10 +4069,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
@@ -3858,7 +4087,13 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
@@ -3867,7 +4102,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
@@ -3876,7 +4117,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
@@ -3885,10 +4132,16 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
@@ -3897,18 +4150,24 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.29.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.29.0(jiti@2.7.0))':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4048,6 +4307,33 @@ snapshots:
   '@neondatabase/api-client@2.7.1':
     dependencies:
       axios: 1.16.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@neondatabase/config-runtime@0.4.0':
+    dependencies:
+      '@neondatabase/config': 0.4.0
+      esbuild: 0.25.12
+      fflate: 0.8.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@neondatabase/config@0.4.0':
+    dependencies:
+      '@neondatabase/api-client': 2.7.1
+      jiti: 2.7.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@neondatabase/env@0.3.0':
+    dependencies:
+      '@neondatabase/config': 0.4.0
+      yargs: 18.0.0
+      zod: 4.4.3
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -4357,15 +4643,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3))(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.28.0
-      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -4374,14 +4660,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.28.0
       debug: 4.4.3
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -4391,12 +4677,12 @@ snapshots:
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/visitor-keys': 8.28.0
 
-  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
       debug: 4.4.3
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -4418,13 +4704,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.28.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.28.0
       '@typescript-eslint/types': 8.28.0
       '@typescript-eslint/typescript-estree': 8.28.0(typescript@5.8.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5142,6 +5428,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.28.0:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.0
@@ -5186,9 +5501,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.29.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.29.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.3
@@ -5223,6 +5538,8 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5748,6 +6065,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jiti@2.7.0: {}
 
   jose@6.2.3: {}
 
@@ -6874,12 +7193,12 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.28.0(eslint@9.29.0)(typescript@5.8.3):
+  typescript-eslint@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0)(typescript@5.8.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.28.0(@typescript-eslint/parser@8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3))(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.28.0(eslint@9.29.0(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 9.29.0(jiti@2.7.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -7086,3 +7405,5 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod@4.4.3: {}

--- a/src/commands/__snapshots__/dev.test.ts.snap
+++ b/src/commands/__snapshots__/dev.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`dev > exits 1 when --source is missing 1`] = `""`;
+
+exports[`dev > exits 1 when --source points at a file that does not exist 1`] = `""`;

--- a/src/commands/__snapshots__/dev.test.ts.snap
+++ b/src/commands/__snapshots__/dev.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dev > exits 1 when --source is missing 1`] = `""`;
+exports[`dev > exits 1 when --port is given without --source 1`] = `""`;
 
 exports[`dev > exits 1 when --source points at a file that does not exist 1`] = `""`;
+
+exports[`dev > exits 1 when no --source and no neon.ts is found 1`] = `""`;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -163,6 +163,12 @@ export const ensureAuth = async (
     return;
   }
 
+  // `dev` runs a function locally. It injects the selected branch's env vars
+  // when credentials happen to be available, but must never trigger an
+  // interactive login: use an API key or existing stored credentials if
+  // present, otherwise run with no API client (env injection is skipped).
+  const isLocalDev = props._[0] === 'dev';
+
   // Use existing API key or handle auth command
   if (props.apiKey || props._[0] === 'auth') {
     if (props.apiKey) {
@@ -214,6 +220,14 @@ export const ensureAuth = async (
       'Credentials file %s does not exist, starting authentication',
       credentialsPath,
     );
+  }
+
+  // `dev` never launches the interactive browser flow. With no usable
+  // credentials it proceeds without an API client; env injection is skipped
+  // and the function still runs locally.
+  if (isLocalDev) {
+    log.debug('dev: no usable credentials; running without env injection');
+    return;
   }
 
   // Start new auth flow if no valid token exists or refresh failed

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -10,6 +10,7 @@ import { log } from '../log.js';
 import { CommonProps } from '../types.js';
 import { fillSingleProject } from '../utils/enrichers.js';
 import { looksLikeBranchId } from '../utils/formats.js';
+import { applyPolicyOnCreate } from './config.js';
 import { handler as linkHandler } from './link.js';
 
 type CheckoutProps = CommonProps & {
@@ -60,7 +61,7 @@ export const handler = async (props: CheckoutProps) => {
   // nothing resolves, fall back to an interactive `neonctl link`.
   const projectId = await resolveProjectId(props);
 
-  const branchId = await resolveBranchId(props, projectId);
+  const { branchId, created } = await resolveBranchId(props, projectId);
 
   const orgId = await resolveOrgId(props, projectId);
 
@@ -81,6 +82,18 @@ export const handler = async (props: CheckoutProps) => {
     orgId ? ` (org ${orgId})` : '',
     props.contextFile,
   );
+
+  // Only when checkout just *created* the branch do we apply the local neon.ts policy,
+  // so a new branch comes up with the declared settings/infra immediately. Checking out an
+  // existing branch never reconciles it — that's an explicit `neonctl deploy` / `config
+  // apply`. No neon.ts on disk → nothing to apply.
+  if (created) {
+    await applyPolicyOnCreate({
+      projectId,
+      branchId,
+      ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    });
+  }
 };
 
 /**
@@ -94,15 +107,24 @@ export const handler = async (props: CheckoutProps) => {
  * - **Omitted**: open an interactive picker listing the project's branches (TTY
  *   only); in a non-interactive context a missing branch is a hard error.
  */
+type ResolvedBranch = {
+  branchId: string;
+  /** True only when this checkout created a new branch (vs. selecting an existing one). */
+  created: boolean;
+};
+
 const resolveBranchId = async (
   props: CheckoutProps,
   projectId: string,
-): Promise<string> => {
+): Promise<ResolvedBranch> => {
   const branches = (await props.apiClient.listProjectBranches({ projectId }))
     .data.branches;
 
   if (!props.id) {
-    return pickBranchInteractively(branches, projectId);
+    return {
+      branchId: await pickBranchInteractively(branches, projectId),
+      created: false,
+    };
   }
 
   const ref = props.id;
@@ -111,14 +133,14 @@ const resolveBranchId = async (
   if (looksLikeBranchId(ref)) {
     const byId = branches.find((b: Branch) => b.id === ref);
     if (byId) {
-      return byId.id;
+      return { branchId: byId.id, created: false };
     }
     throw new Error(notFoundMessage(ref, branches));
   }
 
   const byName = branches.find((b: Branch) => b.name === ref);
   if (byName) {
-    return byName.id;
+    return { branchId: byName.id, created: false };
   }
 
   // Name not found: offer to create it interactively, mirroring `branch create`.
@@ -136,7 +158,10 @@ const resolveBranchId = async (
   if (!create) {
     throw new Error(`Aborted: branch "${ref}" was not found and not created.`);
   }
-  return createBranch(props, projectId, ref, branches);
+  return {
+    branchId: await createBranch(props, projectId, ref, branches),
+    created: true,
+  };
 };
 
 const notFoundMessage = (ref: string, branches: Branch[]): string =>

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -104,8 +104,9 @@ export const handler = async (props: CheckoutProps) => {
  * - Branch **name**: looked up by name. If it doesn't exist, in an interactive
  *   terminal we offer to create it (like `neonctl branch create --name <name>`);
  *   in a non-interactive context it's the usual "not found" error.
- * - **Omitted**: open an interactive picker listing the project's branches (TTY
- *   only); in a non-interactive context a missing branch is a hard error.
+ * - **Omitted**: open an interactive picker listing the project's branches plus a
+ *   "create a new branch" option (TTY only); in a non-interactive context a missing
+ *   branch is a hard error.
  */
 type ResolvedBranch = {
   branchId: string;
@@ -121,9 +122,14 @@ const resolveBranchId = async (
     .data.branches;
 
   if (!props.id) {
+    const picked = await pickBranchInteractively(branches);
+    if (picked.kind === 'existing') {
+      return { branchId: picked.branchId, created: false };
+    }
+    // The user chose "create a new branch" from the picker.
     return {
-      branchId: await pickBranchInteractively(branches, projectId),
-      created: false,
+      branchId: await createBranch(props, projectId, picked.name, branches),
+      created: true,
     };
   }
 
@@ -169,37 +175,75 @@ const notFoundMessage = (ref: string, branches: Branch[]): string =>
     .map((b: Branch) => b.name)
     .join(', ')}`;
 
+/**
+ * Outcome of the interactive picker: either an existing branch's id was chosen, or the
+ * user opted to create a new branch and supplied its name.
+ */
+type PickedBranch =
+  | { kind: 'existing'; branchId: string }
+  | { kind: 'create'; name: string };
+
+/** Sentinel `value` for the "create a new branch" choice (no branch id can collide). */
+const CREATE_BRANCH_CHOICE = Symbol('create-branch');
+
 const pickBranchInteractively = async (
   branches: Branch[],
-  projectId: string,
-): Promise<string> => {
+): Promise<PickedBranch> => {
   if (isCi() || !process.stdout.isTTY) {
     throw new Error(
       'No branch specified. Pass a branch name or id (e.g. `neonctl checkout main`), ' +
         'or run interactively to pick one from a list.',
     );
   }
-  if (branches.length === 0) {
-    throw new Error(`No branches found for project ${projectId}.`);
-  }
-  const defaultIndex = Math.max(
-    0,
-    branches.findIndex((b: Branch) => b.default),
-  );
-  const { branchId } = await prompts({
+  // The default selection is the project's default branch when there are branches to
+  // show; the create option sits at the top, so offset the default index by one.
+  const defaultBranchIndex = branches.findIndex((b: Branch) => b.default);
+  const initial = defaultBranchIndex >= 0 ? defaultBranchIndex + 1 : 0;
+  const { choice } = await prompts({
     type: 'select',
-    name: 'branchId',
+    name: 'choice',
     message: 'Which branch would you like to check out?',
-    choices: branches.map((b: Branch) => ({
-      title: `${b.default ? '✱ ' : ''}${b.name} (${b.id})`,
-      value: b.id,
-    })),
-    initial: defaultIndex,
+    choices: [
+      { title: '＋ Create a new branch…', value: CREATE_BRANCH_CHOICE },
+      ...branches.map((b: Branch) => ({
+        title: `${b.default ? '✱ ' : ''}${b.name} (${b.id})`,
+        value: b.id,
+      })),
+    ],
+    initial,
   });
-  if (!branchId) {
+  if (choice === undefined) {
     throw new Error('Aborted: no branch selected.');
   }
-  return branchId;
+  if (choice === CREATE_BRANCH_CHOICE) {
+    return { kind: 'create', name: await promptNewBranchName(branches) };
+  }
+  return { kind: 'existing', branchId: choice as string };
+};
+
+/**
+ * Prompt for a new branch name, rejecting empty input and names already taken on the
+ * project (so we never silently check out a different, pre-existing branch).
+ */
+const promptNewBranchName = async (branches: Branch[]): Promise<string> => {
+  const existing = new Set(branches.map((b: Branch) => b.name));
+  const { name } = await prompts({
+    type: 'text',
+    name: 'name',
+    message: 'New branch name:',
+    validate: (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed === '') return 'Branch name cannot be empty.';
+      if (existing.has(trimmed))
+        return `A branch named "${trimmed}" already exists.`;
+      return true;
+    },
+  });
+  const trimmed = typeof name === 'string' ? name.trim() : '';
+  if (trimmed === '') {
+    throw new Error('Aborted: no branch name provided.');
+  }
+  return trimmed;
 };
 
 /**

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -1,0 +1,366 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NeonApi } from '@neondatabase/config-runtime';
+import type {
+  CreateBucketInput,
+  DeployFunctionInput,
+  GetConnectionUriInput,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import type { ConfigProps } from './config.js';
+import { applyCmd, planCmd, status } from './config.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-snowy-frost-12345';
+const BRANCH_NAME = 'main';
+
+/**
+ * Full {@link NeonApi} implementation backed by fixed in-memory state for one
+ * project + one default branch. The handful of methods that `inspect` / `plan` /
+ * `apply` exercise return real data; everything else throws so an unexpected call
+ * fails loudly instead of silently passing. `enableNeonAuth` records its calls so
+ * a test can assert `apply` actually mutated remote state.
+ */
+class FakeNeonApi implements NeonApi {
+  readonly enableNeonAuthCalls: { projectId: string; branchId: string }[] = [];
+  readonly deployBranchFunctionCalls: {
+    projectId: string;
+    branchId: string;
+    slug: string;
+    input: DeployFunctionInput;
+  }[] = [];
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'dev-project',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranches(): Promise<NeonBranchSnapshot[]> {
+    return [
+      {
+        id: BRANCH_ID,
+        name: BRANCH_NAME,
+        isDefault: true,
+        protected: false,
+      },
+    ];
+  }
+
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-fake-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${BRANCH_ID}.fake.neon.tech/${input.databaseName}?sslmode=require`,
+    };
+  }
+
+  async getNeonAuth(): Promise<NeonAuthSnapshot | null> {
+    return null;
+  }
+
+  async enableNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot> {
+    this.enableNeonAuthCalls.push({ projectId, branchId });
+    return {
+      projectId: 'auth-project',
+      jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+      baseUrl: 'https://auth.fake.neon.tech',
+    };
+  }
+
+  async getNeonDataApi(): Promise<NeonDataApiSnapshot | null> {
+    return null;
+  }
+
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+
+  async createBranchBucket(
+    projectId: string,
+    branchId: string,
+    input: CreateBucketInput,
+  ): Promise<NeonBucketSnapshot> {
+    void projectId;
+    void branchId;
+    return { name: input.name, accessLevel: input.accessLevel ?? 'private' };
+  }
+
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+
+  async createBranchFunction(
+    projectId: string,
+    branchId: string,
+    input: { slug: string; name: string },
+  ): Promise<NeonFunctionSnapshot> {
+    void projectId;
+    void branchId;
+    return {
+      id: `fn-${input.slug}`,
+      slug: input.slug,
+      name: input.name,
+      invocationUrl: `https://${input.slug}.${BRANCH_ID}.fake.neon.tech`,
+    };
+  }
+
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async deployBranchFunction(
+    projectId: string,
+    branchId: string,
+    slug: string,
+    input: DeployFunctionInput,
+  ): Promise<NeonFunctionDeploymentSnapshot> {
+    this.deployBranchFunctionCalls.push({ projectId, branchId, slug, input });
+    return { id: 1, status: 'completed' };
+  }
+
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+/**
+ * Minimal stand-in for the neonctl `Api` client. Only `listProjectBranches` is
+ * exercised (by `branchIdFromProps`, to resolve the branch name to its id);
+ * anything else is absent and would throw if touched.
+ */
+const fakeApiClient = {
+  listProjectBranches: async () => ({
+    data: {
+      branches: [
+        {
+          id: BRANCH_ID,
+          name: BRANCH_NAME,
+          default: true,
+        },
+      ],
+    },
+  }),
+};
+
+/** Capture writer output (the writer respects `props.out`). */
+const captureOut = (): { stream: PassThrough; read: () => string } => {
+  const stream = new PassThrough();
+  let buffer = '';
+  stream.on('data', (chunk: Buffer) => {
+    buffer += chunk.toString();
+  });
+  return { stream, read: () => buffer };
+};
+
+const baseProps = (
+  api: FakeNeonApi,
+  out: PassThrough,
+): ConfigProps & { runtimeApi: NeonApi; out: PassThrough } => ({
+  apiClient: fakeApiClient as never,
+  apiKey: '',
+  apiHost: 'https://console.neon.tech/api/v2',
+  contextFile: '',
+  output: 'json',
+  projectId: PROJECT_ID,
+  branch: BRANCH_NAME,
+  runtimeApi: api,
+  out,
+});
+
+describe('config commands', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-config-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  const writeConfig = (body: string): string => {
+    const path = join(cwd, 'neon.ts');
+    writeFileSync(path, body);
+    return path;
+  };
+
+  it('status returns the live project + branch state', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    await status(baseProps(api, stream));
+
+    const parsed = JSON.parse(read());
+    expect(parsed.project.id).toBe(PROJECT_ID);
+    expect(parsed.branch.id).toBe(BRANCH_ID);
+    expect(parsed.branch.name).toBe(BRANCH_NAME);
+  });
+
+  it('plan is a dry run whose applied list includes the auth service change', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+    const config = writeConfig('export default () => ({ auth: {} });\n');
+
+    await planCmd({ ...baseProps(api, stream), config });
+
+    const result = JSON.parse(read());
+    expect(result.dryRun).toBe(true);
+    const authChange = result.applied.find(
+      (change: { identifier: string }) => change.identifier === 'auth',
+    );
+    expect(authChange).toBeDefined();
+    expect(authChange.kind).toBe('service');
+    // A dry run never mutates remote state.
+    expect(api.enableNeonAuthCalls).toHaveLength(0);
+  });
+
+  it('apply actually enables Neon Auth and is not a dry run', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+    const config = writeConfig('export default () => ({ auth: {} });\n');
+
+    await applyCmd({ ...baseProps(api, stream), config });
+
+    const result = JSON.parse(read());
+    expect(result.dryRun).toBe(false);
+    expect(api.enableNeonAuthCalls).toHaveLength(1);
+    expect(api.enableNeonAuthCalls[0]).toEqual({
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+    });
+  });
+
+  it("apply deploys a function via neonctl's own bundler", async () => {
+    const api = new FakeNeonApi();
+    const { stream } = captureOut();
+
+    // A real handler module on disk: applyCmd's injected bundler (bundleEntry +
+    // zipBundle) actually runs esbuild against this source and zips the output, so
+    // it must be valid TypeScript that esbuild can bundle.
+    const source = join(cwd, 'hello.ts');
+    writeFileSync(
+      source,
+      "export default { fetch() { return new Response('ok'); } };\n",
+    );
+    const config = writeConfig(
+      `export default () => ({ preview: { functions: [{ slug: 'hello', name: 'Hello', source: ${JSON.stringify(
+        source,
+      )} }] } });\n`,
+    );
+
+    await applyCmd({ ...baseProps(api, stream), config });
+
+    // The function was new (listBranchFunctions returns []), so apply both creates
+    // it and deploys code to it. We assert the deploy carried a real bundle.
+    expect(api.deployBranchFunctionCalls).toHaveLength(1);
+    const call = api.deployBranchFunctionCalls[0];
+    expect(call.projectId).toBe(PROJECT_ID);
+    expect(call.branchId).toBe(BRANCH_ID);
+    expect(call.slug).toBe('hello');
+
+    // The bundle must be the real ZIP produced by neonctl's bundleEntry + zipBundle
+    // (NOT config-runtime's own esbuild default bundler). A non-empty Uint8Array
+    // whose first two bytes are the ZIP local-file-header magic ("PK") proves a real
+    // archive was built by neonctl's injected FunctionBundler.
+    const { bundle } = call.input;
+    expect(bundle).toBeInstanceOf(Uint8Array);
+    expect(bundle.byteLength).toBeGreaterThan(0);
+    expect(bundle[0]).toBe(0x50); // 'P'
+    expect(bundle[1]).toBe(0x4b); // 'K'
+  });
+});

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -22,7 +22,7 @@ import type {
 } from '@neondatabase/config';
 
 import type { ConfigProps } from './config.js';
-import { applyCmd, planCmd, status } from './config.js';
+import { applyCmd, applyPolicyOnCreate, planCmd, status } from './config.js';
 
 const PROJECT_ID = 'patient-art-12345';
 const BRANCH_ID = 'br-snowy-frost-12345';
@@ -294,7 +294,7 @@ describe('config commands', () => {
   it('plan is a dry run whose applied list includes the auth service change', async () => {
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();
-    const config = writeConfig('export default () => ({ auth: {} });\n');
+    const config = writeConfig('export default { auth: {} };\n');
 
     await planCmd({ ...baseProps(api, stream), config });
 
@@ -312,7 +312,7 @@ describe('config commands', () => {
   it('apply actually enables Neon Auth and is not a dry run', async () => {
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();
-    const config = writeConfig('export default () => ({ auth: {} });\n');
+    const config = writeConfig('export default { auth: {} };\n');
 
     await applyCmd({ ...baseProps(api, stream), config });
 
@@ -338,9 +338,9 @@ describe('config commands', () => {
       "export default { fetch() { return new Response('ok'); } };\n",
     );
     const config = writeConfig(
-      `export default () => ({ preview: { functions: [{ slug: 'hello', name: 'Hello', source: ${JSON.stringify(
+      `export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
         source,
-      )} }] } });\n`,
+      )} } } } };\n`,
     );
 
     await applyCmd({ ...baseProps(api, stream), config });
@@ -362,5 +362,75 @@ describe('config commands', () => {
     expect(bundle.byteLength).toBeGreaterThan(0);
     expect(bundle[0]).toBe(0x50); // 'P'
     expect(bundle[1]).toBe(0x4b); // 'K'
+  });
+
+  it('--env loads a .env file into the environment before evaluating neon.ts', async () => {
+    const api = new FakeNeonApi();
+    const { stream } = captureOut();
+
+    const source = join(cwd, 'hello.ts');
+    writeFileSync(
+      source,
+      "export default { fetch() { return new Response('ok'); } };\n",
+    );
+    // The function's env value reads process.env.RESEND_API_KEY — which is only present if
+    // the --env file is loaded before the policy is evaluated.
+    const config = writeConfig(
+      `export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
+        source,
+      )}, env: { resendApiKey: process.env.RESEND_API_KEY ?? '' } } } } };\n`,
+    );
+    const envFile = join(cwd, '.env.deploy');
+    writeFileSync(envFile, 'RESEND_API_KEY=re_from_file\n');
+
+    try {
+      await applyCmd({ ...baseProps(api, stream), config, env: envFile });
+    } finally {
+      delete process.env.RESEND_API_KEY;
+    }
+
+    expect(api.deployBranchFunctionCalls).toHaveLength(1);
+    expect(api.deployBranchFunctionCalls[0].input.environment).toEqual({
+      resendApiKey: 're_from_file',
+    });
+  });
+});
+
+describe('applyPolicyOnCreate', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-create-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('applies the neon.ts policy to the new branch when one is present', async () => {
+    const api = new FakeNeonApi();
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
+
+    await applyPolicyOnCreate({
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      runtimeApi: api,
+      cwd,
+    });
+
+    expect(api.enableNeonAuthCalls).toHaveLength(1);
+  });
+
+  it('is a no-op when there is no neon.ts on the path', async () => {
+    const api = new FakeNeonApi();
+
+    await applyPolicyOnCreate({
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      runtimeApi: api,
+      cwd, // empty temp dir, no neon.ts
+    });
+
+    expect(api.enableNeonAuthCalls).toHaveLength(0);
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,237 @@
+import yargs from 'yargs';
+import {
+  apply,
+  inspect,
+  loadConfigFromFile,
+  plan,
+  type Config,
+  type ConflictReport,
+  type FunctionBundler,
+  type NeonApi,
+  type PushResult,
+} from '@neondatabase/config-runtime';
+
+import { log } from '../log.js';
+import { BranchScopeProps } from '../types.js';
+import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+import { bundleEntry } from '../utils/esbuild.js';
+import { zipBundle } from '../utils/zip.js';
+import { writer } from '../writer.js';
+
+/**
+ * Bundle a function with neonctl's OWN bundler (the shared esbuild helper) so the
+ * config-runtime never has to import esbuild itself. Injecting this keeps esbuild
+ * out of config-runtime's static module graph — and therefore out of the packaged
+ * neonctl snapshot, which resolves esbuild dynamically at deploy time.
+ */
+const neonctlBundler: FunctionBundler = async (fn) =>
+  zipBundle(await bundleEntry(fn.source));
+
+const INSPECT_FIELDS = ['project', 'branch', 'config'] as const;
+const APPLIED_FIELDS = ['action', 'kind', 'identifier', 'details'] as const;
+const CONFLICT_FIELDS = [
+  'identifier',
+  'field',
+  'current',
+  'desired',
+  'reason',
+] as const;
+
+export type ConfigProps = BranchScopeProps & {
+  /** Explicit path to a neon.ts policy. When omitted, loadConfigFromFile walks up from cwd. */
+  config?: string;
+  /** Auto-confirm overriding existing remote settings (apply only). */
+  updateExisting?: boolean;
+  /** Auto-confirm applying to a protected branch (apply only). */
+  allowProtected?: boolean;
+  /** Injected NeonApi adapter (tests). Production omits it so the real adapter is built from credentials. */
+  runtimeApi?: NeonApi;
+};
+
+/** Apply-only flags, exported so `deploy` can reuse the exact same surface. */
+export const applyFlags = {
+  'update-existing': {
+    describe: 'Auto-confirm overriding existing remote settings on the branch',
+    type: 'boolean',
+    default: false,
+  },
+  'allow-protected': {
+    describe: 'Auto-confirm applying to a branch marked protected on Neon',
+    type: 'boolean',
+    default: false,
+  },
+} as const;
+
+export const command = 'config';
+export const describe = 'Manage a branch with a neon.ts policy';
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 config <sub-command> [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+    })
+    .middleware(fillSingleProject as any)
+    .command(
+      'status',
+      "Show the branch's live Neon state",
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+        }),
+      (args) => status(args as any),
+    )
+    .command(
+      'plan',
+      'Show what `config apply` would change (dry run)',
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+        }),
+      (args) => planCmd(args as any),
+    )
+    .command(
+      'apply',
+      'Apply a neon.ts policy to the branch',
+      (yargs) =>
+        yargs.options({
+          config: {
+            describe:
+              'Path to a neon.ts policy (defaults to walking up from cwd)',
+            type: 'string',
+          },
+          ...applyFlags,
+        }),
+      (args) => applyCmd(args as any),
+    );
+
+export const handler = (args: yargs.Argv) => {
+  return args;
+};
+
+const loadConfig = async (props: ConfigProps): Promise<Config> => {
+  const { config } = await loadConfigFromFile({
+    ...(props.config ? { path: props.config } : {}),
+  });
+  return config;
+};
+
+export const status = async (props: ConfigProps): Promise<void> => {
+  const branchId = await branchIdFromProps(props);
+  const live = await inspect({
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+  writer(props).end(live, { fields: INSPECT_FIELDS });
+};
+
+export const planCmd = async (props: ConfigProps): Promise<void> => {
+  const config = await loadConfig(props);
+  const branchId = await branchIdFromProps(props);
+  // `plan` is a dry run that never bundles, so its options don't accept (or need)
+  // an injected bundler — only `apply` does (it uses neonctlBundler).
+  const result = await plan(config, {
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+  reportPushResult(props, result, 'plan');
+};
+
+export const applyCmd = async (props: ConfigProps): Promise<void> => {
+  const config = await loadConfig(props);
+  const branchId = await branchIdFromProps(props);
+  const result = await apply(config, {
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+    ...(props.updateExisting ? { updateExisting: true } : {}),
+    ...(props.allowProtected ? { allowProtectedBranch: true } : {}),
+    bundleFunction: neonctlBundler,
+  });
+  reportPushResult(props, result, 'apply');
+};
+
+type ReportMode = 'plan' | 'apply';
+
+/**
+ * Render a {@link PushResult}. JSON/YAML output emits the raw result verbatim so it
+ * can be piped; the human-readable path renders the actual changes (dropping noops)
+ * and any blocking conflicts as tables, or a "nothing to do" line when both are empty.
+ */
+const reportPushResult = (
+  props: ConfigProps,
+  result: PushResult,
+  mode: ReportMode,
+): void => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    writer(props).end(result, { fields: [] });
+    return;
+  }
+
+  const changes = result.applied
+    .filter((change) => change.action !== 'noop')
+    .map((change) => ({
+      action: change.action,
+      kind: change.kind,
+      identifier: change.identifier,
+      details: change.details ? JSON.stringify(change.details) : '',
+    }));
+  const conflicts = result.conflicts.map((conflict: ConflictReport) => ({
+    identifier: conflict.identifier,
+    field: conflict.field,
+    current: stringify(conflict.current),
+    desired: stringify(conflict.desired),
+    reason: conflict.reason,
+  }));
+
+  if (changes.length === 0 && conflicts.length === 0) {
+    log.info(
+      `No changes — branch ${result.branchName} already matches the policy.`,
+    );
+    return;
+  }
+
+  const out = writer(props);
+  if (changes.length > 0) {
+    out.write(changes, {
+      fields: APPLIED_FIELDS,
+      title: mode === 'plan' ? 'Planned changes' : 'Applied changes',
+    });
+  }
+  if (conflicts.length > 0) {
+    out.write(conflicts, { fields: CONFLICT_FIELDS, title: 'Conflicts' });
+  }
+  out.end();
+
+  if (conflicts.length > 0) {
+    log.info(
+      'Resolve the conflicts above, or re-run with --update-existing to override the current remote settings.',
+    );
+  }
+};
+
+const stringify = (value: unknown): string =>
+  value === undefined
+    ? ''
+    : typeof value === 'string'
+      ? value
+      : JSON.stringify(value);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,6 +13,7 @@ import {
 
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
+import { loadEnvFileIntoProcess } from '../env_file.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { bundleEntry } from '../utils/esbuild.js';
 import { zipBundle } from '../utils/zip.js';
@@ -40,6 +41,13 @@ const CONFLICT_FIELDS = [
 export type ConfigProps = BranchScopeProps & {
   /** Explicit path to a neon.ts policy. When omitted, loadConfigFromFile walks up from cwd. */
   config?: string;
+  /**
+   * Optional path to a `.env` file loaded into `process.env` **before** the `neon.ts`
+   * policy is evaluated, so function `env` values that read `process.env.X` pick up the
+   * right per-environment values without juggling shells. Existing `process.env` entries
+   * win over the file.
+   */
+  env?: string;
   /** Auto-confirm overriding existing remote settings (apply only). */
   updateExisting?: boolean;
   /** Auto-confirm applying to a protected branch (apply only). */
@@ -47,6 +55,19 @@ export type ConfigProps = BranchScopeProps & {
   /** Injected NeonApi adapter (tests). Production omits it so the real adapter is built from credentials. */
   runtimeApi?: NeonApi;
 };
+
+/**
+ * Shared `--env` flag for `config plan|apply` and `deploy`. Loads a `.env` into
+ * `process.env` before the policy is evaluated.
+ */
+export const envFlag = {
+  env: {
+    describe:
+      'Path to a .env file to load into the environment before evaluating neon.ts ' +
+      '(so function env values resolve from it). Existing env vars are not overridden.',
+    type: 'string',
+  },
+} as const;
 
 /** Apply-only flags, exported so `deploy` can reuse the exact same surface. */
 export const applyFlags = {
@@ -101,6 +122,7 @@ export const builder = (argv: yargs.Argv) =>
               'Path to a neon.ts policy (defaults to walking up from cwd)',
             type: 'string',
           },
+          ...envFlag,
         }),
       (args) => planCmd(args as any),
     )
@@ -114,6 +136,7 @@ export const builder = (argv: yargs.Argv) =>
               'Path to a neon.ts policy (defaults to walking up from cwd)',
             type: 'string',
           },
+          ...envFlag,
           ...applyFlags,
         }),
       (args) => applyCmd(args as any),
@@ -124,6 +147,17 @@ export const handler = (args: yargs.Argv) => {
 };
 
 const loadConfig = async (props: ConfigProps): Promise<Config> => {
+  // Load the optional --env file FIRST so a `neon.ts` whose function `env` values read
+  // `process.env.X` sees them. Must happen before the policy module is imported/evaluated.
+  if (props.env) {
+    const applied = loadEnvFileIntoProcess(props.env);
+    log.debug(
+      'Loaded %d var(s) from %s into the environment: %s',
+      applied.length,
+      props.env,
+      applied.join(', '),
+    );
+  }
   const { config } = await loadConfigFromFile({
     ...(props.config ? { path: props.config } : {}),
   });
@@ -235,3 +269,54 @@ const stringify = (value: unknown): string =>
     : typeof value === 'string'
       ? value
       : JSON.stringify(value);
+
+/**
+ * Apply a `neon.ts` policy to a **freshly created** branch (used by `neonctl checkout`
+ * when it creates a branch). No-op when there is no `neon.ts` on the path from cwd up to
+ * the repo root — checkout still succeeds, it just has no policy to apply.
+ *
+ * The branch was just created by us, so we apply non-interactively (`updateExisting` /
+ * `allowProtectedBranch`) — there is no pre-existing state a user would be surprised to
+ * see overridden. Functions are bundled with neonctl's own esbuild helper.
+ */
+export const applyPolicyOnCreate = async (props: {
+  projectId: string;
+  branchId: string;
+  apiKey?: string;
+  runtimeApi?: NeonApi;
+  /** Directory to search for `neon.ts` from. Defaults to the process cwd. */
+  cwd?: string;
+}): Promise<void> => {
+  let config: Config;
+  try {
+    ({ config } = await loadConfigFromFile({
+      ...(props.cwd ? { cwd: props.cwd } : {}),
+    }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) return;
+    throw err;
+  }
+
+  log.info('Applying neon.ts policy to the new branch…');
+  const result = await apply(config, {
+    projectId: props.projectId,
+    branchId: props.branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+    updateExisting: true,
+    allowProtectedBranch: true,
+    bundleFunction: neonctlBundler,
+  });
+  const changes = result.applied.filter((c) => c.action !== 'noop');
+  if (changes.length === 0) {
+    log.info('neon.ts applied — no changes were needed.');
+    return;
+  }
+  log.info(
+    'neon.ts applied — %d change%s: %s',
+    changes.length,
+    changes.length === 1 ? '' : 's',
+    changes.map((c) => `${c.action} ${c.identifier}`).join(', '),
+  );
+};

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,0 +1,30 @@
+import yargs from 'yargs';
+
+import { fillSingleProject } from '../utils/enrichers.js';
+import { applyCmd, applyFlags, type ConfigProps } from './config.js';
+
+export const command = 'deploy';
+export const describe =
+  'Apply a neon.ts policy to a branch (alias for `config apply`)';
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 deploy [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+      config: {
+        describe: 'Path to a neon.ts policy (defaults to walking up from cwd)',
+        type: 'string',
+      },
+      ...applyFlags,
+    })
+    .middleware(fillSingleProject as any)
+    .strict();
+
+export const handler = (props: ConfigProps) => applyCmd(props);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs';
 
 import { fillSingleProject } from '../utils/enrichers.js';
-import { applyCmd, applyFlags, type ConfigProps } from './config.js';
+import { applyCmd, applyFlags, envFlag, type ConfigProps } from './config.js';
 
 export const command = 'deploy';
 export const describe =
@@ -22,6 +22,7 @@ export const builder = (argv: yargs.Argv) =>
         describe: 'Path to a neon.ts policy (defaults to walking up from cwd)',
         type: 'string',
       },
+      ...envFlag,
       ...applyFlags,
     })
     .middleware(fillSingleProject as any)

--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -4,8 +4,28 @@ import { describe } from 'vitest';
 import { test } from '../test_utils/fixtures';
 
 describe('dev', () => {
-  test('exits 1 when --source is missing', async ({ testCliCommand }) => {
-    await testCliCommand(['dev'], { code: 1 });
+  test('exits 1 when no --source and no neon.ts is found', async ({
+    testCliCommand,
+  }) => {
+    // Runs in the repo root, which has no neon.ts: nothing to serve.
+    await testCliCommand(['dev'], {
+      code: 1,
+      stderr:
+        'ERROR: No --source given and no neon.ts found. Pass --source <path> ' +
+        'to run a single function, or add a neon.ts that declares functions ' +
+        'under `preview.functions`.',
+    });
+  });
+
+  test('exits 1 when --port is given without --source', async ({
+    testCliCommand,
+  }) => {
+    await testCliCommand(['dev', '--port', '3000'], {
+      code: 1,
+      stderr:
+        'ERROR: --port can only be used with --source. To set ports for the ' +
+        'functions in neon.ts, give each one a `dev.port` in its config.',
+    });
   });
 
   test('exits 1 when --source points at a file that does not exist', async ({

--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -1,0 +1,17 @@
+import { join } from 'node:path';
+import { describe } from 'vitest';
+
+import { test } from '../test_utils/fixtures';
+
+describe('dev', () => {
+  test('exits 1 when --source is missing', async ({ testCliCommand }) => {
+    await testCliCommand(['dev'], { code: 1 });
+  });
+
+  test('exits 1 when --source points at a file that does not exist', async ({
+    testCliCommand,
+  }) => {
+    const missing = join(process.cwd(), 'does-not-exist.ts');
+    await testCliCommand(['dev', '--source', missing], { code: 1 });
+  });
+});

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,0 +1,458 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import chalk from 'chalk';
+import yargs from 'yargs';
+
+import { log } from '../log.js';
+import { bundleEntry } from '../utils/esbuild.js';
+import { resolveDevEnv } from '../dev/env.js';
+import { resolveWatchInputs } from '../dev/inputs.js';
+import { branchIdResolve } from '../utils/enrichers.js';
+import type { CommonProps } from '../types.js';
+
+type DevProps = CommonProps & {
+  source: string;
+  port?: number;
+  projectId?: string;
+  branch?: string;
+  id?: string;
+};
+
+export const command = 'dev';
+export const describe = 'Run a Neon Function locally with a dev server';
+
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 dev --source <path> [options]')
+    .example(
+      '$0 dev --source ./functions/hello.ts',
+      'Serve one function on a free port with hot reload',
+    )
+    .example(
+      '$0 dev --source ./functions/hello.ts --port 3000',
+      'Serve on an explicit port (fails if the port is taken)',
+    )
+    .example(
+      'portless run $0 dev --source ./functions/hello.ts',
+      'Serve through portless (honors the injected PORT)',
+    )
+    .options({
+      source: {
+        describe: 'Path to the function entry module',
+        type: 'string',
+        demandOption: true,
+      },
+      port: {
+        describe:
+          'Port to listen on. Fails if taken. Without it (and without a ' +
+          'PORT env var) a free port is chosen automatically.',
+        type: 'number',
+      },
+    })
+    .strict();
+
+export const handler = async (props: DevProps): Promise<void> => {
+  const source = resolve(process.cwd(), props.source);
+  if (!existsSync(source)) {
+    throw new Error(`Source file not found: ${source}`);
+  }
+
+  const neonEnv = await resolveNeonEnv(props);
+  const childEnv = buildChildEnv(props.port, neonEnv);
+
+  await runDevServer({
+    source,
+    cwd: process.cwd(),
+    runtimePath: resolveRuntimePath(),
+    childEnv,
+  });
+};
+
+/**
+ * Resolve the branch's Neon env vars to inject (see {@link resolveDevEnv}).
+ * Requires an authenticated API client; without one (no credentials), env
+ * injection is silently skipped so the function still runs locally.
+ */
+const resolveNeonEnv = async (
+  props: DevProps,
+): Promise<Record<string, string>> => {
+  if (!props.apiClient || !props.projectId) {
+    log.debug('dev: no API client / project context; skipping env injection');
+    return resolveDevEnv({ cwd: process.cwd() });
+  }
+
+  let branchId: string | undefined;
+  try {
+    const branch = props.branch ?? props.id;
+    branchId = branch
+      ? await branchIdResolve({
+          branch,
+          apiClient: props.apiClient,
+          projectId: props.projectId,
+        })
+      : undefined;
+  } catch (err) {
+    log.debug(
+      'dev: could not resolve branch id: %s',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  return resolveDevEnv({
+    cwd: process.cwd(),
+    projectId: props.projectId,
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+  });
+};
+
+const DEFAULT_PORT_BASE = 8787;
+
+/**
+ * Build the child env. The Neon vars layer over the inherited environment (so
+ * the branch's DATABASE_URL wins over a stale inherited value); a function that
+ * loads its own `.env` at runtime still overrides them. Port resolution:
+ *   1. `--port`              -> explicit, fail if taken
+ *   2. `PORT` env (portless) -> explicit, fail if taken
+ *   3. neither               -> search upward from the default base, never fail
+ */
+const buildChildEnv = (
+  port: number | undefined,
+  neonEnv: Record<string, string>,
+): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...neonEnv };
+  delete env.NEON_DEV_PORT;
+  delete env.NEON_DEV_PORT_BASE;
+
+  if (port !== undefined) {
+    env.NEON_DEV_PORT = String(port);
+    return env;
+  }
+  if (process.env.PORT !== undefined && process.env.PORT !== '') {
+    env.NEON_DEV_PORT = process.env.PORT;
+    return env;
+  }
+  env.NEON_DEV_PORT_BASE = String(DEFAULT_PORT_BASE);
+  return env;
+};
+
+type DevServerOptions = {
+  source: string;
+  cwd: string;
+  runtimePath: string;
+  childEnv: NodeJS.ProcessEnv;
+};
+
+const READY_PATTERN = /neon-dev:ready (\d+)/;
+
+const runDevServer = async (options: DevServerOptions): Promise<void> => {
+  let child: ChildProcess | null = null;
+  let boundPort: number | null = null;
+  let shuttingDown = false;
+  let restartTimer: NodeJS.Timeout | null = null;
+  let everReady = false;
+  let watcher: Watcher | null = null;
+
+  // The bundle and its module resolution root live under the user's
+  // node_modules so the function's npm deps (left external by the bundler)
+  // resolve at runtime. Cleaned up on shutdown.
+  const bundleDir = join(options.cwd, 'node_modules', '.neon-dev');
+
+  const bundleAndStart = async (): Promise<number | null> => {
+    let bundlePath: string;
+    try {
+      bundlePath = await writeBundle(options.source, bundleDir);
+    } catch (err) {
+      log.error(
+        'Failed to bundle %s:\n%s',
+        options.source,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+
+    // Re-sync the watch set after every (re)bundle: imports can be added or
+    // removed between edits, so the precise input list shifts over time.
+    if (watcher) await watcher.sync();
+
+    const next = spawn(process.execPath, [options.runtimePath, bundlePath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: options.childEnv,
+    });
+    child = next;
+
+    const ready = waitForReady(next);
+    pipeChildOutput(next);
+
+    next.on('exit', (code, signal) => {
+      if (shuttingDown || child !== next) return;
+      if (signal) {
+        log.debug('runtime exited via %s', signal);
+        return;
+      }
+      if (code && code !== 0 && everReady) {
+        log.error('Function exited with code %d (waiting for a change)', code);
+      }
+    });
+
+    const port = await ready;
+    if (port !== null) {
+      boundPort = port;
+      everReady = true;
+    }
+    return port;
+  };
+
+  const restart = (): void => {
+    if (shuttingDown) return;
+    if (restartTimer) clearTimeout(restartTimer);
+    restartTimer = setTimeout(() => {
+      void (async () => {
+        log.info(chalk.dim('Change detected, restarting…'));
+        if (child) await killChild(child);
+        if (shuttingDown) return;
+        const port = await bundleAndStart();
+        if (port !== null) {
+          log.info(chalk.green('Ready') + ` ${urlFor(port)}`);
+        }
+      })();
+    }, 150);
+  };
+
+  // Create the watcher before the first bundle so `bundleAndStart` can sync the
+  // watch set on every run (including the initial one).
+  watcher = await startWatcher(options.source, restart);
+
+  const initialPort = await bundleAndStart();
+  if (initialPort === null) {
+    await watcher.close();
+    throw new Error(
+      'The function failed to start. See the output above for details.',
+    );
+  }
+  printBanner(options.source, boundPort);
+
+  const activeWatcher = watcher;
+  await new Promise<void>((resolveRun) => {
+    const shutdown = (): void => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      if (restartTimer) clearTimeout(restartTimer);
+      void (async () => {
+        await activeWatcher.close();
+        if (child) await killChild(child);
+        rmSync(bundleDir, { recursive: true, force: true });
+        log.info(chalk.dim('Stopped the dev server.'));
+        resolveRun();
+      })();
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+  });
+};
+
+/**
+ * Bundle the source with the shared esbuild helper and write the output into
+ * `bundleDir` (under the user's node_modules so external deps resolve). Returns
+ * the path to the bundled entry.
+ */
+const writeBundle = async (
+  source: string,
+  bundleDir: string,
+): Promise<string> => {
+  const files = await bundleEntry(source);
+  mkdirSync(bundleDir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(bundleDir, name), contents);
+  }
+  return join(bundleDir, 'out.js');
+};
+
+const urlFor = (port: number): string => `http://localhost:${port}`;
+
+const waitForReady = (child: ChildProcess): Promise<number | null> =>
+  new Promise<number | null>((resolveReady) => {
+    let settled = false;
+    let buffer = '';
+    const onData = (chunk: Buffer): void => {
+      buffer += chunk.toString();
+      const match = READY_PATTERN.exec(buffer);
+      if (match && !settled) {
+        settled = true;
+        child.stdout?.off('data', onData);
+        resolveReady(Number(match[1]));
+      }
+    };
+    child.stdout?.on('data', onData);
+    child.once('exit', () => {
+      if (!settled) {
+        settled = true;
+        resolveReady(null);
+      }
+    });
+  });
+
+/**
+ * Forward the child's stdout/stderr to the parent, swallowing the
+ * machine-readable `neon-dev:ready` line.
+ */
+const pipeChildOutput = (child: ChildProcess): void => {
+  const forward = (stream: 'stdout' | 'stderr'): void => {
+    let buffer = '';
+    child[stream]?.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (READY_PATTERN.test(line)) continue;
+        process[stream].write(`${line}\n`);
+      }
+    });
+  };
+  forward('stdout');
+  forward('stderr');
+};
+
+const printBanner = (source: string, boundPort: number | null): void => {
+  log.info('');
+  log.info(chalk.green.bold('  Neon Functions dev server'));
+  log.info('');
+  const url = boundPort === null ? chalk.red('not running') : urlFor(boundPort);
+  log.info(`  ${chalk.dim('URL')}     ${url}`);
+  log.info(`  ${chalk.dim('Source')}  ${source}`);
+  log.info('');
+};
+
+type Watcher = {
+  /** Re-derive the watch set and add/remove files to match. */
+  sync: () => Promise<void>;
+  close: () => Promise<void>;
+};
+
+const startWatcher = async (
+  source: string,
+  restart: () => void,
+): Promise<Watcher> => {
+  // chokidar is bundled with neonctl; import lazily to keep startup cheap.
+  const { default: chokidar } = await import('chokidar');
+
+  // Precise input watching: watch exactly the files esbuild reads to build the
+  // bundle (entry + every local import) so a single edit triggers exactly one
+  // rebuild. Falls back to directory watching when the input set is unavailable
+  // (packaged binary / esbuild module won't load); `null` signals that case.
+  const initialInputs = await resolveWatchInputs(source);
+
+  if (initialInputs === null) {
+    return startDirectoryWatcher(chokidar, source, restart);
+  }
+  return startInputWatcher(chokidar, source, initialInputs, restart);
+};
+
+type Chokidar = typeof import('chokidar').default;
+
+/**
+ * Watch a precise set of files (the bundle's inputs). `sync` re-derives the set
+ * after each rebuild — adding newly-imported files and unwatching removed ones —
+ * because the import graph can change between edits.
+ */
+const startInputWatcher = async (
+  chokidar: Chokidar,
+  source: string,
+  initialInputs: string[],
+  restart: () => void,
+): Promise<Watcher> => {
+  // Always keep the entry watched even if a transient bundle failure drops it
+  // from the input set, so edits that fix the error are still detected.
+  const watched = new Set<string>([source, ...initialInputs]);
+  const watcher = chokidar.watch([...watched], { ignoreInitial: true });
+  await once(watcher, 'ready');
+  watcher.on('all', () => {
+    restart();
+  });
+
+  const sync = async (): Promise<void> => {
+    const next = await resolveWatchInputs(source);
+    // A failed/unavailable re-resolve keeps the current set rather than dropping
+    // everything — the next successful rebuild re-syncs it.
+    if (next === null) return;
+    const desired = new Set<string>([source, ...next]);
+    for (const file of desired) {
+      if (!watched.has(file)) {
+        watcher.add(file);
+        watched.add(file);
+      }
+    }
+    for (const file of watched) {
+      if (!desired.has(file)) {
+        watcher.unwatch(file);
+        watched.delete(file);
+      }
+    }
+  };
+
+  return { sync, close: () => watcher.close() };
+};
+
+/**
+ * Fallback when the precise input set is unavailable: watch the source's
+ * directory. `ignored` is a path predicate (chokidar 5) matching on path
+ * *segments* (not a substring like '/node_modules/') so the bare `node_modules`
+ * directory event emitted when we write our bundle into node_modules/.neon-dev
+ * is also ignored — otherwise it triggers an endless rebuild loop.
+ */
+const startDirectoryWatcher = async (
+  chokidar: Chokidar,
+  source: string,
+  restart: () => void,
+): Promise<Watcher> => {
+  const watchedDir = dirname(source);
+  const isIgnored = (p: string): boolean => {
+    const segments = p.split(/[/\\]/);
+    return (
+      segments.includes('node_modules') ||
+      segments.includes('.git') ||
+      segments.includes('dist')
+    );
+  };
+  const watcher = chokidar.watch(watchedDir, {
+    ignoreInitial: true,
+    ignored: (path: string) => isIgnored(path),
+  });
+  await once(watcher, 'ready');
+  watcher.on('all', () => {
+    restart();
+  });
+  return { sync: () => Promise.resolve(), close: () => watcher.close() };
+};
+
+const killChild = (child: ChildProcess): Promise<void> => {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolveKill) => {
+    const timeout = setTimeout(() => child.kill('SIGKILL'), 2000);
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      resolveKill();
+    });
+    child.kill('SIGTERM');
+  });
+};
+
+/**
+ * Locate the compiled runtime entry (`dist/dev/runtime.js`) relative to this
+ * module (`dist/commands/dev.js`). Run in place by a plain `node` child, which
+ * resolves the runtime's own imports (e.g. `@hono/node-server`) from neonctl's
+ * node_modules.
+ */
+const resolveRuntimePath = (): string => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidate = join(here, '..', 'dev', 'runtime.js');
+  if (!existsSync(candidate)) {
+    throw new Error(`Could not locate the dev runtime at ${candidate}`);
+  }
+  return candidate;
+};

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -9,12 +9,16 @@ import yargs from 'yargs';
 import { log } from '../log.js';
 import { bundleEntry } from '../utils/esbuild.js';
 import { resolveDevEnv } from '../dev/env.js';
+import {
+  resolveFunctionsFromConfig,
+  type PlannedFunction,
+} from '../dev/functions.js';
 import { resolveWatchInputs } from '../dev/inputs.js';
 import { branchIdResolve } from '../utils/enrichers.js';
 import type { CommonProps } from '../types.js';
 
 type DevProps = CommonProps & {
-  source: string;
+  source?: string;
   port?: number;
   projectId?: string;
   branch?: string;
@@ -22,229 +26,376 @@ type DevProps = CommonProps & {
 };
 
 export const command = 'dev';
-export const describe = 'Run a Neon Function locally with a dev server';
+export const describe = 'Run Neon Functions locally with a dev server';
 
 export const builder = (argv: yargs.Argv) =>
   argv
-    .usage('$0 dev --source <path> [options]')
+    .usage('$0 dev [--source <path>] [options]')
     .example(
       '$0 dev --source ./functions/hello.ts',
       'Serve one function on a free port with hot reload',
     )
     .example(
-      '$0 dev --source ./functions/hello.ts --port 3000',
-      'Serve on an explicit port (fails if the port is taken)',
+      '$0 dev',
+      'Serve every function declared in neon.ts (one dev server each)',
     )
     .example(
-      'portless run $0 dev --source ./functions/hello.ts',
-      'Serve through portless (honors the injected PORT)',
+      '$0 dev --source ./functions/hello.ts --port 3000',
+      'Serve one function on an explicit port (fails if the port is taken)',
     )
     .options({
       source: {
-        describe: 'Path to the function entry module',
+        describe:
+          'Path to a single function entry module. Omit to serve every ' +
+          'function declared in neon.ts.',
         type: 'string',
-        demandOption: true,
       },
       port: {
         describe:
-          'Port to listen on. Fails if taken. Without it (and without a ' +
-          'PORT env var) a free port is chosen automatically.',
+          'Port to listen on (single-function mode only, with --source). ' +
+          'Fails if taken. Without it (and without a PORT env var) a free ' +
+          'port is chosen automatically.',
         type: 'number',
       },
     })
     .strict();
 
 export const handler = async (props: DevProps): Promise<void> => {
-  const source = resolve(process.cwd(), props.source);
+  if (props.source !== undefined) {
+    await runSingleSource(props);
+    return;
+  }
+
+  // No --source: --port has no single target to bind, so reject it explicitly
+  // rather than silently ignoring it.
+  if (props.port !== undefined) {
+    throw new Error(
+      '--port can only be used with --source. To set ports for the functions ' +
+        'in neon.ts, give each one a `dev.port` in its config.',
+    );
+  }
+
+  await runFromConfig(props);
+};
+
+/** Single-function mode: serve exactly the `--source` path (legacy behavior). */
+const runSingleSource = async (props: DevProps): Promise<void> => {
+  const source = resolve(process.cwd(), props.source as string);
   if (!existsSync(source)) {
     throw new Error(`Source file not found: ${source}`);
   }
 
-  const neonEnv = await resolveNeonEnv(props);
-  const childEnv = buildChildEnv(props.port, neonEnv);
-
-  await runDevServer({
-    source,
+  const branchId = await resolveBranchId(props);
+  const neonEnv = await resolveDevEnv({
     cwd: process.cwd(),
-    runtimePath: resolveRuntimePath(),
-    childEnv,
+    ...(props.projectId ? { projectId: props.projectId } : {}),
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
   });
+
+  const unit: ServedUnit = {
+    slug: null,
+    source,
+    bundleDir: join(process.cwd(), 'node_modules', '.neon-dev'),
+    childEnv: buildChildEnv(neonEnv, portFromProps(props.port)),
+    label: null,
+  };
+
+  await runSupervisor([unit]);
 };
 
 /**
- * Resolve the branch's Neon env vars to inject (see {@link resolveDevEnv}).
- * Requires an authenticated API client; without one (no credentials), env
- * injection is silently skipped so the function still runs locally.
+ * Multi-function mode: serve every function declared in neon.ts. Requires a neon.ts
+ * (there is no single source to fall back on), one dev server per function.
  */
-const resolveNeonEnv = async (
-  props: DevProps,
-): Promise<Record<string, string>> => {
-  if (!props.apiClient || !props.projectId) {
-    log.debug('dev: no API client / project context; skipping env injection');
-    return resolveDevEnv({ cwd: process.cwd() });
+const runFromConfig = async (props: DevProps): Promise<void> => {
+  const branchId = await resolveBranchId(props);
+  const functions = await resolveFunctionsFromConfig(process.cwd());
+
+  if (functions === null) {
+    throw new Error(
+      'No --source given and no neon.ts found. Pass --source <path> to run a ' +
+        'single function, or add a neon.ts that declares functions under ' +
+        '`preview.functions`.',
+    );
+  }
+  if (functions.length === 0) {
+    throw new Error(
+      'neon.ts has no functions to serve. Add at least one under ' +
+        '`preview.functions`, or pass --source <path>.',
+    );
   }
 
-  let branchId: string | undefined;
+  const neonEnv = await resolveDevEnv({
+    cwd: process.cwd(),
+    ...(props.projectId ? { projectId: props.projectId } : {}),
+    ...(branchId ? { branchId } : {}),
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+  });
+
+  // Give each search-mode (no dev.port, non-portless) function a distinct search base so
+  // they don't all start probing at the same port. The runtime still walks upward from its
+  // base, so an occupied base self-resolves; the offset just makes startup deterministic.
+  let searchOffset = 0;
+  const units = functions.map((fn) => {
+    const base = DEFAULT_PORT_BASE + searchOffset;
+    if (!fn.portless && fn.port === undefined) searchOffset += 1;
+    return plannedToUnit(fn, neonEnv, base);
+  });
+  await runSupervisor(units);
+};
+
+/**
+ * Resolve the selected branch id from props, if any. Best-effort: a failure here only
+ * means env injection is skipped, so it never throws.
+ */
+const resolveBranchId = async (
+  props: DevProps,
+): Promise<string | undefined> => {
+  if (!props.apiClient || !props.projectId) return undefined;
+  const branch = props.branch ?? props.id;
+  if (!branch) return undefined;
   try {
-    const branch = props.branch ?? props.id;
-    branchId = branch
-      ? await branchIdResolve({
-          branch,
-          apiClient: props.apiClient,
-          projectId: props.projectId,
-        })
-      : undefined;
+    return await branchIdResolve({
+      branch,
+      apiClient: props.apiClient,
+      projectId: props.projectId,
+    });
   } catch (err) {
     log.debug(
       'dev: could not resolve branch id: %s',
       err instanceof Error ? err.message : String(err),
     );
+    return undefined;
   }
-
-  return resolveDevEnv({
-    cwd: process.cwd(),
-    projectId: props.projectId,
-    ...(branchId ? { branchId } : {}),
-    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
-  });
 };
 
 const DEFAULT_PORT_BASE = 8787;
 
+type PortSpec =
+  // Bind exactly this port (fail if taken) via NEON_DEV_PORT.
+  | { mode: 'explicit'; port: number }
+  // Search upward from `from` via NEON_DEV_PORT_BASE.
+  | { mode: 'search'; from: number }
+  // Set no port env at all — let an injected PORT (portless) drive the runtime.
+  | { mode: 'inherit' };
+
+const portFromProps = (port: number | undefined): PortSpec => {
+  if (port !== undefined) return { mode: 'explicit', port };
+  if (process.env.PORT !== undefined && process.env.PORT !== '') {
+    return { mode: 'explicit', port: Number(process.env.PORT) };
+  }
+  return { mode: 'search', from: DEFAULT_PORT_BASE };
+};
+
 /**
- * Build the child env. The Neon vars layer over the inherited environment (so
- * the branch's DATABASE_URL wins over a stale inherited value); a function that
- * loads its own `.env` at runtime still overrides them. Port resolution:
- *   1. `--port`              -> explicit, fail if taken
- *   2. `PORT` env (portless) -> explicit, fail if taken
- *   3. neither               -> search upward from the default base, never fail
+ * Translate a {@link PlannedFunction} into a {@link ServedUnit}. Port rules:
+ *   - portless: portless assigns the port and injects PORT, which the runtime honors — so
+ *     we set no port env (`inherit`) and `dev.port` is ignored. Wrapped with
+ *     `portless <slug>` for a stable `slug.localhost` URL.
+ *   - explicit `dev.port`: bind exactly, fail if taken.
+ *   - no `dev.port`: search for a free port (base coordinated by the caller).
+ * Per-function neon.ts env layers over the shared branch env.
+ */
+const plannedToUnit = (
+  fn: PlannedFunction,
+  branchEnv: Record<string, string>,
+  searchBase: number,
+): ServedUnit => {
+  const port: PortSpec = fn.portless
+    ? { mode: 'inherit' }
+    : fn.port !== undefined
+      ? { mode: 'explicit', port: fn.port }
+      : { mode: 'search', from: searchBase };
+  const childEnv = buildChildEnv({ ...branchEnv, ...fn.env }, port);
+  return {
+    slug: fn.slug,
+    source: fn.source,
+    bundleDir: join(process.cwd(), 'node_modules', '.neon-dev', fn.slug),
+    childEnv,
+    label: fn.slug,
+    ...(fn.portless ? { portless: { slug: fn.slug } } : {}),
+  };
+};
+
+/**
+ * Build a child's env. Neon vars layer over the inherited environment (so the branch's
+ * DATABASE_URL wins over a stale inherited value); a function that loads its own `.env`
+ * at runtime still overrides them. The port spec is encoded for the runtime via
+ * NEON_DEV_PORT (explicit) or NEON_DEV_PORT_BASE (search).
  */
 const buildChildEnv = (
-  port: number | undefined,
   neonEnv: Record<string, string>,
+  port: PortSpec,
 ): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = { ...process.env, ...neonEnv };
   delete env.NEON_DEV_PORT;
   delete env.NEON_DEV_PORT_BASE;
-
-  if (port !== undefined) {
-    env.NEON_DEV_PORT = String(port);
-    return env;
+  if (port.mode === 'explicit') {
+    env.NEON_DEV_PORT = String(port.port);
+  } else if (port.mode === 'search') {
+    env.NEON_DEV_PORT_BASE = String(port.from);
   }
-  if (process.env.PORT !== undefined && process.env.PORT !== '') {
-    env.NEON_DEV_PORT = process.env.PORT;
-    return env;
-  }
-  env.NEON_DEV_PORT_BASE = String(DEFAULT_PORT_BASE);
+  // 'inherit': set neither, so an injected PORT (portless) drives the runtime.
   return env;
 };
 
-type DevServerOptions = {
+/**
+ * One function being served locally. `slug`/`label` are null in single-source mode
+ * (one unnamed server). `portless`, when set, wraps the child with `portless run`.
+ */
+type ServedUnit = {
+  slug: string | null;
   source: string;
-  cwd: string;
-  runtimePath: string;
+  bundleDir: string;
   childEnv: NodeJS.ProcessEnv;
+  label: string | null;
+  portless?: { slug: string };
+};
+
+type RunningUnit = {
+  unit: ServedUnit;
+  child: ChildProcess | null;
+  boundPort: number | null;
+  everReady: boolean;
+  restartTimer: NodeJS.Timeout | null;
+  watcher: Watcher | null;
+  status: 'starting' | 'ready' | 'error';
 };
 
 const READY_PATTERN = /neon-dev:ready (\d+)/;
 
-const runDevServer = async (options: DevServerOptions): Promise<void> => {
-  let child: ChildProcess | null = null;
-  let boundPort: number | null = null;
+/**
+ * Supervise one or more {@link ServedUnit}s: bundle + start each in its own child, watch
+ * its inputs for hot reload, and tear everything down cleanly on shutdown. Units are
+ * independent — one crashing or failing to start does not stop the others (it is shown
+ * as errored and recovered on the next edit). A single SIGINT/SIGTERM shuts all of them
+ * down, tree-killing each child so no descendant (e.g. a portless-wrapped runtime) is
+ * orphaned.
+ */
+const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
+  if (hasPortlessUnit(units)) {
+    assertPortlessAvailable();
+  }
+
+  const runtimePath = resolveRuntimePath();
   let shuttingDown = false;
-  let restartTimer: NodeJS.Timeout | null = null;
-  let everReady = false;
-  let watcher: Watcher | null = null;
 
-  // The bundle and its module resolution root live under the user's
-  // node_modules so the function's npm deps (left external by the bundler)
-  // resolve at runtime. Cleaned up on shutdown.
-  const bundleDir = join(options.cwd, 'node_modules', '.neon-dev');
+  const running: RunningUnit[] = units.map((unit) => ({
+    unit,
+    child: null,
+    boundPort: null,
+    everReady: false,
+    restartTimer: null,
+    watcher: null,
+    status: 'starting',
+  }));
 
-  const bundleAndStart = async (): Promise<number | null> => {
+  const bundleAndStart = async (r: RunningUnit): Promise<void> => {
     let bundlePath: string;
     try {
-      bundlePath = await writeBundle(options.source, bundleDir);
+      bundlePath = await writeBundle(r.unit.source, r.unit.bundleDir);
     } catch (err) {
-      log.error(
-        'Failed to bundle %s:\n%s',
-        options.source,
-        err instanceof Error ? err.message : String(err),
+      r.status = 'error';
+      logUnit(
+        r.unit,
+        chalk.red('bundle failed: ') +
+          (err instanceof Error ? err.message : String(err)),
       );
-      return null;
+      return;
     }
 
-    // Re-sync the watch set after every (re)bundle: imports can be added or
-    // removed between edits, so the precise input list shifts over time.
-    if (watcher) await watcher.sync();
+    if (r.watcher) await r.watcher.sync();
 
-    const next = spawn(process.execPath, [options.runtimePath, bundlePath], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: options.childEnv,
-    });
-    child = next;
+    const next = spawnChild(r.unit, runtimePath, bundlePath);
+    r.child = next;
 
     const ready = waitForReady(next);
-    pipeChildOutput(next);
+    pipeChildOutput(next, r.unit.label);
 
     next.on('exit', (code, signal) => {
-      if (shuttingDown || child !== next) return;
+      if (shuttingDown || r.child !== next) return;
       if (signal) {
-        log.debug('runtime exited via %s', signal);
+        log.debug(
+          'runtime for %s exited via %s',
+          r.unit.slug ?? '(source)',
+          signal,
+        );
         return;
       }
-      if (code && code !== 0 && everReady) {
-        log.error('Function exited with code %d (waiting for a change)', code);
+      if (code && code !== 0 && r.everReady) {
+        r.status = 'error';
+        logUnit(
+          r.unit,
+          chalk.red(`exited with code ${code} (waiting for a change)`),
+        );
       }
     });
 
     const port = await ready;
     if (port !== null) {
-      boundPort = port;
-      everReady = true;
+      r.boundPort = port;
+      r.everReady = true;
+      r.status = 'ready';
+    } else {
+      r.status = 'error';
     }
-    return port;
   };
 
-  const restart = (): void => {
+  const restart = (r: RunningUnit): void => {
     if (shuttingDown) return;
-    if (restartTimer) clearTimeout(restartTimer);
-    restartTimer = setTimeout(() => {
+    if (r.restartTimer) clearTimeout(r.restartTimer);
+    r.restartTimer = setTimeout(() => {
       void (async () => {
-        log.info(chalk.dim('Change detected, restarting…'));
-        if (child) await killChild(child);
+        logUnit(r.unit, chalk.dim('change detected, restarting…'));
+        if (r.child) await killTree(r.child);
         if (shuttingDown) return;
-        const port = await bundleAndStart();
-        if (port !== null) {
-          log.info(chalk.green('Ready') + ` ${urlFor(port)}`);
+        await bundleAndStart(r);
+        if (r.status === 'ready') {
+          logUnit(r.unit, chalk.green('ready') + ` ${urlFor(r.boundPort)}`);
         }
       })();
     }, 150);
   };
 
-  // Create the watcher before the first bundle so `bundleAndStart` can sync the
+  // Create each watcher before its first bundle so bundleAndStart can sync the
   // watch set on every run (including the initial one).
-  watcher = await startWatcher(options.source, restart);
-
-  const initialPort = await bundleAndStart();
-  if (initialPort === null) {
-    await watcher.close();
-    throw new Error(
-      'The function failed to start. See the output above for details.',
-    );
+  for (const r of running) {
+    r.watcher = await startWatcher(r.unit.source, () => {
+      restart(r);
+    });
   }
-  printBanner(options.source, boundPort);
 
-  const activeWatcher = watcher;
+  // Start every unit. They are independent: keep going if one fails.
+  await Promise.all(running.map((r) => bundleAndStart(r)));
+
+  if (running.every((r) => r.status === 'error')) {
+    await Promise.all(running.map((r) => r.watcher?.close()));
+    await Promise.all(
+      running.map((r) => (r.child ? killTree(r.child) : undefined)),
+    );
+    for (const r of running)
+      rmSync(r.unit.bundleDir, { recursive: true, force: true });
+    throw new Error('No function started. See the output above for details.');
+  }
+
+  printBanner(running);
+
   await new Promise<void>((resolveRun) => {
     const shutdown = (): void => {
       if (shuttingDown) return;
       shuttingDown = true;
-      if (restartTimer) clearTimeout(restartTimer);
       void (async () => {
-        await activeWatcher.close();
-        if (child) await killChild(child);
-        rmSync(bundleDir, { recursive: true, force: true });
+        for (const r of running) {
+          if (r.restartTimer) clearTimeout(r.restartTimer);
+        }
+        await Promise.all(running.map((r) => r.watcher?.close()));
+        await Promise.all(
+          running.map((r) => (r.child ? killTree(r.child) : undefined)),
+        );
+        for (const r of running) {
+          rmSync(r.unit.bundleDir, { recursive: true, force: true });
+        }
         log.info(chalk.dim('Stopped the dev server.'));
         resolveRun();
       })();
@@ -254,11 +405,64 @@ const runDevServer = async (options: DevServerOptions): Promise<void> => {
   });
 };
 
+const hasPortlessUnit = (units: ServedUnit[]): boolean =>
+  units.some((u) => u.portless !== undefined);
+
 /**
- * Bundle the source with the shared esbuild helper and write the output into
- * `bundleDir` (under the user's node_modules so external deps resolve). Returns
- * the path to the bundled entry.
+ * Spawn the child for a unit. A portless unit is wrapped as `portless <slug> node
+ * <runtime> <bundle>`: portless assigns a port, injects it as PORT (which the runtime
+ * honors), and exposes the server at `slug.localhost`. A plain unit runs the bundled
+ * output directly under `node`.
+ *
+ * Spawned detached (own process group) so killTree can reap the whole group — important
+ * for the portless case, where the tree is portless -> node runtime.
  */
+const spawnChild = (
+  unit: ServedUnit,
+  runtimePath: string,
+  bundlePath: string,
+): ChildProcess => {
+  if (unit.portless) {
+    return spawn(
+      'portless',
+      [unit.portless.slug, process.execPath, runtimePath, bundlePath],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: unit.childEnv,
+        detached: true,
+      },
+    );
+  }
+  return spawn(process.execPath, [runtimePath, bundlePath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: unit.childEnv,
+    detached: true,
+  });
+};
+
+/** Fail early with an actionable message if a portless unit is requested but the binary is missing. */
+const assertPortlessAvailable = (): void => {
+  const result = spawnSyncCheck('portless');
+  if (!result) {
+    throw new Error(
+      'A function sets `dev.portless: true`, but the `portless` command was not ' +
+        'found on your PATH. Install it globally (e.g. `npm i -g portless`) or ' +
+        'remove `dev.portless` from the function in neon.ts.',
+    );
+  }
+};
+
+const spawnSyncCheck = (bin: string): boolean => {
+  try {
+    // Synchronous, no-side-effect probe: `which`/`where` resolves the binary.
+    const probe = process.platform === 'win32' ? 'where' : 'which';
+    const { status } = spawnSync(probe, [bin]);
+    return status === 0;
+  } catch {
+    return false;
+  }
+};
+
 const writeBundle = async (
   source: string,
   bundleDir: string,
@@ -271,7 +475,8 @@ const writeBundle = async (
   return join(bundleDir, 'out.js');
 };
 
-const urlFor = (port: number): string => `http://localhost:${port}`;
+const urlFor = (port: number | null): string =>
+  port === null ? chalk.red('not running') : `http://localhost:${port}`;
 
 const waitForReady = (child: ChildProcess): Promise<number | null> =>
   new Promise<number | null>((resolveReady) => {
@@ -296,10 +501,12 @@ const waitForReady = (child: ChildProcess): Promise<number | null> =>
   });
 
 /**
- * Forward the child's stdout/stderr to the parent, swallowing the
- * machine-readable `neon-dev:ready` line.
+ * Forward the child's stdout/stderr to the parent, swallowing the machine-readable
+ * `neon-dev:ready` line. When `label` is set (multi-function mode), every line is
+ * prefixed with `[slug]` so concurrent servers' output stays readable.
  */
-const pipeChildOutput = (child: ChildProcess): void => {
+const pipeChildOutput = (child: ChildProcess, label: string | null): void => {
+  const prefix = label ? chalk.dim(`[${label}] `) : '';
   const forward = (stream: 'stdout' | 'stderr'): void => {
     let buffer = '';
     child[stream]?.on('data', (chunk: Buffer) => {
@@ -308,7 +515,7 @@ const pipeChildOutput = (child: ChildProcess): void => {
       buffer = lines.pop() ?? '';
       for (const line of lines) {
         if (READY_PATTERN.test(line)) continue;
-        process[stream].write(`${line}\n`);
+        process[stream].write(`${prefix}${line}\n`);
       }
     });
   };
@@ -316,18 +523,24 @@ const pipeChildOutput = (child: ChildProcess): void => {
   forward('stderr');
 };
 
-const printBanner = (source: string, boundPort: number | null): void => {
+const printBanner = (running: RunningUnit[]): void => {
   log.info('');
   log.info(chalk.green.bold('  Neon Functions dev server'));
   log.info('');
-  const url = boundPort === null ? chalk.red('not running') : urlFor(boundPort);
-  log.info(`  ${chalk.dim('URL')}     ${url}`);
-  log.info(`  ${chalk.dim('Source')}  ${source}`);
+  for (const r of running) {
+    const name = r.unit.label ?? 'function';
+    const url = urlFor(r.boundPort);
+    log.info(`  ${chalk.dim(name.padEnd(20))} ${url}`);
+  }
   log.info('');
 };
 
+const logUnit = (unit: ServedUnit, message: string): void => {
+  const prefix = unit.label ? chalk.dim(`[${unit.label}] `) : '';
+  log.info(`${prefix}${message}`);
+};
+
 type Watcher = {
-  /** Re-derive the watch set and add/remove files to match. */
   sync: () => Promise<void>;
   close: () => Promise<void>;
 };
@@ -336,15 +549,8 @@ const startWatcher = async (
   source: string,
   restart: () => void,
 ): Promise<Watcher> => {
-  // chokidar is bundled with neonctl; import lazily to keep startup cheap.
   const { default: chokidar } = await import('chokidar');
-
-  // Precise input watching: watch exactly the files esbuild reads to build the
-  // bundle (entry + every local import) so a single edit triggers exactly one
-  // rebuild. Falls back to directory watching when the input set is unavailable
-  // (packaged binary / esbuild module won't load); `null` signals that case.
   const initialInputs = await resolveWatchInputs(source);
-
   if (initialInputs === null) {
     return startDirectoryWatcher(chokidar, source, restart);
   }
@@ -353,19 +559,12 @@ const startWatcher = async (
 
 type Chokidar = typeof import('chokidar').default;
 
-/**
- * Watch a precise set of files (the bundle's inputs). `sync` re-derives the set
- * after each rebuild — adding newly-imported files and unwatching removed ones —
- * because the import graph can change between edits.
- */
 const startInputWatcher = async (
   chokidar: Chokidar,
   source: string,
   initialInputs: string[],
   restart: () => void,
 ): Promise<Watcher> => {
-  // Always keep the entry watched even if a transient bundle failure drops it
-  // from the input set, so edits that fix the error are still detected.
   const watched = new Set<string>([source, ...initialInputs]);
   const watcher = chokidar.watch([...watched], { ignoreInitial: true });
   await once(watcher, 'ready');
@@ -375,8 +574,6 @@ const startInputWatcher = async (
 
   const sync = async (): Promise<void> => {
     const next = await resolveWatchInputs(source);
-    // A failed/unavailable re-resolve keeps the current set rather than dropping
-    // everything — the next successful rebuild re-syncs it.
     if (next === null) return;
     const desired = new Set<string>([source, ...next]);
     for (const file of desired) {
@@ -396,13 +593,6 @@ const startInputWatcher = async (
   return { sync, close: () => watcher.close() };
 };
 
-/**
- * Fallback when the precise input set is unavailable: watch the source's
- * directory. `ignored` is a path predicate (chokidar 5) matching on path
- * *segments* (not a substring like '/node_modules/') so the bare `node_modules`
- * directory event emitted when we write our bundle into node_modules/.neon-dev
- * is also ignored — otherwise it triggers an endless rebuild loop.
- */
 const startDirectoryWatcher = async (
   chokidar: Chokidar,
   source: string,
@@ -428,26 +618,53 @@ const startDirectoryWatcher = async (
   return { sync: () => Promise.resolve(), close: () => watcher.close() };
 };
 
-const killChild = (child: ChildProcess): Promise<void> => {
+/**
+ * Terminate a child and every descendant it spawned. The child is started `detached`, so
+ * on POSIX it leads its own process group and a negative-PID signal reaps the group
+ * (covering portless -> neonctl -> node). On Windows there are no POSIX groups, so we
+ * shell out to `taskkill /T` to kill the tree. Escalates SIGTERM -> SIGKILL after 2s.
+ */
+const killTree = (child: ChildProcess): Promise<void> => {
   if (child.exitCode !== null || child.signalCode !== null) {
     return Promise.resolve();
   }
+  const pid = child.pid;
   return new Promise<void>((resolveKill) => {
-    const timeout = setTimeout(() => child.kill('SIGKILL'), 2000);
+    const timeout = setTimeout(() => {
+      forceKill(child, pid);
+    }, 2000);
     child.once('exit', () => {
       clearTimeout(timeout);
       resolveKill();
     });
+    if (pid !== undefined && process.platform !== 'win32') {
+      try {
+        process.kill(-pid, 'SIGTERM');
+        return;
+      } catch {
+        // Fall through to a direct kill if the group is already gone.
+      }
+    }
     child.kill('SIGTERM');
   });
 };
 
-/**
- * Locate the compiled runtime entry (`dist/dev/runtime.js`) relative to this
- * module (`dist/commands/dev.js`). Run in place by a plain `node` child, which
- * resolves the runtime's own imports (e.g. `@hono/node-server`) from neonctl's
- * node_modules.
- */
+const forceKill = (child: ChildProcess, pid: number | undefined): void => {
+  if (pid === undefined) {
+    child.kill('SIGKILL');
+    return;
+  }
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(pid), '/T', '/F']);
+    return;
+  }
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+};
+
 const resolveRuntimePath = (): string => {
   const here = dirname(fileURLToPath(import.meta.url));
   const candidate = join(here, '..', 'dev', 'runtime.js');

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -469,6 +469,11 @@ const writeBundle = async (
 ): Promise<string> => {
   const files = await bundleEntry(source);
   mkdirSync(bundleDir, { recursive: true });
+  // The bundle is ESM (`format: 'esm'`), but it's written into a `.js` file under the
+  // user's node_modules — where Node, finding no `"type"`, would treat `.js` as CommonJS
+  // and throw `Unexpected token 'export'`. Drop a `package.json` marker so Node runs it as
+  // ESM. (A bare `out.mjs` would also work but breaks the `out.js.map` sourcemap link.)
+  writeFileSync(join(bundleDir, 'package.json'), '{"type":"module"}\n');
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(join(bundleDir, name), contents);
   }

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -201,10 +201,7 @@ describe('env pull', () => {
 
   it('includes NEON_AUTH_BASE_URL when the branch has Auth enabled', async () => {
     // A neon.ts that enables auth, plus a branch that actually has the integration.
-    writeFileSync(
-      join(cwd, 'neon.ts'),
-      'export default () => ({ auth: {} });\n',
-    );
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
     const api = new FakeNeonApi({
       getNeonAuth: async () => ({
         projectId: 'auth-project',

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -1,0 +1,245 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NeonApi } from '@neondatabase/config';
+import type {
+  GetConnectionUriInput,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import { pull, type EnvPullProps } from './env.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-snowy-frost-12345';
+const BRANCH_NAME = 'main';
+
+type FakeOverrides = {
+  getNeonAuth?: NeonApi['getNeonAuth'];
+};
+
+/**
+ * Minimal {@link NeonApi} for one project + default branch, with the methods `pullConfig`
+ * and `fetchEnv` exercise (env-pull's tier-2 path). Auth defaults to off; override to test
+ * the NEON_AUTH_BASE_URL pull.
+ */
+class FakeNeonApi implements NeonApi {
+  constructor(private readonly overrides: FakeOverrides = {}) {}
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'p',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranches(): Promise<NeonBranchSnapshot[]> {
+    return [
+      { id: BRANCH_ID, name: BRANCH_NAME, isDefault: true, protected: false },
+    ];
+  }
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    const host = input.pooled
+      ? `${BRANCH_ID}-pooler.fake.neon.tech`
+      : `${BRANCH_ID}.fake.neon.tech`;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${host}/${input.databaseName}?sslmode=require`,
+    };
+  }
+  async getNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot | null> {
+    if (this.overrides.getNeonAuth) {
+      return this.overrides.getNeonAuth(projectId, branchId);
+    }
+    return null;
+  }
+  async enableNeonAuth(): Promise<NeonAuthSnapshot> {
+    throw new Error('not implemented');
+  }
+  async getNeonDataApi(): Promise<NeonDataApiSnapshot | null> {
+    return null;
+  }
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+  async createBranchBucket(): Promise<NeonBucketSnapshot> {
+    throw new Error('not implemented');
+  }
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
+    throw new Error('not implemented');
+  }
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async deployBranchFunction(): Promise<NeonFunctionDeploymentSnapshot> {
+    throw new Error('not implemented');
+  }
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+/** Stand-in for the neonctl Api client; only branch resolution is exercised. */
+const fakeApiClient = {
+  listProjectBranches: async () => ({
+    data: {
+      branches: [{ id: BRANCH_ID, name: BRANCH_NAME, default: true }],
+    },
+  }),
+};
+
+const baseProps = (api: FakeNeonApi, cwd: string): EnvPullProps => ({
+  apiClient: fakeApiClient as never,
+  apiKey: '',
+  apiHost: 'https://console.neon.tech/api/v2',
+  contextFile: '',
+  output: 'table',
+  projectId: PROJECT_ID,
+  branch: BRANCH_NAME,
+  cwd,
+  runtimeApi: api,
+});
+
+describe('env pull', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-env-pull-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('writes Neon vars into .env.local when no .env exists', async () => {
+    await pull(baseProps(new FakeNeonApi(), cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    expect(content).toMatch(/^DATABASE_URL=/m);
+    expect(content).toMatch(/^DATABASE_URL_UNPOOLED=/m);
+    expect(content).toContain('-pooler.fake.neon.tech');
+    // Auth is off by default, so NEON_AUTH_BASE_URL is not written.
+    expect(content).not.toContain('NEON_AUTH_BASE_URL');
+  });
+
+  it('includes NEON_AUTH_BASE_URL when the branch has Auth enabled', async () => {
+    // A neon.ts that enables auth, plus a branch that actually has the integration.
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    await pull(baseProps(api, cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    expect(content).toMatch(
+      /^NEON_AUTH_BASE_URL=https:\/\/auth\.fake\.neon\.tech$/m,
+    );
+  });
+
+  it('updates an existing .env in place, preserving other keys', async () => {
+    writeFileSync(
+      join(cwd, '.env'),
+      '# app\nAPP_NAME=demo\nDATABASE_URL=postgres://stale\n',
+    );
+
+    await pull(baseProps(new FakeNeonApi(), cwd));
+
+    // Existing .env is used (not .env.local) and unrelated keys survive.
+    const content = readFileSync(join(cwd, '.env'), 'utf8');
+    expect(content).toContain('# app');
+    expect(content).toContain('APP_NAME=demo');
+    expect(content).toContain('-pooler.fake.neon.tech');
+    expect(content).not.toContain('postgres://stale');
+  });
+
+  it('writes to an explicit --file', async () => {
+    await pull({ ...baseProps(new FakeNeonApi(), cwd), file: '.env.preview' });
+    const content = readFileSync(join(cwd, '.env.preview'), 'utf8');
+    expect(content).toMatch(/^DATABASE_URL=/m);
+  });
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,112 @@
+import yargs from 'yargs';
+
+import { type NeonApi } from '@neondatabase/config';
+import { NEON_ENV_VAR_KEYS } from '@neondatabase/env';
+
+import { log } from '../log.js';
+import { BranchScopeProps } from '../types.js';
+import { resolveNeonEnvVars } from '../dev/env.js';
+import { mergeEnvFile, resolveEnvFilePath } from '../env_file.js';
+import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+
+export type EnvPullProps = BranchScopeProps & {
+  /** Target dotenv file. Defaults to an existing `.env`, else `.env.local`. */
+  file?: string;
+  /** Working directory to resolve neon.ts / write the .env file in. Defaults to cwd (tests). */
+  cwd?: string;
+  /** Injected NeonApi adapter (tests). Production builds it from credentials. */
+  runtimeApi?: NeonApi;
+};
+
+export const command = 'env';
+export const describe = "Manage a branch's Neon env variables locally";
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 env <sub-command> [options]')
+    .options({
+      'project-id': { describe: 'Project ID', type: 'string' },
+      branch: { describe: 'Branch ID or name', type: 'string' },
+    })
+    .middleware(fillSingleProject as any)
+    .command(
+      'pull',
+      "Write the branch's Neon env variables to a local .env file",
+      (yargs) =>
+        yargs
+          .usage('$0 env pull [options]')
+          .options({
+            file: {
+              describe:
+                'Target .env file to write. Defaults to an existing .env, ' +
+                'otherwise .env.local. Only Neon variables are updated; other ' +
+                'lines are preserved.',
+              type: 'string',
+            },
+          })
+          .example(
+            '$0 env pull',
+            "Write the linked branch's Neon vars into .env.local (or .env if present)",
+          )
+          .example(
+            '$0 env pull --branch preview --file .env.preview',
+            'Pull a specific branch into a specific file',
+          ),
+      (args) => pull(args as any),
+    )
+    .demandCommand(1);
+
+export const handler = (args: yargs.Argv) => args;
+
+/** Every OS-level env var name `@neondatabase/env` can emit, used only for reporting. */
+const NEON_VAR_NAMES = Object.values(NEON_ENV_VAR_KEYS).flatMap((group) =>
+  Object.values(group),
+);
+
+export const pull = async (props: EnvPullProps): Promise<void> => {
+  const cwd = props.cwd ?? process.cwd();
+  const branchId = await branchIdFromProps(props);
+
+  // Reuse `neon dev`'s tiered resolver (neon.ts policy -> plan gate -> fetchEnv, else
+  // pullConfig -> fetchEnv). Unlike dev, an unresolved context or failure is surfaced —
+  // `env pull` is an explicit action, so it should error rather than write nothing.
+  const vars = await resolveNeonEnvVars({
+    cwd,
+    projectId: props.projectId,
+    branchId,
+    ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+  });
+
+  const neonVars = pickNeonVars(vars);
+  if (Object.keys(neonVars).length === 0) {
+    log.info(
+      'No Neon env variables to pull for this branch (no DATABASE_URL or ' +
+        'enabled Auth / Data API).',
+    );
+    return;
+  }
+
+  const targetPath = resolveEnvFilePath(cwd, props.file);
+  const { written } = mergeEnvFile(targetPath, neonVars);
+  log.info(
+    'Pulled %d Neon variable%s into %s: %s',
+    written.length,
+    written.length === 1 ? '' : 's',
+    targetPath,
+    written.join(', '),
+  );
+};
+
+/**
+ * Keep only the recognized Neon variables from the resolved set, so a stray inherited
+ * value never lands in the user's `.env` file. (Today `resolveNeonEnvVars` only emits Neon
+ * vars, but filtering keeps the contract explicit and future-proof.)
+ */
+const pickNeonVars = (vars: Record<string, string>): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const name of NEON_VAR_NAMES) {
+    const value = vars[name];
+    if (value !== undefined) out[name] = value;
+  }
+  return out;
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ import * as init from './init.js';
 import * as dataApi from './data_api.js';
 import * as neonAuth from './neon_auth.js';
 import * as functions from './functions.js';
+import * as dev from './dev.js';
 
 export default [
   auth,
@@ -38,4 +39,5 @@ export default [
   init,
   dataApi,
   functions,
+  dev,
 ];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,8 @@ import * as dataApi from './data_api.js';
 import * as neonAuth from './neon_auth.js';
 import * as functions from './functions.js';
 import * as dev from './dev.js';
+import * as config from './config.js';
+import * as deploy from './deploy.js';
 
 export default [
   auth,
@@ -40,4 +42,6 @@ export default [
   dataApi,
   functions,
   dev,
+  config,
+  deploy,
 ];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,6 +20,7 @@ import * as functions from './functions.js';
 import * as dev from './dev.js';
 import * as config from './config.js';
 import * as deploy from './deploy.js';
+import * as env from './env.js';
 
 export default [
   auth,
@@ -44,4 +45,5 @@ export default [
   dev,
   config,
   deploy,
+  env,
 ];

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -1,0 +1,306 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  GetConnectionUriInput,
+  NeonApi,
+  NeonAuthSnapshot,
+  NeonBranchSnapshot,
+  NeonBucketSnapshot,
+  NeonDataApiSnapshot,
+  NeonDatabaseSnapshot,
+  NeonEndpointSnapshot,
+  NeonFunctionDeploymentSnapshot,
+  NeonFunctionSnapshot,
+  NeonProjectSnapshot,
+  NeonRoleSnapshot,
+} from '@neondatabase/config';
+
+import { resolveDevEnv } from './env.js';
+
+const PROJECT_ID = 'patient-art-12345';
+const BRANCH_ID = 'br-main-00000001';
+
+type FakeOverrides = {
+  /** Override `getNeonAuth`. Defaults to returning `null`. */
+  getNeonAuth?: NeonApi['getNeonAuth'];
+  /** Override `getNeonDataApi`. Defaults to returning `null`. */
+  getNeonDataApi?: NeonApi['getNeonDataApi'];
+  /** Override `listBranches` (e.g. to make it throw for the graceful-degrade case). */
+  listBranches?: NeonApi['listBranches'];
+};
+
+/**
+ * A full {@link NeonApi} implementation backed by fixed in-memory state for one
+ * project + one default branch. Methods that `pullConfig` and `fetchEnv` exercise
+ * return real data; everything else throws `not implemented` so an unexpected call
+ * fails loudly instead of silently passing.
+ */
+class FakeNeonApi implements NeonApi {
+  constructor(private readonly overrides: FakeOverrides = {}) {}
+
+  async listProjects(): Promise<NeonProjectSnapshot[]> {
+    throw new Error('not implemented');
+  }
+
+  async getProject(projectId: string): Promise<NeonProjectSnapshot> {
+    return {
+      id: projectId,
+      name: 'dev-project',
+      regionId: 'aws-us-east-1',
+      pgVersion: 17,
+    };
+  }
+
+  async createProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async updateProject(): Promise<NeonProjectSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranches(projectId: string): Promise<NeonBranchSnapshot[]> {
+    if (this.overrides.listBranches) {
+      return this.overrides.listBranches(projectId);
+    }
+    return [
+      {
+        id: BRANCH_ID,
+        name: 'main',
+        isDefault: true,
+        protected: false,
+      },
+    ];
+  }
+
+  async createBranch(): Promise<{
+    branch: NeonBranchSnapshot;
+    endpoints: NeonEndpointSnapshot[];
+  }> {
+    throw new Error('not implemented');
+  }
+
+  async updateBranch(): Promise<NeonBranchSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listEndpoints(): Promise<NeonEndpointSnapshot[]> {
+    return [
+      {
+        id: 'ep-fake-1',
+        branchId: BRANCH_ID,
+        type: 'read_write',
+        autoscalingLimitMinCu: 0.25,
+        autoscalingLimitMaxCu: 0.25,
+        suspendTimeout: '5m',
+      },
+    ];
+  }
+
+  async updateEndpoint(): Promise<NeonEndpointSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchRoles(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonRoleSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb_owner', branchId, protected: false }];
+  }
+
+  async listBranchDatabases(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonDatabaseSnapshot[]> {
+    void projectId;
+    return [{ name: 'neondb', branchId, ownerName: 'neondb_owner' }];
+  }
+
+  async getConnectionUri(
+    projectId: string,
+    input: GetConnectionUriInput,
+  ): Promise<{ uri: string }> {
+    void projectId;
+    const host = input.pooled
+      ? `${BRANCH_ID}-pooler.fake.neon.tech`
+      : `${BRANCH_ID}.fake.neon.tech`;
+    return {
+      uri: `postgresql://${input.roleName}:pw@${host}/${input.databaseName}?sslmode=require`,
+    };
+  }
+
+  async getNeonAuth(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonAuthSnapshot | null> {
+    if (this.overrides.getNeonAuth) {
+      return this.overrides.getNeonAuth(projectId, branchId);
+    }
+    return null;
+  }
+
+  async enableNeonAuth(): Promise<NeonAuthSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async getNeonDataApi(
+    projectId: string,
+    branchId: string,
+    databaseName: string,
+  ): Promise<NeonDataApiSnapshot | null> {
+    if (this.overrides.getNeonDataApi) {
+      return this.overrides.getNeonDataApi(projectId, branchId, databaseName);
+    }
+    return null;
+  }
+
+  async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+    return [];
+  }
+
+  async createBranchBucket(): Promise<NeonBucketSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async deleteBranchBucket(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+    return [];
+  }
+
+  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async deleteBranchFunction(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async deployBranchFunction(): Promise<NeonFunctionDeploymentSnapshot> {
+    throw new Error('not implemented');
+  }
+
+  async getAiGatewayEnabled(): Promise<boolean> {
+    return false;
+  }
+
+  async enableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+
+  async disableAiGateway(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+describe('resolveDevEnv', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-dev-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('tier 3: no neon.ts and no project/branch -> {}', async () => {
+    await expect(resolveDevEnv({ cwd })).resolves.toEqual({});
+  });
+
+  it('tier 2: no neon.ts but project + branch -> pooled + unpooled DATABASE_URL', async () => {
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api: new FakeNeonApi(),
+    });
+
+    expect(result.DATABASE_URL).toContain('-pooler.fake.neon.tech');
+    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.DATABASE_URL_UNPOOLED).not.toContain('-pooler.');
+    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+  });
+
+  it('tier 2 with Auth integration present: still only Postgres URLs (auth is not surfaced)', async () => {
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    // Tier 2 derives its config from `pullConfig`, whose `buildPulledBranchConfig`
+    // never emits an `auth` block. `resolveConfig` therefore resolves `authEnabled`
+    // to `false`, so `fetchEnv` never calls `getNeonAuth` and NEON_AUTH_BASE_URL is
+    // not injected — even when a live Neon Auth integration exists on the branch.
+    // Enabling auth requires a tier-1 `neon.ts` policy that returns `auth: {}`
+    // (covered by the tier-1 test below).
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(Object.keys(result).sort()).toEqual([
+      'DATABASE_URL',
+      'DATABASE_URL_UNPOOLED',
+    ]);
+    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+  });
+
+  it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(result.DATABASE_URL).toBeDefined();
+    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+  });
+
+  it('graceful: an api whose listBranches throws -> {} (does not throw)', async () => {
+    const api = new FakeNeonApi({
+      listBranches: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    await expect(
+      resolveDevEnv({
+        cwd,
+        projectId: PROJECT_ID,
+        branchId: BRANCH_ID,
+        api,
+      }),
+    ).resolves.toEqual({});
+  });
+});

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -262,10 +262,7 @@ describe('resolveDevEnv', () => {
   });
 
   it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
-    writeFileSync(
-      join(cwd, 'neon.ts'),
-      'export default () => ({ auth: {} });\n',
-    );
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
 
     const api = new FakeNeonApi({
       getNeonAuth: async () => ({
@@ -288,10 +285,7 @@ describe('resolveDevEnv', () => {
   });
 
   it('tier 1 mismatch: neon.ts enables auth the branch lacks -> throws DevEnvMismatchError', async () => {
-    writeFileSync(
-      join(cwd, 'neon.ts'),
-      'export default () => ({ auth: {} });\n',
-    );
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
 
     // The branch has NO Auth integration (default `getNeonAuth` -> null), so
     // `plan` reports an `enable-auth` create: the policy declares a resource the
@@ -309,10 +303,7 @@ describe('resolveDevEnv', () => {
   });
 
   it('tier 1 mismatch error: names the missing resource and points at deploy', async () => {
-    writeFileSync(
-      join(cwd, 'neon.ts'),
-      'export default () => ({ auth: {} });\n',
-    );
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
     const api = new FakeNeonApi();
 
     await expect(
@@ -321,10 +312,7 @@ describe('resolveDevEnv', () => {
   });
 
   it('tier 1 match: neon.ts enables auth the branch already has -> injects, no throw', async () => {
-    writeFileSync(
-      join(cwd, 'neon.ts'),
-      'export default () => ({ auth: {} });\n',
-    );
+    writeFileSync(join(cwd, 'neon.ts'), 'export default { auth: {} };\n');
 
     // The branch already has the Auth integration, so `plan` reports no missing
     // resource and `dev` injects NEON_AUTH_BASE_URL.

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -18,7 +18,7 @@ import type {
   NeonRoleSnapshot,
 } from '@neondatabase/config';
 
-import { resolveDevEnv } from './env.js';
+import { DevEnvMismatchError, resolveDevEnv } from './env.js';
 
 const PROJECT_ID = 'patient-art-12345';
 const BRANCH_ID = 'br-main-00000001';
@@ -232,7 +232,7 @@ describe('resolveDevEnv', () => {
     expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
   });
 
-  it('tier 2 with Auth integration present: still only Postgres URLs (auth is not surfaced)', async () => {
+  it('tier 2 with Auth integration present: surfaces NEON_AUTH_BASE_URL too', async () => {
     const api = new FakeNeonApi({
       getNeonAuth: async () => ({
         projectId: 'auth-project',
@@ -241,12 +241,11 @@ describe('resolveDevEnv', () => {
       }),
     });
 
-    // Tier 2 derives its config from `pullConfig`, whose `buildPulledBranchConfig`
-    // never emits an `auth` block. `resolveConfig` therefore resolves `authEnabled`
-    // to `false`, so `fetchEnv` never calls `getNeonAuth` and NEON_AUTH_BASE_URL is
-    // not injected — even when a live Neon Auth integration exists on the branch.
-    // Enabling auth requires a tier-1 `neon.ts` policy that returns `auth: {}`
-    // (covered by the tier-1 test below).
+    // Tier 2 derives its config from `pullConfig`, which now reverse-engineers the
+    // branch's Auth / Data API enablement into `config.auth` / `config.dataApi`. So
+    // `resolveConfig` sees `authEnabled === true`, `fetchEnv` calls `getNeonAuth`,
+    // and NEON_AUTH_BASE_URL is injected from the branch's live state — without any
+    // neon.ts. This mirrors what the deployed function would receive.
     const result = await resolveDevEnv({
       cwd,
       projectId: PROJECT_ID,
@@ -257,8 +256,9 @@ describe('resolveDevEnv', () => {
     expect(Object.keys(result).sort()).toEqual([
       'DATABASE_URL',
       'DATABASE_URL_UNPOOLED',
+      'NEON_AUTH_BASE_URL',
     ]);
-    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 
   it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
@@ -284,6 +284,65 @@ describe('resolveDevEnv', () => {
 
     expect(result.DATABASE_URL).toBeDefined();
     expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+  });
+
+  it('tier 1 mismatch: neon.ts enables auth the branch lacks -> throws DevEnvMismatchError', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    // The branch has NO Auth integration (default `getNeonAuth` -> null), so
+    // `plan` reports an `enable-auth` create: the policy declares a resource the
+    // branch is missing. `dev` must stop and point the user at `neonctl deploy`.
+    const api = new FakeNeonApi();
+
+    await expect(
+      resolveDevEnv({
+        cwd,
+        projectId: PROJECT_ID,
+        branchId: BRANCH_ID,
+        api,
+      }),
+    ).rejects.toBeInstanceOf(DevEnvMismatchError);
+  });
+
+  it('tier 1 mismatch error: names the missing resource and points at deploy', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+    const api = new FakeNeonApi();
+
+    await expect(
+      resolveDevEnv({ cwd, projectId: PROJECT_ID, branchId: BRANCH_ID, api }),
+    ).rejects.toThrow(/auth.*neonctl deploy/s);
+  });
+
+  it('tier 1 match: neon.ts enables auth the branch already has -> injects, no throw', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default () => ({ auth: {} });\n',
+    );
+
+    // The branch already has the Auth integration, so `plan` reports no missing
+    // resource and `dev` injects NEON_AUTH_BASE_URL.
+    const api = new FakeNeonApi({
+      getNeonAuth: async () => ({
+        projectId: 'auth-project',
+        jwksUrl: 'https://auth.fake.neon.tech/.well-known/jwks.json',
+        baseUrl: 'https://auth.fake.neon.tech',
+      }),
+    });
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
     expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -1,5 +1,4 @@
 import {
-  defineConfig,
   loadConfigFromFile,
   type Config,
   type NeonApi,
@@ -86,10 +85,9 @@ export const resolveNeonEnvVars = async (
       ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
       ...(ctx.api ? { api: ctx.api } : {}),
     });
-    return await fetchAndProject(
-      defineConfig(() => pulled.config),
-      ctx,
-    );
+    // `pulled.config` is already a `Config` (static auth/dataApi toggles + a branch
+    // tuning closure), so it feeds straight into fetchEnv — no wrapping needed.
+    return await fetchAndProject(pulled.config, ctx);
   }
 
   throw new MissingBranchContextError(

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -1,0 +1,109 @@
+import {
+  defineConfig,
+  loadConfigFromFile,
+  type Config,
+  type NeonApi,
+} from '@neondatabase/config';
+import { pullConfig } from '@neondatabase/config-runtime';
+import { fetchEnv, toEntries } from '@neondatabase/env';
+
+import { log } from '../log.js';
+
+export type DevEnvContext = {
+  cwd: string;
+  projectId?: string;
+  branchId?: string;
+  apiKey?: string;
+  /** Injected NeonApi adapter (tests). Production builds it from `apiKey`. */
+  api?: NeonApi;
+};
+
+/**
+ * Resolve the Neon env vars to inject into a locally-served function, mirroring
+ * what the deployed function would receive for the selected branch (pooled /
+ * direct `DATABASE_URL`, plus Auth / Data API when enabled).
+ *
+ * Tiered, and **always degrades gracefully** — a function must still run with no
+ * Neon account, no `.neon`, and no network:
+ *
+ *   1. a `neon.ts` policy is found -> evaluate it with `fetchEnv`
+ *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
+ *      branch's live state into a config, then `fetchEnv` injects what's enabled
+ *   3. otherwise -> inject nothing
+ *
+ * Any failure logs a warning and returns `{}` rather than throwing.
+ */
+export const resolveDevEnv = async (
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  try {
+    const config = await loadNeonConfig(ctx.cwd);
+
+    if (config) {
+      if (!ctx.projectId || !ctx.branchId) {
+        log.warning(
+          'Found a neon.ts but could not resolve the project/branch to ' +
+            'inject env for. Run `neonctl link` and `neonctl checkout <branch>`.',
+        );
+        return {};
+      }
+      return await fetchAndProject(config, ctx);
+    }
+
+    if (ctx.projectId && ctx.branchId) {
+      const pulled = await pullConfig({
+        projectId: ctx.projectId,
+        branchId: ctx.branchId,
+        ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+        ...(ctx.api ? { api: ctx.api } : {}),
+      });
+      const branchConfig = pulled.config;
+      return await fetchAndProject(
+        defineConfig(() => branchConfig),
+        ctx,
+      );
+    }
+
+    log.debug(
+      'dev: no neon.ts and no project/branch context; skipping env injection',
+    );
+    return {};
+  } catch (err) {
+    log.warning(
+      'Could not inject Neon env vars; the function will run without them: %s',
+      err instanceof Error ? err.message : String(err),
+    );
+    return {};
+  }
+};
+
+const fetchAndProject = async (
+  config: Config,
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  const env = await fetchEnv(config, {
+    projectId: ctx.projectId as string,
+    branchId: ctx.branchId as string,
+    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.api ? { api: ctx.api } : {}),
+  });
+  return toEntries(env);
+};
+
+/**
+ * Load a `neon.ts` policy if one exists on the path from `cwd` up to the repo
+ * root. Returns `null` when there is none (the common "no config" case), and
+ * surfaces real load errors (e.g. a syntax error in an existing file).
+ */
+const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
+  try {
+    const { config } = await loadConfigFromFile({ cwd });
+    return config;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) {
+      return null;
+    }
+    throw err;
+  }
+};

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -4,7 +4,11 @@ import {
   type Config,
   type NeonApi,
 } from '@neondatabase/config';
-import { pullConfig } from '@neondatabase/config-runtime';
+import {
+  plan,
+  pullConfig,
+  type AppliedChange,
+} from '@neondatabase/config-runtime';
 import { fetchEnv, toEntries } from '@neondatabase/env';
 
 import { log } from '../log.js';
@@ -19,19 +23,37 @@ export type DevEnvContext = {
 };
 
 /**
+ * Thrown when a `neon.ts` policy declares a branch-level resource (Neon Auth,
+ * Data API, a bucket, the AI Gateway) that the linked remote branch does not
+ * have yet. Unlike every other failure in {@link resolveDevEnv} — which degrades
+ * to "run without injection" — this is a hard stop: the user's intent (a policy)
+ * cannot be honored, and silently dropping the secret would be more confusing
+ * than refusing to start. The fix is to provision the resource first.
+ */
+export class DevEnvMismatchError extends Error {
+  override readonly name = 'DevEnvMismatchError';
+}
+
+/**
  * Resolve the Neon env vars to inject into a locally-served function, mirroring
  * what the deployed function would receive for the selected branch (pooled /
  * direct `DATABASE_URL`, plus Auth / Data API when enabled).
  *
- * Tiered, and **always degrades gracefully** — a function must still run with no
- * Neon account, no `.neon`, and no network:
+ * Tiered:
  *
- *   1. a `neon.ts` policy is found -> evaluate it with `fetchEnv`
+ *   1. a `neon.ts` policy is found -> the policy is the source of truth for what
+ *      the function *wants*. We first check the policy against the branch's live
+ *      state (`plan`); if the policy declares a resource the branch is missing,
+ *      we stop with a {@link DevEnvMismatchError} pointing the user at
+ *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy and injects.
  *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
- *      branch's live state into a config, then `fetchEnv` injects what's enabled
- *   3. otherwise -> inject nothing
+ *      branch's live state (incl. Auth / Data API enablement) into a config,
+ *      then `fetchEnv` injects what is actually enabled, silently.
+ *   3. otherwise -> inject nothing.
  *
- * Any failure logs a warning and returns `{}` rather than throwing.
+ * Every failure **except** {@link DevEnvMismatchError} degrades gracefully: it
+ * logs a warning and returns `{}` so the function still runs (no Neon account,
+ * no `.neon`, no network). A mismatch is re-thrown for the caller to surface.
  */
 export const resolveDevEnv = async (
   ctx: DevEnvContext,
@@ -47,6 +69,7 @@ export const resolveDevEnv = async (
         );
         return {};
       }
+      await assertPolicyMatchesBranch(config, ctx);
       return await fetchAndProject(config, ctx);
     }
 
@@ -69,6 +92,8 @@ export const resolveDevEnv = async (
     );
     return {};
   } catch (err) {
+    // A policy/branch mismatch is intentional and actionable — surface it.
+    if (err instanceof DevEnvMismatchError) throw err;
     log.warning(
       'Could not inject Neon env vars; the function will run without them: %s',
       err instanceof Error ? err.message : String(err),
@@ -76,6 +101,50 @@ export const resolveDevEnv = async (
     return {};
   }
 };
+
+/**
+ * Tier-1 guard. Dry-run the policy against the branch's live state and stop if
+ * it declares a branch-level resource the branch is missing. Built on `plan` so
+ * it covers every present and future provisionable resource for free: any
+ * `create` action is a resource `neonctl deploy` would provision.
+ *
+ * Functions are deliberately excluded: running an *un*deployed function locally
+ * is the whole point of `neon dev`, so a not-yet-deployed function in the policy
+ * must not block the dev server.
+ */
+const assertPolicyMatchesBranch = async (
+  config: Config,
+  ctx: DevEnvContext,
+): Promise<void> => {
+  const result = await plan(config, {
+    projectId: ctx.projectId as string,
+    branchId: ctx.branchId as string,
+    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.api ? { api: ctx.api } : {}),
+  });
+
+  const missing = result.applied.filter(isMissingResource);
+  if (missing.length === 0) return;
+
+  const names = missing.map((change) => change.identifier).join(', ');
+  throw new DevEnvMismatchError(
+    `Your neon.ts declares ${names} for branch ${ctx.branchId}, but the branch ` +
+      'does not have it yet, so the matching env vars cannot be injected. ' +
+      'Provision it first with `neonctl deploy` (or `neonctl config apply`), ' +
+      'then re-run `neonctl dev`.',
+  );
+};
+
+/**
+ * A planned change that provisions a branch-level resource the branch lacks: a
+ * `create` on a service (Neon Auth, Data API, a bucket, the AI Gateway). Branch
+ * setting drift (`update`) and `noop`s are ignored — they don't block local dev
+ * — and functions are excluded (see {@link assertPolicyMatchesBranch}).
+ */
+const isMissingResource = (change: AppliedChange): boolean =>
+  change.kind === 'service' &&
+  change.action === 'create' &&
+  !change.identifier.startsWith('function:');
 
 const fetchAndProject = async (
   config: Config,

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -35,65 +35,87 @@ export class DevEnvMismatchError extends Error {
 }
 
 /**
- * Resolve the Neon env vars to inject into a locally-served function, mirroring
- * what the deployed function would receive for the selected branch (pooled /
- * direct `DATABASE_URL`, plus Auth / Data API when enabled).
+ * Signals that no project/branch context could be resolved, so there is nothing to
+ * resolve env from. `resolveDevEnv` degrades on this (dev runs without injection);
+ * `env pull` surfaces it (an explicit pull needs a branch).
+ */
+export class MissingBranchContextError extends Error {
+  override readonly name = 'MissingBranchContextError';
+}
+
+/**
+ * Resolve the branch's Neon env vars (pooled / direct `DATABASE_URL`, plus Auth /
+ * Data API when enabled) into a `{ KEY: value }` map. Shared by `neon dev` (which
+ * injects them) and `neon env pull` (which writes them to a `.env` file).
  *
  * Tiered:
  *
- *   1. a `neon.ts` policy is found -> the policy is the source of truth for what
- *      the function *wants*. We first check the policy against the branch's live
- *      state (`plan`); if the policy declares a resource the branch is missing,
- *      we stop with a {@link DevEnvMismatchError} pointing the user at
- *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy and injects.
+ *   1. a `neon.ts` policy is found -> the policy is the source of truth. We first
+ *      check it against the branch's live state (`plan`); if it declares a resource
+ *      the branch is missing, we stop with a {@link DevEnvMismatchError} pointing at
+ *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy.
  *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
- *      branch's live state (incl. Auth / Data API enablement) into a config,
- *      then `fetchEnv` injects what is actually enabled, silently.
- *   3. otherwise -> inject nothing.
+ *      branch's live state (incl. Auth / Data API enablement) into a config, then
+ *      `fetchEnv` resolves what is actually enabled.
+ *   3. otherwise -> throw {@link MissingBranchContextError}.
  *
- * Every failure **except** {@link DevEnvMismatchError} degrades gracefully: it
- * logs a warning and returns `{}` so the function still runs (no Neon account,
- * no `.neon`, no network). A mismatch is re-thrown for the caller to surface.
+ * Unlike {@link resolveDevEnv}, this never swallows errors — callers decide how to
+ * handle them.
+ */
+export const resolveNeonEnvVars = async (
+  ctx: DevEnvContext,
+): Promise<Record<string, string>> => {
+  const config = await loadNeonConfig(ctx.cwd);
+
+  if (config) {
+    if (!ctx.projectId || !ctx.branchId) {
+      throw new MissingBranchContextError(
+        'Found a neon.ts but could not resolve the project/branch. ' +
+          'Run `neonctl link` and `neonctl checkout <branch>`, or pass ' +
+          '--project-id / --branch.',
+      );
+    }
+    await assertPolicyMatchesBranch(config, ctx);
+    return await fetchAndProject(config, ctx);
+  }
+
+  if (ctx.projectId && ctx.branchId) {
+    const pulled = await pullConfig({
+      projectId: ctx.projectId,
+      branchId: ctx.branchId,
+      ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+      ...(ctx.api ? { api: ctx.api } : {}),
+    });
+    return await fetchAndProject(
+      defineConfig(() => pulled.config),
+      ctx,
+    );
+  }
+
+  throw new MissingBranchContextError(
+    'No project/branch context found. Link a branch (`neonctl link` / ' +
+      '`neonctl checkout`) or pass --project-id and --branch.',
+  );
+};
+
+/**
+ * `neon dev`'s env resolver: {@link resolveNeonEnvVars} with graceful degradation.
+ * A missing branch context or any failure (no Neon account, no `.neon`, no network)
+ * logs a warning and returns `{}` so the function still runs locally; only a
+ * {@link DevEnvMismatchError} (policy declares a resource the branch lacks) is
+ * re-thrown for the caller to surface.
  */
 export const resolveDevEnv = async (
   ctx: DevEnvContext,
 ): Promise<Record<string, string>> => {
   try {
-    const config = await loadNeonConfig(ctx.cwd);
-
-    if (config) {
-      if (!ctx.projectId || !ctx.branchId) {
-        log.warning(
-          'Found a neon.ts but could not resolve the project/branch to ' +
-            'inject env for. Run `neonctl link` and `neonctl checkout <branch>`.',
-        );
-        return {};
-      }
-      await assertPolicyMatchesBranch(config, ctx);
-      return await fetchAndProject(config, ctx);
-    }
-
-    if (ctx.projectId && ctx.branchId) {
-      const pulled = await pullConfig({
-        projectId: ctx.projectId,
-        branchId: ctx.branchId,
-        ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
-        ...(ctx.api ? { api: ctx.api } : {}),
-      });
-      const branchConfig = pulled.config;
-      return await fetchAndProject(
-        defineConfig(() => branchConfig),
-        ctx,
-      );
-    }
-
-    log.debug(
-      'dev: no neon.ts and no project/branch context; skipping env injection',
-    );
-    return {};
+    return await resolveNeonEnvVars(ctx);
   } catch (err) {
-    // A policy/branch mismatch is intentional and actionable — surface it.
     if (err instanceof DevEnvMismatchError) throw err;
+    if (err instanceof MissingBranchContextError) {
+      log.debug('dev: %s; skipping env injection', err.message);
+      return {};
+    }
     log.warning(
       'Could not inject Neon env vars; the function will run without them: %s',
       err instanceof Error ? err.message : String(err),

--- a/src/dev/functions.test.ts
+++ b/src/dev/functions.test.ts
@@ -40,22 +40,22 @@ describe('resolveFunctionsFromConfig', () => {
   });
 
   it('returns an empty list when neon.ts declares no functions', async () => {
-    writeWorkspace(cwd, 'export default () => ({});\n', []);
+    writeWorkspace(cwd, 'export default {};\n', []);
     await expect(resolveFunctionsFromConfig(cwd)).resolves.toEqual([]);
   });
 
   it('resolves each function with an absolute source and its dev settings', async () => {
     writeWorkspace(
       cwd,
-      `export default () => ({
+      `export default {
         preview: {
-          functions: [
-            { slug: 'hello', name: 'Hello', source: './hello.ts', dev: { port: 8788 } },
-            { slug: 'api', name: 'Api', source: './api.ts', dev: { portless: true } },
-            { slug: 'bare', name: 'Bare', source: './bare.ts' },
-          ],
+          functions: {
+            hello: { name: 'Hello', source: './hello.ts', dev: { port: 8788 } },
+            api: { name: 'Api', source: './api.ts', dev: { portless: true } },
+            bare: { name: 'Bare', source: './bare.ts' },
+          },
         },
-      });\n`,
+      };\n`,
       ['hello.ts', 'api.ts', 'bare.ts'],
     );
 
@@ -85,9 +85,9 @@ describe('resolveFunctionsFromConfig', () => {
   it('throws when a declared function source does not exist on disk', async () => {
     writeWorkspace(
       cwd,
-      `export default () => ({
-        preview: { functions: [{ slug: 'gone', name: 'Gone', source: './missing.ts' }] },
-      });\n`,
+      `export default {
+        preview: { functions: { gone: { name: 'Gone', source: './missing.ts' } } },
+      };\n`,
       [],
     );
     await expect(resolveFunctionsFromConfig(cwd)).rejects.toThrow(
@@ -98,13 +98,13 @@ describe('resolveFunctionsFromConfig', () => {
   it('carries per-function env through', async () => {
     writeWorkspace(
       cwd,
-      `export default () => ({
+      `export default {
         preview: {
-          functions: [
-            { slug: 'e', name: 'E', source: './e.ts', env: { FOO: 'bar' } },
-          ],
+          functions: {
+            e: { name: 'E', source: './e.ts', env: { FOO: 'bar' } },
+          },
         },
-      });\n`,
+      };\n`,
       ['e.ts'],
     );
     const fns = await resolveFunctionsFromConfig(cwd);

--- a/src/dev/functions.test.ts
+++ b/src/dev/functions.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveFunctionsFromConfig } from './functions.js';
+
+/**
+ * Write a neon.ts and the function source files it references into a temp dir, so
+ * resolveFunctionsFromConfig (which loads + resolves the policy and checks each source
+ * exists on disk) runs against a realistic layout.
+ */
+const writeWorkspace = (
+  cwd: string,
+  neonTs: string,
+  sources: string[],
+): void => {
+  writeFileSync(join(cwd, 'neon.ts'), neonTs);
+  for (const rel of sources) {
+    writeFileSync(
+      join(cwd, rel),
+      'export default { fetch: () => new Response("ok") };\n',
+    );
+  }
+};
+
+describe('resolveFunctionsFromConfig', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-dev-fns-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('returns null when there is no neon.ts', async () => {
+    await expect(resolveFunctionsFromConfig(cwd)).resolves.toBeNull();
+  });
+
+  it('returns an empty list when neon.ts declares no functions', async () => {
+    writeWorkspace(cwd, 'export default () => ({});\n', []);
+    await expect(resolveFunctionsFromConfig(cwd)).resolves.toEqual([]);
+  });
+
+  it('resolves each function with an absolute source and its dev settings', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: {
+          functions: [
+            { slug: 'hello', name: 'Hello', source: './hello.ts', dev: { port: 8788 } },
+            { slug: 'api', name: 'Api', source: './api.ts', dev: { portless: true } },
+            { slug: 'bare', name: 'Bare', source: './bare.ts' },
+          ],
+        },
+      });\n`,
+      ['hello.ts', 'api.ts', 'bare.ts'],
+    );
+
+    const fns = await resolveFunctionsFromConfig(cwd);
+    expect(fns).not.toBeNull();
+    const bySlug = Object.fromEntries((fns ?? []).map((f) => [f.slug, f]));
+
+    expect(bySlug.hello).toMatchObject({
+      slug: 'hello',
+      name: 'Hello',
+      source: join(cwd, 'hello.ts'),
+      port: 8788,
+      portless: false,
+    });
+    expect(bySlug.api).toMatchObject({
+      slug: 'api',
+      source: join(cwd, 'api.ts'),
+      portless: true,
+    });
+    // portless function gets no port (portless assigns it).
+    expect(bySlug.api.port).toBeUndefined();
+    // bare function: no port, not portless.
+    expect(bySlug.bare.portless).toBe(false);
+    expect(bySlug.bare.port).toBeUndefined();
+  });
+
+  it('throws when a declared function source does not exist on disk', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: { functions: [{ slug: 'gone', name: 'Gone', source: './missing.ts' }] },
+      });\n`,
+      [],
+    );
+    await expect(resolveFunctionsFromConfig(cwd)).rejects.toThrow(
+      /source that does not exist/,
+    );
+  });
+
+  it('carries per-function env through', async () => {
+    writeWorkspace(
+      cwd,
+      `export default () => ({
+        preview: {
+          functions: [
+            { slug: 'e', name: 'E', source: './e.ts', env: { FOO: 'bar' } },
+          ],
+        },
+      });\n`,
+      ['e.ts'],
+    );
+    const fns = await resolveFunctionsFromConfig(cwd);
+    expect(fns?.[0].env).toEqual({ FOO: 'bar' });
+  });
+});

--- a/src/dev/functions.ts
+++ b/src/dev/functions.ts
@@ -1,0 +1,98 @@
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import {
+  loadConfigFromFile,
+  resolveConfig,
+  type Config,
+  type FunctionDevConfig,
+} from '@neondatabase/config';
+
+/**
+ * A function from `neon.ts`, resolved into everything `neon dev` needs to serve it
+ * locally. `source` is absolute (resolved against the `neon.ts` location). `port` is the
+ * function's explicit `dev.port`, or `undefined` to let the supervisor find a free one
+ * (only allowed when not `portless`). `env` is the function's own `neon.ts` env, layered
+ * over the shared branch env per child.
+ */
+export type PlannedFunction = {
+  slug: string;
+  name: string;
+  source: string;
+  port?: number;
+  portless: boolean;
+  env: Record<string, string>;
+};
+
+/**
+ * Load `neon.ts` (if any) and resolve the list of functions it declares into
+ * {@link PlannedFunction}s for `neon dev` to serve. Returns `null` when there is no
+ * `neon.ts` on the path from `cwd` up to the repo root — the caller turns that into a
+ * "no --source and no neon.ts" error.
+ *
+ * `branchName` is used only to evaluate a policy that switches on `branch.name`; the
+ * function list is otherwise branch-independent, so a placeholder is fine when unknown.
+ */
+export const resolveFunctionsFromConfig = async (
+  cwd: string,
+  branchName?: string,
+): Promise<PlannedFunction[] | null> => {
+  const loaded = await loadNeonConfig(cwd);
+  if (!loaded) return null;
+
+  const { config, configDir } = loaded;
+  const resolved = resolveConfig(config, {
+    name: branchName ?? 'local',
+    exists: branchName !== undefined,
+  });
+
+  const functions = resolved.preview?.functions ?? [];
+  return functions.map((fn) => {
+    const source = isAbsolute(fn.source)
+      ? fn.source
+      : resolve(configDir, fn.source);
+    if (!existsSync(source)) {
+      throw new Error(
+        `Function "${fn.slug}" points at a source that does not exist: ${source} ` +
+          `(from neon.ts "${fn.source}"). Fix the source path and re-run.`,
+      );
+    }
+    return {
+      slug: fn.slug,
+      name: fn.name,
+      source,
+      portless: fn.dev?.portless === true,
+      ...(devPort(fn.dev) !== undefined
+        ? { port: devPort(fn.dev) as number }
+        : {}),
+      env: { ...fn.env },
+    };
+  });
+};
+
+/**
+ * Read the `port` off a {@link FunctionDevConfig}. The discriminated union guarantees a
+ * `port` is present whenever `portless` is true, so this is `undefined` only for the
+ * non-portless, port-omitted case (the supervisor then searches for a free port).
+ */
+const devPort = (dev: FunctionDevConfig | undefined): number | undefined =>
+  dev?.port;
+
+type LoadedConfig = { config: Config; configDir: string };
+
+/**
+ * Load a `neon.ts` policy if one exists, returning the loaded config and the directory
+ * it lives in (used to resolve each function's relative `source`). Returns `null` when no
+ * config file is found; surfaces real load errors (e.g. a syntax error).
+ */
+const loadNeonConfig = async (cwd: string): Promise<LoadedConfig | null> => {
+  try {
+    const { config, resolvedPath } = await loadConfigFromFile({ cwd });
+    return { config, configDir: dirname(resolvedPath) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) {
+      return null;
+    }
+    throw err;
+  }
+};

--- a/src/dev/inputs.ts
+++ b/src/dev/inputs.ts
@@ -1,0 +1,83 @@
+import { resolve } from 'node:path';
+
+// esbuild's JS module, narrowed to the metafile-producing call we use. Typed
+// structurally so we never statically import from 'esbuild' (see resolveInputs
+// for why). Mirrors the shape in src/utils/esbuild.ts.
+type EsbuildModule = {
+  build: (opts: Record<string, unknown>) => Promise<{
+    metafile?: { inputs?: Record<string, unknown> };
+  }>;
+};
+
+export type InputDeps = {
+  // @yao-pkg/pkg defines process.pkg inside the packaged binary.
+  isPackaged: () => boolean;
+  loadEsbuild: (name: string) => Promise<EsbuildModule>;
+};
+
+const defaultDeps: InputDeps = {
+  isPackaged: () => (process as { pkg?: unknown }).pkg !== undefined,
+  loadEsbuild: (name) => import(name) as Promise<EsbuildModule>,
+};
+
+/**
+ * Resolve the exact set of files esbuild reads to produce the bundle for
+ * `source` — the entry plus every local module it imports (npm deps are left
+ * external, so they never appear). These are the files the dev watcher should
+ * watch, so a single edit triggers exactly one rebuild.
+ *
+ * Returns absolute paths, or `null` when the precise set cannot be computed —
+ * either inside the packaged binary (which cannot import esbuild as a module;
+ * it shells out to a binary that has no JSON-metafile equivalent here) or on a
+ * platform where the esbuild module won't load. Callers fall back to a coarser
+ * watch in that case.
+ *
+ * This performs a metafile-only pass (`write:false`, `metafile:true`) so it
+ * never emits output; the actual bundle bytes still come from `bundleEntry`.
+ */
+export const resolveWatchInputs = async (
+  source: string,
+  deps: InputDeps = defaultDeps,
+): Promise<string[] | null> => {
+  if (deps.isPackaged()) return null;
+
+  // esbuild is resolved by a COMPUTED specifier, never the literal string
+  // 'esbuild', for the same reason as src/utils/esbuild.ts: rollup and
+  // @yao-pkg/pkg statically scan for literal import()/require() and would pull
+  // esbuild's native Go binary into the bundle/snapshot. Keep it invisible.
+  const name = ['es', 'build'].join('');
+  let esbuild: EsbuildModule;
+  try {
+    esbuild = await deps.loadEsbuild(name);
+  } catch {
+    return null;
+  }
+
+  let metafile: { inputs?: Record<string, unknown> } | undefined;
+  try {
+    // Mirrors bundleEntry's flags so the resolved input graph matches the real
+    // bundle. metafile:true + write:false makes this a pure analysis pass.
+    const result = await esbuild.build({
+      entryPoints: [source],
+      bundle: true,
+      write: false,
+      metafile: true,
+      format: 'esm',
+      platform: 'node',
+      packages: 'external',
+      logLevel: 'silent',
+    });
+    metafile = result.metafile;
+  } catch {
+    // A bundle error here is non-fatal for watching: bundleEntry surfaces the
+    // real diagnostic. Fall back to the coarser watch so edits still rebuild.
+    return null;
+  }
+
+  const inputs = metafile?.inputs;
+  if (!inputs) return null;
+
+  // metafile input keys are paths relative to esbuild's cwd; resolve to absolute
+  // so they compare cleanly against chokidar's watched paths.
+  return Object.keys(inputs).map((p) => resolve(process.cwd(), p));
+};

--- a/src/dev/runtime.test.ts
+++ b/src/dev/runtime.test.ts
@@ -1,0 +1,146 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getRequestListener } from '@hono/node-server';
+
+import {
+  portSelectionFromEnv,
+  resolveFetchHandler,
+  withErrorBoundary,
+  type FetchHandler,
+} from './runtime.js';
+
+describe('resolveFetchHandler', () => {
+  it('picks `export default { fetch }`', async () => {
+    const response = new Response('from fetch object');
+    const handler = resolveFetchHandler({
+      default: { fetch: () => response },
+    });
+    const result = await handler(new Request('http://localhost/'));
+    expect(result).toBe(response);
+  });
+
+  it('picks `export default function`', async () => {
+    const response = new Response('from default function');
+    const handler = resolveFetchHandler({
+      default: () => response,
+    });
+    const result = await handler(new Request('http://localhost/'));
+    expect(result).toBe(response);
+  });
+
+  it('throws a helpful error when no handler is present', () => {
+    expect(() => resolveFetchHandler({})).toThrow(/No request handler found/);
+  });
+
+  it('throws when only a named `handler` export exists (named handler is not supported)', () => {
+    expect(() =>
+      resolveFetchHandler({ handler: () => new Response('named') }),
+    ).toThrow(/No request handler found/);
+  });
+});
+
+describe('withErrorBoundary', () => {
+  it('turns a thrown error into a 500 whose body contains the message', async () => {
+    const boundary = withErrorBoundary(() => {
+      throw new Error('boom from the user handler');
+    });
+    const res = await boundary(new Request('http://localhost/'));
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toContain('boom from the user handler');
+  });
+
+  it('passes a successful response through unchanged', async () => {
+    const ok = new Response('all good', { status: 201 });
+    const boundary = withErrorBoundary(() => ok);
+    const res = await boundary(new Request('http://localhost/'));
+    expect(res).toBe(ok);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('portSelectionFromEnv', () => {
+  it('returns an explicit selection when NEON_DEV_PORT is set', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT: '3000' })).toEqual({
+      mode: 'explicit',
+      port: 3000,
+    });
+  });
+
+  it('searches from the default base when NEON_DEV_PORT is empty', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT: '' })).toEqual({
+      mode: 'search',
+      from: 8787,
+    });
+  });
+
+  it('searches from the default base when NEON_DEV_PORT is unset', () => {
+    expect(portSelectionFromEnv({})).toEqual({ mode: 'search', from: 8787 });
+  });
+
+  it('respects NEON_DEV_PORT_BASE when searching', () => {
+    expect(portSelectionFromEnv({ NEON_DEV_PORT_BASE: '4000' })).toEqual({
+      mode: 'search',
+      from: 4000,
+    });
+  });
+
+  it('throws on an invalid NEON_DEV_PORT', () => {
+    expect(() => portSelectionFromEnv({ NEON_DEV_PORT: 'not-a-port' })).toThrow(
+      /Invalid NEON_DEV_PORT/,
+    );
+  });
+});
+
+describe('getRequestListener round-trip', () => {
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      const toClose = server;
+      server = null;
+      await new Promise<void>((resolve, reject) => {
+        toClose.close((err) => {
+          if (err) reject(err instanceof Error ? err : new Error(String(err)));
+          else resolve();
+        });
+      });
+    }
+  });
+
+  const start = async (handler: FetchHandler): Promise<number> => {
+    const listener = getRequestListener(handler);
+    const created = createServer((incoming, outgoing) => {
+      void listener(incoming, outgoing);
+    });
+    server = created;
+    return new Promise<number>((resolve, reject) => {
+      created.once('error', reject);
+      created.listen(0, () => {
+        resolve((created.address() as AddressInfo).port);
+      });
+    });
+  };
+
+  it('round-trips a request through the runtime helpers', async () => {
+    const handler = withErrorBoundary(
+      resolveFetchHandler({
+        default: {
+          fetch: (req: Request) =>
+            new Response(`hello from ${new URL(req.url).pathname}`, {
+              status: 200,
+              headers: { 'x-neon-dev': 'runtime' },
+            }),
+        },
+      }),
+    );
+
+    const port = await start(handler);
+    const res = await fetch(`http://127.0.0.1:${port}/greet`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-neon-dev')).toBe('runtime');
+    await expect(res.text()).resolves.toBe('hello from /greet');
+  });
+});

--- a/src/dev/runtime.test.ts
+++ b/src/dev/runtime.test.ts
@@ -91,6 +91,25 @@ describe('portSelectionFromEnv', () => {
       /Invalid NEON_DEV_PORT/,
     );
   });
+
+  it('binds an injected PORT (e.g. from portless) when NEON_DEV_PORT is unset', () => {
+    expect(portSelectionFromEnv({ PORT: '4123' })).toEqual({
+      mode: 'explicit',
+      port: 4123,
+    });
+  });
+
+  it('prefers NEON_DEV_PORT over PORT', () => {
+    expect(
+      portSelectionFromEnv({ NEON_DEV_PORT: '3000', PORT: '4123' }),
+    ).toEqual({ mode: 'explicit', port: 3000 });
+  });
+
+  it('throws on an invalid PORT', () => {
+    expect(() => portSelectionFromEnv({ PORT: 'nope' })).toThrow(
+      /Invalid PORT/,
+    );
+  });
 });
 
 describe('getRequestListener round-trip', () => {

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -1,0 +1,201 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { getRequestListener } from '@hono/node-server';
+
+/**
+ * A WHATWG fetch-style handler: takes a Request, returns a Response. The single
+ * shape the local dev server and the deployed Neon Functions runtime both speak.
+ */
+export type FetchHandler = (req: Request) => Response | Promise<Response>;
+
+type UserModule = Record<string, unknown>;
+
+const isFunction = (value: unknown): value is FetchHandler =>
+  typeof value === 'function';
+
+const hasFetchMethod = (
+  value: unknown,
+): value is { fetch: (req: Request) => Response | Promise<Response> } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'fetch' in value &&
+  typeof (value as { fetch: unknown }).fetch === 'function';
+
+/**
+ * Resolve the user's exported handler to a single fetch callback.
+ *
+ * Resolution order (first match wins):
+ *   1. `export default { fetch }`      — Workers / Neon Functions style
+ *   2. `export default function (req)` — bare (async) default function
+ */
+export const resolveFetchHandler = (mod: UserModule): FetchHandler => {
+  const defaultExport = mod.default;
+
+  if (hasFetchMethod(defaultExport)) {
+    const target = defaultExport;
+    return (req) => target.fetch(req);
+  }
+
+  if (isFunction(defaultExport)) {
+    return defaultExport;
+  }
+
+  throw new Error(
+    'No request handler found in the source module. Export one of:\n' +
+      '  export default { fetch(req) { /* ... */ } }\n' +
+      '  export default function (req) { /* ... */ }',
+  );
+};
+
+/**
+ * Wrap a fetch handler so user errors become a 500 response (with the message
+ * in the body during dev) instead of crashing the child process.
+ */
+export const withErrorBoundary = (handler: FetchHandler): FetchHandler => {
+  return async (req) => {
+    try {
+      return await handler(req);
+    } catch (err) {
+      const message =
+        err instanceof Error ? (err.stack ?? err.message) : String(err);
+      process.stderr.write(`Request handler threw an error:\n${message}\n`);
+      return new Response(`Internal Server Error\n\n${message}`, {
+        status: 500,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+      });
+    }
+  };
+};
+
+/**
+ * How the runtime picks its port:
+ *   - `explicit`: bind this exact port and crash on conflict (an explicit choice
+ *     — `--port` or portless's `PORT` — that is taken is an error).
+ *   - `search`: walk upward from `from` until a free port is found; never crash.
+ */
+export type PortSelection =
+  | { mode: 'explicit'; port: number }
+  | { mode: 'search'; from: number };
+
+export type StartRuntimeOptions = {
+  source: string;
+  port: PortSelection;
+  hostname?: string;
+};
+
+const isAddressInUse = (err: unknown): boolean =>
+  typeof err === 'object' &&
+  err !== null &&
+  (err as { code?: unknown }).code === 'EADDRINUSE';
+
+const DEFAULT_SEARCH_BASE = 8787;
+const MAX_SEARCH_STEPS = 100;
+
+const bindPort = async (
+  server: Server,
+  selection: PortSelection,
+  hostname: string | undefined,
+): Promise<number> => {
+  if (selection.mode === 'explicit') {
+    return listen(server, selection.port, hostname);
+  }
+  for (let step = 0; step < MAX_SEARCH_STEPS; step++) {
+    try {
+      return await listen(server, selection.from + step, hostname);
+    } catch (err) {
+      if (!isAddressInUse(err)) throw err;
+    }
+  }
+  throw new Error(
+    `Could not find a free port in ${selection.from}-${
+      selection.from + MAX_SEARCH_STEPS - 1
+    }`,
+  );
+};
+
+const listen = (
+  server: Server,
+  port: number,
+  hostname?: string,
+): Promise<number> =>
+  new Promise<number>((resolveListen, rejectListen) => {
+    const onError = (err: Error): void => {
+      server.off('listening', onListening);
+      rejectListen(err);
+    };
+    const onListening = (): void => {
+      server.off('error', onError);
+      resolveListen((server.address() as AddressInfo).port);
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, hostname);
+  });
+
+/**
+ * Load the (already-bundled) user module, build the listener, and start an HTTP
+ * server. Announces the bound port on stdout as `neon-dev:ready <port>` so the
+ * parent can render the URL. Resolves with the bound port.
+ */
+export const startRuntime = async ({
+  source,
+  port,
+  hostname,
+}: StartRuntimeOptions): Promise<number> => {
+  const absoluteSource = resolve(process.cwd(), source);
+  const mod = (await import(pathToFileURL(absoluteSource).href)) as UserModule;
+  const handler = withErrorBoundary(resolveFetchHandler(mod));
+
+  const listener = getRequestListener(handler, { hostname });
+  const server = createServer((incoming, outgoing) => {
+    void listener(incoming, outgoing);
+  });
+
+  const boundPort = await bindPort(server, port, hostname);
+  process.stdout.write(`neon-dev:ready ${boundPort}\n`);
+  return boundPort;
+};
+
+/**
+ * Build a {@link PortSelection} from the environment:
+ *   - `NEON_DEV_PORT` set -> explicit bind (crash if taken)
+ *   - otherwise           -> search upward from `NEON_DEV_PORT_BASE` (or default)
+ */
+export const portSelectionFromEnv = (env: NodeJS.ProcessEnv): PortSelection => {
+  const explicit = env.NEON_DEV_PORT;
+  if (explicit !== undefined && explicit !== '') {
+    const port = Number(explicit);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+      throw new Error(`Invalid NEON_DEV_PORT: "${explicit}"`);
+    }
+    return { mode: 'explicit', port };
+  }
+  const base = Number(env.NEON_DEV_PORT_BASE ?? DEFAULT_SEARCH_BASE);
+  return {
+    mode: 'search',
+    from: Number.isInteger(base) ? base : DEFAULT_SEARCH_BASE,
+  };
+};
+
+const isDirectExecution = (): boolean => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+};
+
+if (isDirectExecution()) {
+  const source = process.env.NEON_DEV_SOURCE ?? process.argv[2];
+  if (!source) {
+    process.stderr.write('neon-dev runtime: missing source path\n');
+    process.exit(1);
+  }
+  startRuntime({ source, port: portSelectionFromEnv(process.env) }).catch(
+    (err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`neon-dev runtime failed to start: ${msg}\n`);
+      process.exit(1);
+    },
+  );
+}

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -159,24 +159,35 @@ export const startRuntime = async ({
 };
 
 /**
- * Build a {@link PortSelection} from the environment:
- *   - `NEON_DEV_PORT` set -> explicit bind (crash if taken)
- *   - otherwise           -> search upward from `NEON_DEV_PORT_BASE` (or default)
+ * Build a {@link PortSelection} from the environment. Precedence:
+ *   1. `NEON_DEV_PORT` -> explicit bind (crash if taken). Set by `neon dev` from an
+ *      explicit `--port` / `dev.port`.
+ *   2. `PORT`          -> explicit bind. This is what `portless` injects (and what a bare
+ *      `PORT=3000 neon dev` sets), so the runtime binds the port chosen for it.
+ *   3. otherwise        -> search upward from `NEON_DEV_PORT_BASE` (or the default base).
  */
 export const portSelectionFromEnv = (env: NodeJS.ProcessEnv): PortSelection => {
   const explicit = env.NEON_DEV_PORT;
   if (explicit !== undefined && explicit !== '') {
-    const port = Number(explicit);
-    if (!Number.isInteger(port) || port < 0 || port > 65535) {
-      throw new Error(`Invalid NEON_DEV_PORT: "${explicit}"`);
-    }
-    return { mode: 'explicit', port };
+    return { mode: 'explicit', port: parsePort(explicit, 'NEON_DEV_PORT') };
+  }
+  const injected = env.PORT;
+  if (injected !== undefined && injected !== '') {
+    return { mode: 'explicit', port: parsePort(injected, 'PORT') };
   }
   const base = Number(env.NEON_DEV_PORT_BASE ?? DEFAULT_SEARCH_BASE);
   return {
     mode: 'search',
     from: Number.isInteger(base) ? base : DEFAULT_SEARCH_BASE,
   };
+};
+
+const parsePort = (value: string, varName: string): number => {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid ${varName}: "${value}"`);
+  }
+  return port;
 };
 
 const isDirectExecution = (): boolean => {

--- a/src/env_file.test.ts
+++ b/src/env_file.test.ts
@@ -144,6 +144,17 @@ describe('readEnvFile', () => {
     });
   });
 
+  it('keeps `=` characters inside a value', () => {
+    const path = join(cwd, '.env');
+    writeFileSync(
+      path,
+      'DATABASE_URL=postgres://u:p@h/db?sslmode=require&options=-c%20a=b\n',
+    );
+    expect(readEnvFile(path).DATABASE_URL).toBe(
+      'postgres://u:p@h/db?sslmode=require&options=-c%20a=b',
+    );
+  });
+
   it('throws when the file does not exist', () => {
     expect(() => readEnvFile(join(cwd, 'missing.env'))).toThrow(
       /Env file not found/,

--- a/src/env_file.test.ts
+++ b/src/env_file.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { mergeEnvContent, resolveEnvFilePath } from './env_file.js';
+import {
+  loadEnvFileIntoProcess,
+  mergeEnvContent,
+  readEnvFile,
+  resolveEnvFilePath,
+} from './env_file.js';
 
 describe('mergeEnvContent', () => {
   it('writes keys into an empty file with a trailing newline', () => {
@@ -105,5 +110,70 @@ describe('resolveEnvFilePath', () => {
   it('uses an existing .env when present (vercel-style)', () => {
     writeFileSync(join(cwd, '.env'), 'EXISTING=1\n');
     expect(resolveEnvFilePath(cwd)).toBe(join(cwd, '.env'));
+  });
+});
+
+describe('readEnvFile', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-readenv-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('parses assignments, ignoring comments / blanks and unquoting values', () => {
+    const path = join(cwd, '.env');
+    writeFileSync(
+      path,
+      [
+        '# a comment',
+        '',
+        'PLAIN=value',
+        'export EXPORTED=exp',
+        'QUOTED="has space"',
+        "SINGLE='single'",
+        'not an assignment',
+      ].join('\n'),
+    );
+    expect(readEnvFile(path)).toEqual({
+      PLAIN: 'value',
+      EXPORTED: 'exp',
+      QUOTED: 'has space',
+      SINGLE: 'single',
+    });
+  });
+
+  it('throws when the file does not exist', () => {
+    expect(() => readEnvFile(join(cwd, 'missing.env'))).toThrow(
+      /Env file not found/,
+    );
+  });
+});
+
+describe('loadEnvFileIntoProcess', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-loadenv-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+    delete process.env.NEONCTL_TEST_LOADENV_NEW;
+    delete process.env.NEONCTL_TEST_LOADENV_EXISTING;
+  });
+
+  it('sets unset vars but never overrides existing process.env entries', () => {
+    process.env.NEONCTL_TEST_LOADENV_EXISTING = 'from-process';
+    const path = join(cwd, '.env');
+    writeFileSync(
+      path,
+      'NEONCTL_TEST_LOADENV_NEW=from-file\nNEONCTL_TEST_LOADENV_EXISTING=from-file\n',
+    );
+
+    const applied = loadEnvFileIntoProcess(path);
+
+    expect(process.env.NEONCTL_TEST_LOADENV_NEW).toBe('from-file');
+    expect(process.env.NEONCTL_TEST_LOADENV_EXISTING).toBe('from-process');
+    expect(applied).toEqual(['NEONCTL_TEST_LOADENV_NEW']);
   });
 });

--- a/src/env_file.test.ts
+++ b/src/env_file.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mergeEnvContent, resolveEnvFilePath } from './env_file.js';
+
+describe('mergeEnvContent', () => {
+  it('writes keys into an empty file with a trailing newline', () => {
+    const { content, written } = mergeEnvContent('', {
+      DATABASE_URL: 'postgres://x',
+    });
+    expect(content).toBe('DATABASE_URL=postgres://x\n');
+    expect(written).toEqual(['DATABASE_URL']);
+  });
+
+  it('updates an existing key in place, preserving position and other lines', () => {
+    const original = [
+      '# my env',
+      'FOO=bar',
+      'DATABASE_URL=postgres://old',
+      'BAZ=qux',
+      '',
+    ].join('\n');
+    const { content } = mergeEnvContent(original, {
+      DATABASE_URL: 'postgres://new',
+    });
+    expect(content).toBe(
+      ['# my env', 'FOO=bar', 'DATABASE_URL=postgres://new', 'BAZ=qux'].join(
+        '\n',
+      ) + '\n',
+    );
+  });
+
+  it('appends new keys after existing content', () => {
+    const original = 'FOO=bar\n';
+    const { content, written } = mergeEnvContent(original, {
+      DATABASE_URL: 'postgres://x',
+      NEON_AUTH_BASE_URL: 'https://auth',
+    });
+    expect(content).toBe(
+      [
+        'FOO=bar',
+        'DATABASE_URL=postgres://x',
+        'NEON_AUTH_BASE_URL=https://auth',
+      ].join('\n') + '\n',
+    );
+    expect(written).toEqual(['DATABASE_URL', 'NEON_AUTH_BASE_URL']);
+  });
+
+  it('preserves comments and blank lines, and a leading `export`', () => {
+    const original = [
+      '# header',
+      '',
+      'export DATABASE_URL=old',
+      '# trailing comment',
+    ].join('\n');
+    const { content } = mergeEnvContent(original, { DATABASE_URL: 'new' });
+    // The `export ` form is matched for the key, replaced with the canonical KEY=value.
+    expect(content).toContain('# header');
+    expect(content).toContain('# trailing comment');
+    expect(content).toContain('DATABASE_URL=new');
+  });
+
+  it('quotes values that contain special characters', () => {
+    const { content } = mergeEnvContent('', {
+      DATABASE_URL: 'postgres://u:p w@h/db?x=1',
+    });
+    expect(content).toBe('DATABASE_URL="postgres://u:p w@h/db?x=1"\n');
+  });
+
+  it('is a no-op for empty updates', () => {
+    const original = 'FOO=bar\n';
+    const { content, written } = mergeEnvContent(original, {});
+    expect(content).toBe(original);
+    expect(written).toEqual([]);
+  });
+
+  it('does not accumulate trailing blank lines across merges', () => {
+    const first = mergeEnvContent('', { A: '1' }).content;
+    const second = mergeEnvContent(first, { B: '2' }).content;
+    expect(second).toBe('A=1\nB=2\n');
+  });
+});
+
+describe('resolveEnvFilePath', () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-envfile-'));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('uses an explicit --file when given', () => {
+    expect(resolveEnvFilePath(cwd, '.env.preview')).toBe(
+      join(cwd, '.env.preview'),
+    );
+  });
+
+  it('defaults to .env.local when no .env exists', () => {
+    expect(resolveEnvFilePath(cwd)).toBe(join(cwd, '.env.local'));
+  });
+
+  it('uses an existing .env when present (vercel-style)', () => {
+    writeFileSync(join(cwd, '.env'), 'EXISTING=1\n');
+    expect(resolveEnvFilePath(cwd)).toBe(join(cwd, '.env'));
+  });
+});

--- a/src/env_file.ts
+++ b/src/env_file.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Default dotenv file `env pull` writes to: `.env` when one already exists in the working
+ * directory (update where secrets already live), otherwise `.env.local` — matching the
+ * `vercel env pull` convention. An explicit `--file` always wins over this.
+ */
+export const resolveEnvFilePath = (cwd: string, file?: string): string => {
+  if (file) return join(cwd, file);
+  if (existsSync(join(cwd, '.env'))) return join(cwd, '.env');
+  return join(cwd, '.env.local');
+};
+
+/**
+ * Merge `updates` into the dotenv content at `path`, preserving every other line
+ * (comments, blank lines, unrelated keys) and the file's existing order. Keys present in
+ * both are updated in place; keys only in `updates` are appended. A non-existent file is
+ * treated as empty. Returns the list of keys that were written (for reporting).
+ */
+export const mergeEnvFile = (
+  path: string,
+  updates: Record<string, string>,
+): { written: string[] } => {
+  const original = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const { content, written } = mergeEnvContent(original, updates);
+  writeFileSync(path, content);
+  return { written };
+};
+
+/**
+ * Pure core of {@link mergeEnvFile}: takes the current file content and the updates, and
+ * returns the new content plus which keys were written. Kept side-effect-free so it can be
+ * unit-tested without touching the filesystem.
+ */
+export const mergeEnvContent = (
+  original: string,
+  updates: Record<string, string>,
+): { content: string; written: string[] } => {
+  const keys = Object.keys(updates);
+  if (keys.length === 0) return { content: original, written: [] };
+
+  const remaining = new Set(keys);
+  const lines = original === '' ? [] : original.split('\n');
+
+  // Update keys in place where they already appear, so their position and any surrounding
+  // comments are preserved.
+  const updatedLines = lines.map((line) => {
+    const key = parseKey(line);
+    if (key !== null && remaining.has(key)) {
+      remaining.delete(key);
+      return formatLine(key, updates[key]);
+    }
+    return line;
+  });
+
+  // Append keys that weren't already present, in the order they were given.
+  const appended = keys
+    .filter((key) => remaining.has(key))
+    .map((key) => formatLine(key, updates[key]));
+
+  const body = trimTrailingBlank(updatedLines);
+  const content = [...body, ...appended].join('\n');
+  return {
+    // A dotenv file ends with a trailing newline.
+    content: content === '' ? '' : `${content}\n`,
+    written: keys,
+  };
+};
+
+/**
+ * Extract the variable name from a dotenv line, or `null` for comments / blank lines / any
+ * line that isn't a `KEY=value` assignment. Tolerates a leading `export ` and surrounding
+ * whitespace, matching common `.env` styles.
+ */
+const parseKey = (line: string): string | null => {
+  const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
+  return match ? match[1] : null;
+};
+
+/**
+ * Render a `KEY=value` line. The value is wrapped in double quotes when it contains
+ * characters that would otherwise break parsing (spaces, `#`, quotes, `=`), with inner
+ * quotes/backslashes escaped — Neon connection strings and URLs are safe either way, but
+ * quoting defensively avoids surprises for tools that re-parse the file.
+ */
+const formatLine = (key: string, value: string): string => {
+  const needsQuotes = /[\s#"'=]/.test(value);
+  if (!needsQuotes) return `${key}=${value}`;
+  const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `${key}="${escaped}"`;
+};
+
+/** Drop trailing blank lines so we don't accumulate them across repeated merges. */
+const trimTrailingBlank = (lines: string[]): string[] => {
+  const out = [...lines];
+  while (out.length > 0 && out[out.length - 1]?.trim() === '') out.pop();
+  return out;
+};

--- a/src/env_file.ts
+++ b/src/env_file.ts
@@ -69,6 +69,43 @@ export const mergeEnvContent = (
 };
 
 /**
+ * Read a dotenv file at `path` into a plain `{ KEY: value }` map. A non-existent file is an
+ * error (callers pass an explicit `--env` path, so a typo should fail loudly rather than
+ * silently load nothing). Quotes are stripped and `\"` / `\\` unescaped, matching the
+ * quoting {@link mergeEnvFile} writes. Comments, blank lines, and non-assignment lines are
+ * ignored.
+ */
+export const readEnvFile = (path: string): Record<string, string> => {
+  if (!existsSync(path)) {
+    throw new Error(`Env file not found: ${path}`);
+  }
+  const out: Record<string, string> = {};
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    const parsed = parseAssignment(line);
+    if (parsed) out[parsed.key] = parsed.value;
+  }
+  return out;
+};
+
+/**
+ * Load a dotenv file into `process.env` so values are available to anything read later
+ * (e.g. a `neon.ts` whose function `env` values come from `process.env.X`). Existing
+ * `process.env` entries are **not** overridden — an already-exported var wins over the
+ * file, matching dotenv's default. Returns the keys that were applied.
+ */
+export const loadEnvFileIntoProcess = (path: string): string[] => {
+  const parsed = readEnvFile(path);
+  const applied: string[] = [];
+  for (const [key, value] of Object.entries(parsed)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+      applied.push(key);
+    }
+  }
+  return applied;
+};
+
+/**
  * Extract the variable name from a dotenv line, or `null` for comments / blank lines / any
  * line that isn't a `KEY=value` assignment. Tolerates a leading `export ` and surrounding
  * whitespace, matching common `.env` styles.
@@ -76,6 +113,33 @@ export const mergeEnvContent = (
 const parseKey = (line: string): string | null => {
   const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
   return match ? match[1] : null;
+};
+
+/**
+ * Parse a `KEY=value` dotenv line into its key and unquoted value, or `null` for
+ * comments / blank lines / non-assignments. Mirrors {@link formatLine}'s quoting.
+ */
+const parseAssignment = (
+  line: string,
+): { key: string; value: string } | null => {
+  const match = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(
+    line,
+  );
+  const key = match?.[1];
+  const raw = match?.[2];
+  if (key === undefined || raw === undefined) return null;
+  return { key, value: unquote(raw.trim()) };
+};
+
+/** Strip matching surrounding quotes and unescape `\"` / `\\` inside double quotes. */
+const unquote = (value: string): string => {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1);
+  }
+  return value;
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'dev',
 
+  'deploy',
+
   // aliases
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'init',
 
+  'dev',
+
   // aliases
 ];
 


### PR DESCRIPTION
## Summary

Adds the Neon Platform local-dev + config-as-code surface to neonctl, consuming the published `@neondatabase/config@0.4.0` / `@neondatabase/config-runtime@0.4.0` / `@neondatabase/env@0.3.0`.

Consolidates the previously-stacked PRs (#499 dev, #513 config, #515 env-pull) into one branch, rebased onto current `main` and switched from `link:` to the published packages.

### `neon dev`
- Run a function locally with hot reload; serve every `neon.ts` function when no `--source` is given.
- Tiered env injection: `neon.ts` policy → plan gate → `fetchEnv`; else `pullConfig` → `fetchEnv`. Degrades gracefully (runs without env) except on a policy/branch resource mismatch.
- Bundled function runs as ESM.

### `neon config` + `neon deploy`
- `config status | plan | apply` (inspect / dry-run diff / reconcile a `neon.ts` policy), `deploy` as an `apply` alias.
- `--env <path>`: load a `.env` into `process.env` before evaluating `neon.ts`, so function `env` values resolve from it.

### `neon env pull`
- Write a branch's Neon env vars to a `.env` file (merge-in-place, preserves other lines), Vercel-style default file selection.

### `neon checkout`
- When it **creates** a branch (named or via the new "Create a new branch…" picker option), it applies the local `neon.ts` policy to the new branch. Checking out an existing branch never reconciles.

### Adopts the static-config shape (config 0.4.0)
- `defineConfig({ auth, dataApi, preview, branch })`; `pullConfig` returns the new shape; `parseEnv` scope arg.
- Function memory is fixed by the platform (no `--memory-mib`).

## Test plan

- [x] `pnpm typecheck` + `eslint` + `prettier --check`
- [x] full suite: **2812 passed**, 7 skipped
- [x] built CLI runs (`neonctl-test`), demo (`demos/neon-preview`) typechecks against published packages