### PR TITLE
feat(config): resolved neon.ts-shaped config in status + --config-json

### DIFF
--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -279,7 +279,7 @@ describe('config commands', () => {
     return path;
   };
 
-  it('status returns the live project + branch state', async () => {
+  it('status returns the live project + branch state with a resolved neon.ts-shaped config', async () => {
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();
 
@@ -289,6 +289,40 @@ describe('config commands', () => {
     expect(parsed.project.id).toBe(PROJECT_ID);
     expect(parsed.branch.id).toBe(BRANCH_ID);
     expect(parsed.branch.name).toBe(BRANCH_NAME);
+    // The `config` column is the resolved neon.ts-shaped view, not the raw `{}`: the fake
+    // branch has compute settings (so a `branch.postgres` section) and no auth/dataApi.
+    expect(parsed.config.branch.postgres.computeSettings).toMatchObject({
+      autoscalingLimitMaxCu: 0.25,
+      suspendTimeout: '5m',
+    });
+    expect(parsed.config.auth).toBeUndefined();
+    expect(parsed.config.dataApi).toBeUndefined();
+    expect(parsed.config.preview).toBeUndefined();
+  });
+
+  it('status --config-json prints only the neon.ts-shaped config to stdout', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    // Capture process.stdout (the --config-json path writes there directly).
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      chunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await status({ ...baseProps(api, stream), configJson: true });
+    } finally {
+      process.stdout.write = orig;
+    }
+
+    // The writer (table/json output) is NOT used; only stdout JSON.
+    expect(read()).toBe('');
+    const json = JSON.parse(chunks.join(''));
+    // No project/branch envelope — just the config.
+    expect(json.project).toBeUndefined();
+    expect(json.branch.postgres.computeSettings.suspendTimeout).toBe('5m');
   });
 
   it('plan is a dry run whose applied list includes the auth service change', async () => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { resolveConfig } from '@neondatabase/config';
 import {
   apply,
   inspect,
@@ -10,6 +11,7 @@ import {
   type NeonApi,
   type PushResult,
 } from '@neondatabase/config-runtime';
+import { toNeonConfigView } from '../config_format.js';
 
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
@@ -52,6 +54,8 @@ export type ConfigProps = BranchScopeProps & {
   updateExisting?: boolean;
   /** Auto-confirm applying to a protected branch (apply only). */
   allowProtected?: boolean;
+  /** `status` only: print just the neon.ts-shaped config JSON to stdout. */
+  configJson?: boolean;
   /** Injected NeonApi adapter (tests). Production omits it so the real adapter is built from credentials. */
   runtimeApi?: NeonApi;
 };
@@ -104,10 +108,13 @@ export const builder = (argv: yargs.Argv) =>
       "Show the branch's live Neon state",
       (yargs) =>
         yargs.options({
-          config: {
+          'config-json': {
             describe:
-              'Path to a neon.ts policy (defaults to walking up from cwd)',
-            type: 'string',
+              "Print only the branch's live config as neon.ts-shaped JSON " +
+              '(services + branch tuning + preview), to stdout. Useful for ' +
+              'scripting or copying into a neon.ts.',
+            type: 'boolean',
+            default: false,
           },
         }),
       (args) => status(args as any),
@@ -172,7 +179,34 @@ export const status = async (props: ConfigProps): Promise<void> => {
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
-  writer(props).end(live, { fields: INSPECT_FIELDS });
+
+  // The pulled `config` carries the branch's tuning inside a closure that JSON can't
+  // render. Resolve it against the live branch target to get the concrete settings, then
+  // project both that and the separately-pulled preview state into a neon.ts-shaped view.
+  const resolved = resolveConfig(live.config, {
+    name: live.branch.name,
+    id: live.branch.id,
+    exists: true,
+    isDefault: live.branch.isDefault,
+    isProtected: live.branch.protected,
+    ...(live.branch.parent ? { parentId: live.branch.parent } : {}),
+    ...(live.branch.expiresAt ? { expiresAt: live.branch.expiresAt } : {}),
+  });
+  const configView = toNeonConfigView(resolved, live.preview);
+
+  // `--config-json`: emit just the neon.ts-shaped config to stdout (script-friendly,
+  // copy-paste-able), regardless of the global --output.
+  if (props.configJson) {
+    process.stdout.write(`${JSON.stringify(configView, null, 2)}\n`);
+    return;
+  }
+
+  // Default: the live project/branch tables, but with the unhelpful raw `config` replaced
+  // by the resolved neon.ts-shaped view so the user sees enabled infra + branch tuning.
+  writer(props).end(
+    { project: live.project, branch: live.branch, config: configView },
+    { fields: INSPECT_FIELDS },
+  );
 };
 
 export const planCmd = async (props: ConfigProps): Promise<void> => {

--- a/src/config_format.test.ts
+++ b/src/config_format.test.ts
@@ -1,0 +1,81 @@
+import type { ResolvedBranchConfig } from '@neondatabase/config';
+import type { PulledBranchConfig } from '@neondatabase/config-runtime';
+import { describe, expect, it } from 'vitest';
+
+import { formatDurationSeconds, toNeonConfigView } from './config_format.js';
+
+describe('formatDurationSeconds', () => {
+  it('renders clean unit boundaries, preferring the largest unit', () => {
+    expect(formatDurationSeconds(604800)).toBe('1w'); // 7 days collapses to 1 week
+    expect(formatDurationSeconds(3 * 24 * 60 * 60)).toBe('3d');
+    expect(formatDurationSeconds(3600)).toBe('1h');
+    expect(formatDurationSeconds(300)).toBe('5m');
+    expect(formatDurationSeconds(2 * 7 * 24 * 60 * 60)).toBe('2w');
+  });
+
+  it('falls back to seconds when no clean unit matches', () => {
+    expect(formatDurationSeconds(90)).toBe('90s');
+  });
+});
+
+describe('toNeonConfigView', () => {
+  const base: ResolvedBranchConfig = {
+    authEnabled: false,
+    dataApiEnabled: false,
+  };
+
+  it('omits disabled services and an empty branch/preview', () => {
+    expect(toNeonConfigView(base, undefined)).toEqual({});
+  });
+
+  it('surfaces enabled services as `true` only', () => {
+    const view = toNeonConfigView(
+      { authEnabled: true, dataApiEnabled: true },
+      undefined,
+    );
+    expect(view).toEqual({ auth: true, dataApi: true });
+  });
+
+  it('renders the branch tuning section, with ttl as a duration string', () => {
+    const view = toNeonConfigView(
+      {
+        authEnabled: false,
+        dataApiEnabled: false,
+        parent: 'main',
+        ttlSeconds: 604800,
+        protected: true,
+        postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+      },
+      undefined,
+    );
+    expect(view.branch).toEqual({
+      parent: 'main',
+      ttl: '1w',
+      protected: true,
+      postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+    });
+  });
+
+  it('projects preview functions/buckets into slug/name-keyed records', () => {
+    const preview: PulledBranchConfig['preview'] = {
+      aiGatewayEnabled: true,
+      functions: [{ slug: 'hello', name: 'Hello' }],
+      buckets: [{ name: 'uploads', access: 'public_read' }],
+    };
+    const view = toNeonConfigView(base, preview);
+    expect(view.preview).toEqual({
+      aiGateway: true,
+      functions: { hello: { name: 'Hello' } },
+      buckets: { uploads: { access: 'public_read' } },
+    });
+  });
+
+  it('omits an all-empty preview', () => {
+    const preview: PulledBranchConfig['preview'] = {
+      aiGatewayEnabled: false,
+      functions: [],
+      buckets: [],
+    };
+    expect(toNeonConfigView(base, preview).preview).toBeUndefined();
+  });
+});

--- a/src/config_format.ts
+++ b/src/config_format.ts
@@ -1,0 +1,97 @@
+import type { ResolvedBranchConfig } from '@neondatabase/config';
+import type { PulledBranchConfig } from '@neondatabase/config-runtime';
+
+/**
+ * Render a TTL in whole seconds back to the canonical `neon.ts` duration string (e.g.
+ * `604800` -> `"7d"`), falling back to seconds when no clean unit boundary matches. Mirrors
+ * the formatter `@neondatabase/config` uses when it emits a TTL, so `config status` shows
+ * the same value a user would write in `neon.ts`.
+ */
+export const formatDurationSeconds = (totalSeconds: number): string => {
+  const units = [
+    ['w', 7 * 24 * 60 * 60],
+    ['d', 24 * 60 * 60],
+    ['h', 60 * 60],
+    ['m', 60],
+  ] as const;
+  for (const [unit, perUnit] of units) {
+    if (totalSeconds % perUnit === 0) return `${totalSeconds / perUnit}${unit}`;
+  }
+  return `${totalSeconds}s`;
+};
+
+/**
+ * The `neon.ts`-shaped view of a branch's live configuration, mirroring how a user would
+ * author it in `defineConfig({ ... })` — minus the `branch` *closure* wrapper, since the
+ * remote only has concrete resolved values. Every field is omitted when it carries no
+ * signal (a disabled service, an empty preview), so `config status` reads like a minimal
+ * `neon.ts`.
+ */
+export type NeonConfigView = {
+  auth?: true;
+  dataApi?: true;
+  preview?: {
+    aiGateway?: true;
+    functions?: Record<string, { name: string }>;
+    buckets?: Record<string, { access: string }>;
+  };
+  branch?: {
+    parent?: string;
+    ttl?: string;
+    protected?: boolean;
+    postgres?: ResolvedBranchConfig['postgres'];
+  };
+};
+
+/**
+ * Project a resolved branch config (plus the separately-pulled preview state, since
+ * functions/buckets don't live on the closure) into a {@link NeonConfigView}.
+ *
+ * - Service toggles are surfaced as `true` only when enabled (disabled is the absence of
+ *   the key, exactly as in `neon.ts`).
+ * - `ttlSeconds` is rendered back to a duration string (`7d`).
+ * - The `branch` section is the JSON-able part of what would otherwise be the `branch`
+ *   closure: `parent` / `ttl` / `protected` / `postgres.computeSettings`.
+ * - `branch` and `preview` are omitted entirely when they would be empty.
+ */
+export const toNeonConfigView = (
+  resolved: ResolvedBranchConfig,
+  preview: PulledBranchConfig['preview'],
+): NeonConfigView => {
+  const view: NeonConfigView = {};
+
+  if (resolved.authEnabled) view.auth = true;
+  if (resolved.dataApiEnabled) view.dataApi = true;
+
+  const previewView = toPreviewView(preview);
+  if (previewView) view.preview = previewView;
+
+  const branch: NeonConfigView['branch'] = {};
+  if (resolved.parent !== undefined) branch.parent = resolved.parent;
+  if (resolved.ttlSeconds !== undefined)
+    branch.ttl = formatDurationSeconds(resolved.ttlSeconds);
+  if (resolved.protected !== undefined) branch.protected = resolved.protected;
+  if (resolved.postgres?.computeSettings) branch.postgres = resolved.postgres;
+  if (Object.keys(branch).length > 0) view.branch = branch;
+
+  return view;
+};
+
+const toPreviewView = (
+  preview: PulledBranchConfig['preview'],
+): NeonConfigView['preview'] | undefined => {
+  if (!preview) return undefined;
+  const out: NonNullable<NeonConfigView['preview']> = {};
+  if (preview.aiGatewayEnabled) out.aiGateway = true;
+  if (preview.functions.length > 0) {
+    out.functions = Object.fromEntries(
+      preview.functions.map((fn) => [fn.slug, { name: fn.name }]),
+    );
+  }
+  if (preview.buckets.length > 0) {
+    out.buckets = Object.fromEntries(
+      preview.buckets.map((b) => [b.name, { access: b.access }]),
+    );
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};


### PR DESCRIPTION
## Summary

`neon config status` previously rendered the raw pulled `Config`. Its branch tuning lives in a **closure** that JSON can't serialize, so the `Config` column always showed `{}` — even on a branch with real compute settings.

This resolves the pulled config against the live branch and projects it (plus the separately-pulled preview state) into a **neon.ts-shaped view** — i.e. what you'd write in `defineConfig({ ... })`, minus the closure wrapper:

```jsonc
{
  "auth": true,                  // enabled GA toggles (omitted when off)
  "dataApi": true,
  "preview": {                   // omitted when empty
    "aiGateway": true,
    "functions": { "hello": { "name": "Hello" } },
    "buckets": { "uploads": { "access": "public_read" } }
  },
  "branch": {                    // the JSON-able part of the branch closure
    "parent": "main",
    "ttl": "1w",                 // ttlSeconds rendered back to a duration
    "protected": true,
    "postgres": { "computeSettings": { "autoscalingLimitMaxCu": 2 } }
  }
}
```

Also adds **`--config-json`**: prints just that view to stdout (script-friendly / copy-paste into a `neon.ts`).

Empty sections are omitted, so a vanilla branch (defaults everywhere, no infra) reads as `{}` — which is the honest "nothing diverges from platform defaults".

## Notes / open question
- Compute settings only appear when they **differ from the project's default endpoint settings** (that's how `pullConfig` reports them). So a fresh branch on defaults shows no `postgres` section. If we'd rather always echo the effective compute config, that's a follow-up in `pullConfig` — flagging for discussion.

## Test plan

- [x] New `config_format` unit tests (duration formatting, view projection, omission rules)
- [x] `config status` test asserts the resolved view; new `--config-json` test asserts stdout-only JSON
- [x] `pnpm lint` (typecheck + eslint + prettier) clean
- [x] full suite: **2820 passed**, 7 skipped
- [x] live smoke test against a real branch