### PR TITLE
feat(dev,config): hot-add functions on neon.ts change + resolved neon.ts-shaped config in status

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ There are three modes:
 ```bash
 $ neonctl link
 ? Which organization would you like to link? › Personal Org (org-abc123)
-? Which project would you like to link? › + Create new project
+? Which project would you like to link? › ＋ Create new project…
 ? Name for the new project: › my-app
 ? Which region should the new project run in? › AWS US East (Ohio) (aws-us-east-2)
 Created project polished-snowflake-12345678 ("my-app") in aws-us-east-2.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.24.0",
+  "version": "2.23.1",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -279,7 +279,7 @@ describe('config commands', () => {
     return path;
   };
 
-  it('status returns the live project + branch state', async () => {
+  it('status returns the live project + branch state with a resolved neon.ts-shaped config', async () => {
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();
 
@@ -289,6 +289,40 @@ describe('config commands', () => {
     expect(parsed.project.id).toBe(PROJECT_ID);
     expect(parsed.branch.id).toBe(BRANCH_ID);
     expect(parsed.branch.name).toBe(BRANCH_NAME);
+    // The `config` column is the resolved neon.ts-shaped view, not the raw `{}`: the fake
+    // branch has compute settings (so a `branch.postgres` section) and no auth/dataApi.
+    expect(parsed.config.branch.postgres.computeSettings).toMatchObject({
+      autoscalingLimitMaxCu: 0.25,
+      suspendTimeout: '5m',
+    });
+    expect(parsed.config.auth).toBeUndefined();
+    expect(parsed.config.dataApi).toBeUndefined();
+    expect(parsed.config.preview).toBeUndefined();
+  });
+
+  it('status --config-json prints only the neon.ts-shaped config to stdout', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    // Capture process.stdout (the --config-json path writes there directly).
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      chunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await status({ ...baseProps(api, stream), configJson: true });
+    } finally {
+      process.stdout.write = orig;
+    }
+
+    // The writer (table/json output) is NOT used; only stdout JSON.
+    expect(read()).toBe('');
+    const json = JSON.parse(chunks.join(''));
+    // No project/branch envelope — just the config.
+    expect(json.project).toBeUndefined();
+    expect(json.branch.postgres.computeSettings.suspendTimeout).toBe('5m');
   });
 
   it('plan is a dry run whose applied list includes the auth service change', async () => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import { resolveConfig } from '@neondatabase/config';
 import {
   apply,
   inspect,
@@ -10,6 +11,7 @@ import {
   type NeonApi,
   type PushResult,
 } from '@neondatabase/config-runtime';
+import { toNeonConfigView } from '../config_format.js';
 
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
@@ -52,6 +54,8 @@ export type ConfigProps = BranchScopeProps & {
   updateExisting?: boolean;
   /** Auto-confirm applying to a protected branch (apply only). */
   allowProtected?: boolean;
+  /** `status` only: print just the neon.ts-shaped config JSON to stdout. */
+  configJson?: boolean;
   /** Injected NeonApi adapter (tests). Production omits it so the real adapter is built from credentials. */
   runtimeApi?: NeonApi;
 };
@@ -104,10 +108,13 @@ export const builder = (argv: yargs.Argv) =>
       "Show the branch's live Neon state",
       (yargs) =>
         yargs.options({
-          config: {
+          'config-json': {
             describe:
-              'Path to a neon.ts policy (defaults to walking up from cwd)',
-            type: 'string',
+              "Print only the branch's live config as neon.ts-shaped JSON " +
+              '(services + branch tuning + preview), to stdout. Useful for ' +
+              'scripting or copying into a neon.ts.',
+            type: 'boolean',
+            default: false,
           },
         }),
       (args) => status(args as any),
@@ -172,7 +179,34 @@ export const status = async (props: ConfigProps): Promise<void> => {
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
-  writer(props).end(live, { fields: INSPECT_FIELDS });
+
+  // The pulled `config` carries the branch's tuning inside a closure that JSON can't
+  // render. Resolve it against the live branch target to get the concrete settings, then
+  // project both that and the separately-pulled preview state into a neon.ts-shaped view.
+  const resolved = resolveConfig(live.config, {
+    name: live.branch.name,
+    id: live.branch.id,
+    exists: true,
+    isDefault: live.branch.isDefault,
+    isProtected: live.branch.protected,
+    ...(live.branch.parent ? { parentId: live.branch.parent } : {}),
+    ...(live.branch.expiresAt ? { expiresAt: live.branch.expiresAt } : {}),
+  });
+  const configView = toNeonConfigView(resolved, live.preview);
+
+  // `--config-json`: emit just the neon.ts-shaped config to stdout (script-friendly,
+  // copy-paste-able), regardless of the global --output.
+  if (props.configJson) {
+    process.stdout.write(`${JSON.stringify(configView, null, 2)}\n`);
+    return;
+  }
+
+  // Default: the live project/branch tables, but with the unhelpful raw `config` replaced
+  // by the resolved neon.ts-shaped view so the user sees enabled infra + branch tuning.
+  writer(props).end(
+    { project: live.project, branch: live.branch, config: configView },
+    { fields: INSPECT_FIELDS },
+  );
 };
 
 export const planCmd = async (props: ConfigProps): Promise<void> => {

--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -1,7 +1,8 @@
 import { join } from 'node:path';
-import { describe } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { test } from '../test_utils/fixtures';
+import { diffUnits, type RunningUnit, type ServedUnit } from './dev.js';
 
 describe('dev', () => {
   test('exits 1 when no --source and no neon.ts is found', async ({
@@ -33,5 +34,104 @@ describe('dev', () => {
   }) => {
     const missing = join(process.cwd(), 'does-not-exist.ts');
     await testCliCommand(['dev', '--source', missing], { code: 1 });
+  });
+});
+
+/**
+ * The slug-keyed diff that powers neon.ts hot-reload: editing neon.ts while `neon dev` runs
+ * should add new functions and drop removed ones without disturbing the functions that
+ * stayed the same. These cover the decision (which units to add/remove/restart); the
+ * side effects (spawn/kill) are driven by the supervisor around it.
+ */
+describe('diffUnits', () => {
+  const unit = (slug: string, configKey: string): ServedUnit => ({
+    slug,
+    source: `/fns/${slug}.ts`,
+    bundleDir: `/tmp/${slug}`,
+    childEnv: {},
+    label: slug,
+    configKey,
+  });
+
+  const runningOf = (...units: ServedUnit[]): RunningUnit[] =>
+    units.map((u) => ({
+      unit: u,
+      child: null,
+      boundPort: null,
+      everReady: false,
+      restartTimer: null,
+      watcher: null,
+      status: 'ready',
+    }));
+
+  it('adds a newly declared function and leaves existing ones untouched', () => {
+    const existing = unit('a', 'ka');
+    const running = runningOf(existing);
+    const desired = [unit('a', 'ka'), unit('b', 'kb')];
+
+    const plan = diffUnits(running, desired);
+
+    expect(plan.add.map((u) => u.slug)).toEqual(['b']);
+    expect(plan.remove).toEqual([]);
+    expect(plan.restart).toEqual([]);
+    // The existing unit's running entry is the very same object — never replaced.
+    expect(running[0].unit).toBe(existing);
+  });
+
+  it('removes a function dropped from neon.ts', () => {
+    const running = runningOf(unit('a', 'ka'), unit('b', 'kb'));
+
+    const plan = diffUnits(running, [unit('a', 'ka')]);
+
+    expect(plan.remove.map((r) => r.unit.slug)).toEqual(['b']);
+    expect(plan.add).toEqual([]);
+    expect(plan.restart).toEqual([]);
+  });
+
+  it('restarts in place a function whose config changed (new configKey)', () => {
+    const running = runningOf(unit('a', 'ka-old'));
+
+    const plan = diffUnits(running, [unit('a', 'ka-new')]);
+
+    expect(plan.restart.map((r) => r.unit.slug)).toEqual(['a']);
+    expect(plan.add).toEqual([]);
+    expect(plan.remove).toEqual([]);
+    // Restart adopts the new config onto the same running entry (kept, not re-created).
+    expect(running[0].unit.configKey).toBe('ka-new');
+  });
+
+  it('leaves an unchanged function alone (no add/remove/restart)', () => {
+    const running = runningOf(unit('a', 'ka'));
+
+    const plan = diffUnits(running, [unit('a', 'ka')]);
+
+    expect(plan).toEqual({ remove: [], restart: [], add: [] });
+  });
+
+  it('removes everything when neon.ts is deleted (null desired)', () => {
+    const running = runningOf(unit('a', 'ka'), unit('b', 'kb'));
+
+    const plan = diffUnits(running, null);
+
+    expect(plan.remove.map((r) => r.unit.slug)).toEqual(['a', 'b']);
+    expect(plan.add).toEqual([]);
+    expect(plan.restart).toEqual([]);
+  });
+
+  it('handles a mix: add one, remove one, restart one, keep one', () => {
+    const keep = unit('keep', 'k');
+    const running = runningOf(keep, unit('drop', 'd'), unit('change', 'c-old'));
+
+    const plan = diffUnits(running, [
+      unit('keep', 'k'),
+      unit('change', 'c-new'),
+      unit('new', 'n'),
+    ]);
+
+    expect(plan.add.map((u) => u.slug)).toEqual(['new']);
+    expect(plan.remove.map((r) => r.unit.slug)).toEqual(['drop']);
+    expect(plan.restart.map((r) => r.unit.slug)).toEqual(['change']);
+    // 'keep' is never in any bucket and its object identity is preserved.
+    expect(running[0].unit).toBe(keep);
   });
 });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -101,6 +101,8 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
     label: null,
   };
 
+  // No config reload in single-source mode: there's exactly one file to serve, and
+  // nothing to add or remove. neon.ts hot-reload is config-mode only.
   await runSupervisor([unit]);
 };
 
@@ -110,15 +112,16 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
  */
 const runFromConfig = async (props: DevProps): Promise<void> => {
   const branchId = await resolveBranchId(props);
-  const functions = await resolveFunctionsFromConfig(process.cwd());
+  const resolved = await resolveFunctionsFromConfig(process.cwd());
 
-  if (functions === null) {
+  if (resolved === null) {
     throw new Error(
       'No --source given and no neon.ts found. Pass --source <path> to run a ' +
         'single function, or add a neon.ts that declares functions under ' +
         '`preview.functions`.',
     );
   }
+  const { configPath, functions } = resolved;
   if (functions.length === 0) {
     throw new Error(
       'neon.ts has no functions to serve. Add at least one under ' +
@@ -133,16 +136,49 @@ const runFromConfig = async (props: DevProps): Promise<void> => {
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
   });
 
-  // Give each search-mode (no dev.port, non-portless) function a distinct search base so
-  // they don't all start probing at the same port. The runtime still walks upward from its
-  // base, so an occupied base self-resolves; the offset just makes startup deterministic.
+  const units = planFunctionsToUnits(functions, neonEnv, DEFAULT_PORT_BASE);
+
+  // Re-derive the units from neon.ts on demand so the config watcher can hot-add/remove
+  // functions without restarting the dev server. `searchBase` lets a freshly-added unit
+  // start probing above the ports already taken by live units (the runtime still walks
+  // upward from there, so this never fails — it just keeps startup deterministic).
+  const replan: Replan = async (searchBase) => {
+    const re = await resolveFunctionsFromConfig(process.cwd());
+    if (re === null) return null;
+    return planFunctionsToUnits(re.functions, neonEnv, searchBase);
+  };
+
+  await runSupervisor(units, { configPath, replan });
+};
+
+/** Re-resolve neon.ts into units, searching ports from `searchBase`. `null` if neon.ts vanished. */
+type Replan = (searchBase: number) => Promise<ServedUnit[] | null>;
+
+/** Extra wiring the supervisor needs to hot-reload neon.ts (config mode only). */
+type ConfigReload = {
+  configPath: string;
+  replan: Replan;
+};
+
+/**
+ * Map a list of {@link PlannedFunction}s to {@link ServedUnit}s, coordinating the search
+ * base across them so search-mode functions don't all probe the same starting port.
+ *
+ * Each search-mode (no `dev.port`, non-portless) function gets a distinct base starting at
+ * `searchBase`; the runtime still walks upward from its base, so an occupied base
+ * self-resolves and this never fails — the offset just makes startup deterministic.
+ */
+const planFunctionsToUnits = (
+  functions: PlannedFunction[],
+  neonEnv: Record<string, string>,
+  searchBase: number,
+): ServedUnit[] => {
   let searchOffset = 0;
-  const units = functions.map((fn) => {
-    const base = DEFAULT_PORT_BASE + searchOffset;
+  return functions.map((fn) => {
+    const base = searchBase + searchOffset;
     if (!fn.portless && fn.port === undefined) searchOffset += 1;
     return plannedToUnit(fn, neonEnv, base);
   });
-  await runSupervisor(units);
 };
 
 /**
@@ -214,6 +250,16 @@ const plannedToUnit = (
     bundleDir: join(process.cwd(), 'node_modules', '.neon-dev', fn.slug),
     childEnv,
     label: fn.slug,
+    // Signature of the function's *own* neon.ts config (NOT the dynamically-chosen search
+    // base) so reconcile can tell a real change from a no-op save. A search-mode function
+    // re-planned with a different base must hash identically, or it would be needlessly
+    // restarted — see reconcile().
+    configKey: JSON.stringify({
+      source: fn.source,
+      port: fn.port ?? null,
+      portless: fn.portless,
+      env: fn.env,
+    }),
     ...(fn.portless ? { portless: { slug: fn.slug } } : {}),
   };
 };
@@ -244,16 +290,22 @@ const buildChildEnv = (
  * One function being served locally. `slug`/`label` are null in single-source mode
  * (one unnamed server). `portless`, when set, wraps the child with `portless run`.
  */
-type ServedUnit = {
+export type ServedUnit = {
   slug: string | null;
   source: string;
   bundleDir: string;
   childEnv: NodeJS.ProcessEnv;
   label: string | null;
+  /**
+   * Signature of the function's own neon.ts config (source/port/portless/env), used by the
+   * config reconciler to detect a real change vs a no-op save. Independent of the dynamic
+   * port search base. Absent in single-source mode (no reconcile there).
+   */
+  configKey?: string;
   portless?: { slug: string };
 };
 
-type RunningUnit = {
+export type RunningUnit = {
   unit: ServedUnit;
   child: ChildProcess | null;
   boundPort: number | null;
@@ -272,8 +324,17 @@ const READY_PATTERN = /neon-dev:ready (\d+)/;
  * as errored and recovered on the next edit). A single SIGINT/SIGTERM shuts all of them
  * down, tree-killing each child so no descendant (e.g. a portless-wrapped runtime) is
  * orphaned.
+ *
+ * In config mode, `reload` lets the supervisor watch `neon.ts` and reconcile the live set
+ * of units when it changes: a newly-declared function is hot-added (its own child, watcher,
+ * and port) and a removed one is torn down — all without disturbing the functions that
+ * stayed the same. A function whose config (env/port/portless/source) changed is restarted
+ * in place; siblings are untouched.
  */
-const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
+const runSupervisor = async (
+  units: ServedUnit[],
+  reload?: ConfigReload,
+): Promise<void> => {
   if (hasPortlessUnit(units)) {
     assertPortlessAvailable();
   }
@@ -281,15 +342,7 @@ const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
   const runtimePath = resolveRuntimePath();
   let shuttingDown = false;
 
-  const running: RunningUnit[] = units.map((unit) => ({
-    unit,
-    child: null,
-    boundPort: null,
-    everReady: false,
-    restartTimer: null,
-    watcher: null,
-    status: 'starting',
-  }));
+  const running: RunningUnit[] = units.map(makeRunningUnit);
 
   const bundleAndStart = async (r: RunningUnit): Promise<void> => {
     let bundlePath: string;
@@ -358,44 +411,72 @@ const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
     }, 150);
   };
 
-  // Create each watcher before its first bundle so bundleAndStart can sync the
-  // watch set on every run (including the initial one).
-  for (const r of running) {
+  // Bring a unit fully online: create its source watcher (before the first bundle so
+  // bundleAndStart can sync the watch set on every run) then bundle + spawn it.
+  const startUnit = async (r: RunningUnit): Promise<void> => {
     r.watcher = await startWatcher(r.unit.source, () => {
       restart(r);
     });
-  }
+    await bundleAndStart(r);
+  };
+
+  // Tear a unit down completely: stop its restart timer + watcher, reap its child tree, and
+  // remove its bundle dir. Used both on shutdown and when neon.ts drops a function.
+  const stopUnit = async (r: RunningUnit): Promise<void> => {
+    if (r.restartTimer) clearTimeout(r.restartTimer);
+    await r.watcher?.close();
+    if (r.child) await killTree(r.child);
+    rmSync(r.unit.bundleDir, { recursive: true, force: true });
+  };
 
   // Start every unit. They are independent: keep going if one fails.
-  await Promise.all(running.map((r) => bundleAndStart(r)));
+  await Promise.all(running.map((r) => startUnit(r)));
 
   if (running.every((r) => r.status === 'error')) {
-    await Promise.all(running.map((r) => r.watcher?.close()));
-    await Promise.all(
-      running.map((r) => (r.child ? killTree(r.child) : undefined)),
-    );
-    for (const r of running)
-      rmSync(r.unit.bundleDir, { recursive: true, force: true });
+    await Promise.all(running.map((r) => stopUnit(r)));
     throw new Error('No function started. See the output above for details.');
   }
 
   printBanner(running);
+
+  // Config mode only: watch neon.ts and reconcile the live unit set when it changes.
+  // Reconciles are serialized: a burst of saves (editor write-then-format) must not run
+  // overlapping diffs against the mutating `running` array. A trailing run coalesces the
+  // burst and picks up the latest config.
+  let configWatcher: Watcher | null = null;
+  if (reload) {
+    const ops: ReconcileOps = {
+      isShuttingDown: () => shuttingDown,
+      startUnit,
+      stopUnit,
+      restartUnit: restart,
+    };
+    let inFlight: Promise<void> | null = null;
+    let pending = false;
+    const drive = (): void => {
+      if (inFlight) {
+        pending = true;
+        return;
+      }
+      inFlight = (async () => {
+        do {
+          pending = false;
+          await reconcileOnce(running, reload.replan, ops);
+        } while (pending && !shuttingDown);
+      })().finally(() => {
+        inFlight = null;
+      });
+    };
+    configWatcher = await startConfigWatcher(reload.configPath, drive);
+  }
 
   await new Promise<void>((resolveRun) => {
     const shutdown = (): void => {
       if (shuttingDown) return;
       shuttingDown = true;
       void (async () => {
-        for (const r of running) {
-          if (r.restartTimer) clearTimeout(r.restartTimer);
-        }
-        await Promise.all(running.map((r) => r.watcher?.close()));
-        await Promise.all(
-          running.map((r) => (r.child ? killTree(r.child) : undefined)),
-        );
-        for (const r of running) {
-          rmSync(r.unit.bundleDir, { recursive: true, force: true });
-        }
+        await configWatcher?.close();
+        await Promise.all(running.map((r) => stopUnit(r)));
         log.info(chalk.dim('Stopped the dev server.'));
         resolveRun();
       })();
@@ -403,6 +484,147 @@ const runSupervisor = async (units: ServedUnit[]): Promise<void> => {
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
   });
+};
+
+const makeRunningUnit = (unit: ServedUnit): RunningUnit => ({
+  unit,
+  child: null,
+  boundPort: null,
+  everReady: false,
+  restartTimer: null,
+  watcher: null,
+  status: 'starting',
+});
+
+/** Lifecycle hooks the reconciler drives, supplied by {@link runSupervisor}. */
+type ReconcileOps = {
+  isShuttingDown: () => boolean;
+  startUnit: (r: RunningUnit) => Promise<void>;
+  stopUnit: (r: RunningUnit) => Promise<void>;
+  restartUnit: (r: RunningUnit) => void;
+};
+
+/**
+ * The converging actions of one reconcile, computed by the pure {@link diffUnits} and then
+ * carried out by {@link reconcileOnce}. Splitting the decision from the side effects keeps
+ * the slug-diff logic testable without spawning real children.
+ */
+export type ReconcilePlan = {
+  /** Live units whose slug disappeared from neon.ts — torn down. */
+  remove: RunningUnit[];
+  /** Live units whose function config changed — restarted in place (kept, not replaced). */
+  restart: RunningUnit[];
+  /** Units for slugs newly declared in neon.ts — hot-added. */
+  add: ServedUnit[];
+};
+
+/**
+ * Pure slug-keyed diff of the live units against the freshly-resolved desired set:
+ *   - a slug present now but not before → **add** (new child + watcher + port),
+ *   - a slug gone from neon.ts → **remove** (torn down),
+ *   - a slug whose config (source/port/portless/env) changed → **restart** in place,
+ *   - an unchanged slug → left out of the plan entirely (never touched).
+ * Functions that stayed the same never die, so an edit that only adds a function is
+ * non-disruptive. `desired === null` (neon.ts deleted) is treated as "no functions".
+ */
+export const diffUnits = (
+  running: RunningUnit[],
+  desired: ServedUnit[] | null,
+): ReconcilePlan => {
+  const desiredBySlug = new Map<string, ServedUnit>();
+  for (const u of desired ?? []) {
+    if (u.slug !== null) desiredBySlug.set(u.slug, u);
+  }
+  const runningBySlug = new Map<string, RunningUnit>();
+  for (const r of running) {
+    if (r.unit.slug !== null) runningBySlug.set(r.unit.slug, r);
+  }
+
+  const plan: ReconcilePlan = { remove: [], restart: [], add: [] };
+
+  for (const [slug, r] of runningBySlug) {
+    if (!desiredBySlug.has(slug)) plan.remove.push(r);
+  }
+  for (const [slug, want] of desiredBySlug) {
+    const r = runningBySlug.get(slug);
+    if (r) {
+      if (r.unit.configKey !== want.configKey) {
+        r.unit = want;
+        plan.restart.push(r);
+      }
+    } else {
+      plan.add.push(want);
+    }
+  }
+  return plan;
+};
+
+/**
+ * Run one reconcile: re-resolve neon.ts (ignoring the change with a clear message if it no
+ * longer loads), {@link diffUnits} against the live set, then apply the plan — tearing down
+ * removed functions, restarting changed ones in place, and hot-adding new ones. Mutates
+ * `running` in place so the surrounding supervisor sees the converged set.
+ */
+const reconcileOnce = async (
+  running: RunningUnit[],
+  replan: Replan,
+  ops: ReconcileOps,
+): Promise<void> => {
+  if (ops.isShuttingDown()) return;
+
+  let desired: ServedUnit[] | null;
+  try {
+    desired = await replan(nextSearchBase(running));
+  } catch (err) {
+    log.info(
+      chalk.red('neon.ts change ignored: ') +
+        (err instanceof Error ? err.message : String(err)) +
+        chalk.dim(' (fix it and save again)'),
+    );
+    return;
+  }
+  if (ops.isShuttingDown()) return;
+
+  if (hasPortlessUnit(desired ?? [])) assertPortlessAvailable();
+
+  const plan = diffUnits(running, desired);
+
+  for (const r of plan.remove) {
+    logUnit(r.unit, chalk.dim('removed from neon.ts, stopping…'));
+    await ops.stopUnit(r);
+    const idx = running.indexOf(r);
+    if (idx !== -1) running.splice(idx, 1);
+  }
+
+  for (const r of plan.restart) ops.restartUnit(r);
+
+  if (plan.add.length > 0) {
+    const added = plan.add.map((unit) => {
+      const r = makeRunningUnit(unit);
+      running.push(r);
+      logUnit(unit, chalk.dim('added in neon.ts, starting…'));
+      return r;
+    });
+    await Promise.all(added.map((r) => ops.startUnit(r)));
+    for (const r of added) {
+      if (r.status === 'ready') {
+        logUnit(r.unit, chalk.green('ready') + ` ${urlFor(r.boundPort)}`);
+      }
+    }
+  }
+};
+
+/**
+ * Choose a port search base above every port the live units already bound, so a hot-added
+ * search-mode function starts probing where there's room. The runtime still walks upward
+ * from here, so it never fails even if this guess is taken — it just keeps things tidy.
+ */
+const nextSearchBase = (running: RunningUnit[]): number => {
+  let max = DEFAULT_PORT_BASE - 1;
+  for (const r of running) {
+    if (r.boundPort !== null && r.boundPort > max) max = r.boundPort;
+  }
+  return max + 1;
 };
 
 const hasPortlessUnit = (units: ServedUnit[]): boolean =>
@@ -560,6 +782,27 @@ const startWatcher = async (
     return startDirectoryWatcher(chokidar, source, restart);
   }
   return startInputWatcher(chokidar, source, initialInputs, restart);
+};
+
+/**
+ * Watch the neon.ts file itself for changes, firing `onChange` on every save. Used by the
+ * supervisor (config mode only) to hot-add/remove/restart functions when the declared set
+ * changes. We watch the single config file rather than its import graph: editing neon.ts to
+ * add or remove a function is the case that matters, and a plain file watch is robust where
+ * the esbuild-based input resolution (built for function bundles) is not a fit for a
+ * jiti-loaded config.
+ */
+const startConfigWatcher = async (
+  configPath: string,
+  onChange: () => void,
+): Promise<Watcher> => {
+  const { default: chokidar } = await import('chokidar');
+  const watcher = chokidar.watch(configPath, { ignoreInitial: true });
+  await once(watcher, 'ready');
+  watcher.on('all', () => {
+    onChange();
+  });
+  return { sync: () => Promise.resolve(), close: () => watcher.close() };
 };
 
 type Chokidar = typeof import('chokidar').default;

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -414,19 +414,21 @@ const promptProjectChoice = async (
   suggestedName?: string,
 ): Promise<ProjectChoice> => {
   const choices = [
+    { title: '＋ Create new project…', value: CREATE_NEW_SENTINEL },
     ...projects.map((project) => ({
       title: `${project.name} (${project.id})`,
       value: project.id,
     })),
-    { title: '+ Create new project', value: CREATE_NEW_SENTINEL },
   ];
+  // Create sits at the top, so default to the first existing project (index 1) when there
+  // is one; with no projects to show, the create option (index 0) is the only choice.
   const { selection } = await prompts({
     onState: onPromptState,
     type: 'select',
     name: 'selection',
     message: 'Which project would you like to link?',
     choices,
-    initial: choices.length === 1 ? 0 : 0,
+    initial: projects.length > 0 ? 1 : 0,
   });
   if (selection === CREATE_NEW_SENTINEL) {
     return { type: 'create', suggestedName };

--- a/src/config_format.test.ts
+++ b/src/config_format.test.ts
@@ -1,0 +1,81 @@
+import type { ResolvedBranchConfig } from '@neondatabase/config';
+import type { PulledBranchConfig } from '@neondatabase/config-runtime';
+import { describe, expect, it } from 'vitest';
+
+import { formatDurationSeconds, toNeonConfigView } from './config_format.js';
+
+describe('formatDurationSeconds', () => {
+  it('renders clean unit boundaries, preferring the largest unit', () => {
+    expect(formatDurationSeconds(604800)).toBe('1w'); // 7 days collapses to 1 week
+    expect(formatDurationSeconds(3 * 24 * 60 * 60)).toBe('3d');
+    expect(formatDurationSeconds(3600)).toBe('1h');
+    expect(formatDurationSeconds(300)).toBe('5m');
+    expect(formatDurationSeconds(2 * 7 * 24 * 60 * 60)).toBe('2w');
+  });
+
+  it('falls back to seconds when no clean unit matches', () => {
+    expect(formatDurationSeconds(90)).toBe('90s');
+  });
+});
+
+describe('toNeonConfigView', () => {
+  const base: ResolvedBranchConfig = {
+    authEnabled: false,
+    dataApiEnabled: false,
+  };
+
+  it('omits disabled services and an empty branch/preview', () => {
+    expect(toNeonConfigView(base, undefined)).toEqual({});
+  });
+
+  it('surfaces enabled services as `true` only', () => {
+    const view = toNeonConfigView(
+      { authEnabled: true, dataApiEnabled: true },
+      undefined,
+    );
+    expect(view).toEqual({ auth: true, dataApi: true });
+  });
+
+  it('renders the branch tuning section, with ttl as a duration string', () => {
+    const view = toNeonConfigView(
+      {
+        authEnabled: false,
+        dataApiEnabled: false,
+        parent: 'main',
+        ttlSeconds: 604800,
+        protected: true,
+        postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+      },
+      undefined,
+    );
+    expect(view.branch).toEqual({
+      parent: 'main',
+      ttl: '1w',
+      protected: true,
+      postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+    });
+  });
+
+  it('projects preview functions/buckets into slug/name-keyed records', () => {
+    const preview: PulledBranchConfig['preview'] = {
+      aiGatewayEnabled: true,
+      functions: [{ slug: 'hello', name: 'Hello' }],
+      buckets: [{ name: 'uploads', access: 'public_read' }],
+    };
+    const view = toNeonConfigView(base, preview);
+    expect(view.preview).toEqual({
+      aiGateway: true,
+      functions: { hello: { name: 'Hello' } },
+      buckets: { uploads: { access: 'public_read' } },
+    });
+  });
+
+  it('omits an all-empty preview', () => {
+    const preview: PulledBranchConfig['preview'] = {
+      aiGatewayEnabled: false,
+      functions: [],
+      buckets: [],
+    };
+    expect(toNeonConfigView(base, preview).preview).toBeUndefined();
+  });
+});

--- a/src/config_format.ts
+++ b/src/config_format.ts
@@ -1,0 +1,97 @@
+import type { ResolvedBranchConfig } from '@neondatabase/config';
+import type { PulledBranchConfig } from '@neondatabase/config-runtime';
+
+/**
+ * Render a TTL in whole seconds back to the canonical `neon.ts` duration string (e.g.
+ * `604800` -> `"7d"`), falling back to seconds when no clean unit boundary matches. Mirrors
+ * the formatter `@neondatabase/config` uses when it emits a TTL, so `config status` shows
+ * the same value a user would write in `neon.ts`.
+ */
+export const formatDurationSeconds = (totalSeconds: number): string => {
+  const units = [
+    ['w', 7 * 24 * 60 * 60],
+    ['d', 24 * 60 * 60],
+    ['h', 60 * 60],
+    ['m', 60],
+  ] as const;
+  for (const [unit, perUnit] of units) {
+    if (totalSeconds % perUnit === 0) return `${totalSeconds / perUnit}${unit}`;
+  }
+  return `${totalSeconds}s`;
+};
+
+/**
+ * The `neon.ts`-shaped view of a branch's live configuration, mirroring how a user would
+ * author it in `defineConfig({ ... })` — minus the `branch` *closure* wrapper, since the
+ * remote only has concrete resolved values. Every field is omitted when it carries no
+ * signal (a disabled service, an empty preview), so `config status` reads like a minimal
+ * `neon.ts`.
+ */
+export type NeonConfigView = {
+  auth?: true;
+  dataApi?: true;
+  preview?: {
+    aiGateway?: true;
+    functions?: Record<string, { name: string }>;
+    buckets?: Record<string, { access: string }>;
+  };
+  branch?: {
+    parent?: string;
+    ttl?: string;
+    protected?: boolean;
+    postgres?: ResolvedBranchConfig['postgres'];
+  };
+};
+
+/**
+ * Project a resolved branch config (plus the separately-pulled preview state, since
+ * functions/buckets don't live on the closure) into a {@link NeonConfigView}.
+ *
+ * - Service toggles are surfaced as `true` only when enabled (disabled is the absence of
+ *   the key, exactly as in `neon.ts`).
+ * - `ttlSeconds` is rendered back to a duration string (`7d`).
+ * - The `branch` section is the JSON-able part of what would otherwise be the `branch`
+ *   closure: `parent` / `ttl` / `protected` / `postgres.computeSettings`.
+ * - `branch` and `preview` are omitted entirely when they would be empty.
+ */
+export const toNeonConfigView = (
+  resolved: ResolvedBranchConfig,
+  preview: PulledBranchConfig['preview'],
+): NeonConfigView => {
+  const view: NeonConfigView = {};
+
+  if (resolved.authEnabled) view.auth = true;
+  if (resolved.dataApiEnabled) view.dataApi = true;
+
+  const previewView = toPreviewView(preview);
+  if (previewView) view.preview = previewView;
+
+  const branch: NeonConfigView['branch'] = {};
+  if (resolved.parent !== undefined) branch.parent = resolved.parent;
+  if (resolved.ttlSeconds !== undefined)
+    branch.ttl = formatDurationSeconds(resolved.ttlSeconds);
+  if (resolved.protected !== undefined) branch.protected = resolved.protected;
+  if (resolved.postgres?.computeSettings) branch.postgres = resolved.postgres;
+  if (Object.keys(branch).length > 0) view.branch = branch;
+
+  return view;
+};
+
+const toPreviewView = (
+  preview: PulledBranchConfig['preview'],
+): NeonConfigView['preview'] | undefined => {
+  if (!preview) return undefined;
+  const out: NonNullable<NeonConfigView['preview']> = {};
+  if (preview.aiGatewayEnabled) out.aiGateway = true;
+  if (preview.functions.length > 0) {
+    out.functions = Object.fromEntries(
+      preview.functions.map((fn) => [fn.slug, { name: fn.name }]),
+    );
+  }
+  if (preview.buckets.length > 0) {
+    out.buckets = Object.fromEntries(
+      preview.buckets.map((b) => [b.name, { access: b.access }]),
+    );
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -30,6 +30,12 @@ type FakeOverrides = {
   getNeonDataApi?: NeonApi['getNeonDataApi'];
   /** Override `listBranches` (e.g. to make it throw for the graceful-degrade case). */
   listBranches?: NeonApi['listBranches'];
+  /**
+   * Override `listBranchFunctions` (e.g. to make it throw, simulating an undeployed
+   * function / Functions Preview disabled). Defaults to returning `[]`. When the env path
+   * is correct this is never called, since functions carry no branch env.
+   */
+  listBranchFunctions?: NeonApi['listBranchFunctions'];
 };
 
 /**
@@ -174,7 +180,17 @@ class FakeNeonApi implements NeonApi {
     throw new Error('not implemented');
   }
 
-  async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+  /** Set true the first time `listBranchFunctions` is called, so tests can assert it isn't. */
+  listBranchFunctionsCalled = false;
+
+  async listBranchFunctions(
+    projectId: string,
+    branchId: string,
+  ): Promise<NeonFunctionSnapshot[]> {
+    this.listBranchFunctionsCalled = true;
+    if (this.overrides.listBranchFunctions) {
+      return this.overrides.listBranchFunctions(projectId, branchId);
+    }
     return [];
   }
 
@@ -349,5 +365,69 @@ describe('resolveDevEnv', () => {
         api,
       }),
     ).resolves.toEqual({});
+  });
+
+  it('tier 1 functions-only: never calls the functions API, still injects DATABASE_URL', async () => {
+    // A functions-only policy. Functions carry no branch env (their env is the local
+    // `functions.<slug>.env`, layered by the dev server), so env resolution must not
+    // enumerate the functions API at all.
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default { preview: { functions: { hello: ' +
+        "{ name: 'Hello', source: './hello.ts' } } } };\n",
+    );
+    const api = new FakeNeonApi();
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(result.DATABASE_URL).toBeDefined();
+    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(api.listBranchFunctionsCalled).toBe(false);
+  });
+
+  it('tier 1 functions-only: an undeployed/unavailable function does not sink env injection', async () => {
+    // Simulate the real-world failure: the Functions Preview is not enabled for the project,
+    // so listBranchFunctions errors. Because the env path strips functions, that API is never
+    // hit and DATABASE_URL is still injected (instead of dropping ALL env, as it used to).
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default { preview: { functions: { hello: ' +
+        "{ name: 'Hello', source: './hello.ts' } } } };\n",
+    );
+    const api = new FakeNeonApi({
+      listBranchFunctions: async () => {
+        throw new Error('platform functions not available for this project');
+      },
+    });
+
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+
+    expect(result.DATABASE_URL).toBeDefined();
+    expect(api.listBranchFunctionsCalled).toBe(false);
+  });
+
+  it('tier 1 functions + auth mismatch: a missing secret-bearing service still hard-stops', async () => {
+    // Stripping functions must NOT weaken the guard for services that DO carry secrets: a
+    // neon.ts enabling auth on a branch that lacks it still throws, pointing at deploy.
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default { auth: {}, preview: { functions: { hello: ' +
+        "{ name: 'Hello', source: './hello.ts' } } } };\n",
+    );
+    const api = new FakeNeonApi(); // getNeonAuth -> null (branch has no auth)
+
+    await expect(
+      resolveDevEnv({ cwd, projectId: PROJECT_ID, branchId: BRANCH_ID, api }),
+    ).rejects.toBeInstanceOf(DevEnvMismatchError);
   });
 });

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -74,8 +74,17 @@ export const resolveNeonEnvVars = async (
           '--project-id / --branch.',
       );
     }
-    await assertPolicyMatchesBranch(config, ctx);
-    return await fetchAndProject(config, ctx);
+    // Resolve env from the policy with its `preview.functions` removed. Functions carry no
+    // branch-level secrets — their env comes from the local `neon.ts` `functions.<slug>.env`,
+    // layered per-function by the dev server — so env resolution never needs the functions
+    // API. Probing it (via `plan`/`fetchEnv`) only adds a failure mode: an undeployed
+    // function, or a project where the Functions Preview isn't enabled, would error and sink
+    // ALL injection (including DATABASE_URL). Stripping functions keeps env resolution honest
+    // while leaving buckets / AI Gateway / Auth / Data API fully checked — those DO carry
+    // secrets, so a declared-but-missing one still hard-stops (see assertPolicyMatchesBranch).
+    const envConfig = withoutPreviewFunctions(config);
+    await assertPolicyMatchesBranch(envConfig, ctx);
+    return await fetchAndProject(envConfig, ctx);
   }
 
   if (ctx.projectId && ctx.branchId) {
@@ -123,14 +132,31 @@ export const resolveDevEnv = async (
 };
 
 /**
+ * Return the policy with its `preview.functions` removed, so the env path never enumerates
+ * functions against the Neon API. Functions are local-source-bundled and produce no
+ * branch-level secrets, so they are irrelevant to env resolution; probing them only risks
+ * failing the whole resolve (undeployed function, or Functions Preview disabled on the
+ * project). Buckets / AI Gateway and the top-level Auth / Data API toggles are preserved —
+ * they DO carry env, so they must still be checked and resolved. Returns the config
+ * unchanged when it declares no functions.
+ */
+const withoutPreviewFunctions = (config: Config): Config => {
+  const preview = config.preview;
+  if (!preview?.functions) return config;
+  const previewWithoutFunctions = { ...preview };
+  delete previewWithoutFunctions.functions;
+  return { ...config, preview: previewWithoutFunctions };
+};
+
+/**
  * Tier-1 guard. Dry-run the policy against the branch's live state and stop if
  * it declares a branch-level resource the branch is missing. Built on `plan` so
  * it covers every present and future provisionable resource for free: any
  * `create` action is a resource `neonctl deploy` would provision.
  *
- * Functions are deliberately excluded: running an *un*deployed function locally
- * is the whole point of `neon dev`, so a not-yet-deployed function in the policy
- * must not block the dev server.
+ * Called with functions already stripped (see {@link withoutPreviewFunctions}), so the
+ * `plan` probe never enumerates the functions API — an undeployed function, or a project
+ * without the Functions Preview, must never block local dev or sink env injection.
  */
 const assertPolicyMatchesBranch = async (
   config: Config,

--- a/src/dev/functions.test.ts
+++ b/src/dev/functions.test.ts
@@ -41,7 +41,9 @@ describe('resolveFunctionsFromConfig', () => {
 
   it('returns an empty list when neon.ts declares no functions', async () => {
     writeWorkspace(cwd, 'export default {};\n', []);
-    await expect(resolveFunctionsFromConfig(cwd)).resolves.toEqual([]);
+    const resolved = await resolveFunctionsFromConfig(cwd);
+    expect(resolved?.functions).toEqual([]);
+    expect(resolved?.configPath).toBe(join(cwd, 'neon.ts'));
   });
 
   it('resolves each function with an absolute source and its dev settings', async () => {
@@ -59,8 +61,10 @@ describe('resolveFunctionsFromConfig', () => {
       ['hello.ts', 'api.ts', 'bare.ts'],
     );
 
-    const fns = await resolveFunctionsFromConfig(cwd);
-    expect(fns).not.toBeNull();
+    const resolved = await resolveFunctionsFromConfig(cwd);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.configPath).toBe(join(cwd, 'neon.ts'));
+    const fns = resolved?.functions;
     const bySlug = Object.fromEntries((fns ?? []).map((f) => [f.slug, f]));
 
     expect(bySlug.hello).toMatchObject({
@@ -107,7 +111,7 @@ describe('resolveFunctionsFromConfig', () => {
       };\n`,
       ['e.ts'],
     );
-    const fns = await resolveFunctionsFromConfig(cwd);
-    expect(fns?.[0].env).toEqual({ FOO: 'bar' });
+    const resolved = await resolveFunctionsFromConfig(cwd);
+    expect(resolved?.functions[0].env).toEqual({ FOO: 'bar' });
   });
 });

--- a/src/dev/functions.ts
+++ b/src/dev/functions.ts
@@ -24,6 +24,17 @@ export type PlannedFunction = {
 };
 
 /**
+ * The result of resolving `neon.ts`: the path to the config file that was loaded (so the
+ * dev server can watch it for hot-add/remove of functions) plus the {@link PlannedFunction}s
+ * it declares.
+ */
+export type ResolvedConfigFunctions = {
+  /** Absolute path to the loaded `neon.ts` (or `.mts`/`.js`/`.mjs`). */
+  configPath: string;
+  functions: PlannedFunction[];
+};
+
+/**
  * Load `neon.ts` (if any) and resolve the list of functions it declares into
  * {@link PlannedFunction}s for `neon dev` to serve. Returns `null` when there is no
  * `neon.ts` on the path from `cwd` up to the repo root — the caller turns that into a
@@ -35,18 +46,18 @@ export type PlannedFunction = {
 export const resolveFunctionsFromConfig = async (
   cwd: string,
   branchName?: string,
-): Promise<PlannedFunction[] | null> => {
+): Promise<ResolvedConfigFunctions | null> => {
   const loaded = await loadNeonConfig(cwd);
   if (!loaded) return null;
 
-  const { config, configDir } = loaded;
+  const { config, configDir, configPath } = loaded;
   const resolved = resolveConfig(config, {
     name: branchName ?? 'local',
     exists: branchName !== undefined,
   });
 
   const functions = resolved.preview?.functions ?? [];
-  return functions.map((fn) => {
+  const planned = functions.map((fn) => {
     const source = isAbsolute(fn.source)
       ? fn.source
       : resolve(configDir, fn.source);
@@ -67,6 +78,8 @@ export const resolveFunctionsFromConfig = async (
       env: { ...fn.env },
     };
   });
+
+  return { configPath, functions: planned };
 };
 
 /**
@@ -77,17 +90,22 @@ export const resolveFunctionsFromConfig = async (
 const devPort = (dev: FunctionDevConfig | undefined): number | undefined =>
   dev?.port;
 
-type LoadedConfig = { config: Config; configDir: string };
+type LoadedConfig = { config: Config; configDir: string; configPath: string };
 
 /**
- * Load a `neon.ts` policy if one exists, returning the loaded config and the directory
- * it lives in (used to resolve each function's relative `source`). Returns `null` when no
- * config file is found; surfaces real load errors (e.g. a syntax error).
+ * Load a `neon.ts` policy if one exists, returning the loaded config, the resolved path to
+ * the config file (used by the dev server to watch it), and the directory it lives in (used
+ * to resolve each function's relative `source`). Returns `null` when no config file is
+ * found; surfaces real load errors (e.g. a syntax error).
  */
 const loadNeonConfig = async (cwd: string): Promise<LoadedConfig | null> => {
   try {
     const { config, resolvedPath } = await loadConfigFromFile({ cwd });
-    return { config, configDir: dirname(resolvedPath) };
+    return {
+      config,
+      configDir: dirname(resolvedPath),
+      configPath: resolvedPath,
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (/Could not find a Neon config file/i.test(message)) {


### PR DESCRIPTION
Combines two features into one PR with a single minor version bump (`2.23.1` → `2.24.0`). Supersedes and includes #519.

---

## 1. `feat(dev)`: hot-add/remove functions on `neon.ts` change without restarting

Today `neon dev` (config mode) snapshots the function list from `neon.ts` once at startup. The config file itself is never watched, and the supervisor can only re-bundle/restart the units it started with — so **adding a function to `neon.ts` requires fully restarting `neon dev`**.

This makes `neon dev` reconcile its live set of function dev servers whenever `neon.ts` changes, keyed by slug:

- **Added** function → hot-added (its own child process, source watcher, and port).
- **Removed** function → torn down (child reaped, watcher closed, bundle dir cleaned).
- **Changed** function config (source/port/portless/env) → restarted in place.
- **Unchanged** function → left completely alone (object identity preserved; never bounced).

So adding a function while `neon dev` is running no longer kills or disrupts the functions that were already serving — they keep running, and the new one comes up alongside them. Scope is `neon.ts` (config) mode only; single `--source` mode is unaffected.

### What changed
- **`src/dev/functions.ts`** — `resolveFunctionsFromConfig` now returns `{ configPath, functions }` so the supervisor knows which `neon.ts` to watch.
- **`src/commands/dev.ts`**
  - Refactored `runSupervisor` around per-unit `startUnit`/`stopUnit` lifecycle helpers and a **mutable** running set.
  - Added a `neon.ts` watcher (`startConfigWatcher`) driving a **serialized** reconciler (a burst of editor saves coalesces into one trailing run; a `neon.ts` that fails to load is reported and ignored rather than crashing the server).
  - Pure, unit-tested slug diff (`diffUnits`) decides add/remove/restart. A per-unit `configKey` (source/port/portless/env, **independent of the dynamic port search base**) distinguishes a real change from a no-op save.
  - Hot-added functions search for a free port **above** the already-bound ones — consistent with the existing contract: if no port is specified we never fail, the runtime walks upward.

---

## 2. `feat(config)`: resolved `neon.ts`-shaped config in `status` + `--config-json` (was #519)

`neon config status` previously rendered the raw pulled `Config`. Its branch tuning lives in a **closure** that JSON can't serialize, so the `Config` column always showed `{}` — even on a branch with real compute settings.

This resolves the pulled config against the live branch and projects it (plus the separately-pulled preview state) into a **`neon.ts`-shaped view** — i.e. what you'd write in `defineConfig({ ... })`, minus the closure wrapper. Top-level `auth`/`dataApi` toggles, a `branch` section (parent/ttl/protected/postgres.computeSettings), and `preview` (functions/buckets/aiGateway). `ttl` is rendered back to a duration string (e.g. `7d` → `1w`).

Also adds **`--config-json`**: prints just that view to stdout (script-friendly / copy-paste into a `neon.ts`). Empty sections are omitted, so a vanilla branch reads as `{}`.

> Note: compute settings only appear when they differ from the project's default endpoint settings (how `pullConfig` reports them). Always echoing effective compute config would be a follow-up in `pullConfig`.

---

## Version

`2.23.1` → `2.24.0` (single minor bump covering both features).

## Test plan
- [x] `pnpm typecheck` / `eslint` / `prettier --check` clean
- [x] `pnpm build` succeeds (and `parameters.gen.ts` is unchanged)
- [x] Unit tests for the `diffUnits` reconciler: add / remove / restart-on-change / no-op unchanged / `neon.ts` deleted / mixed
- [x] Updated `resolveFunctionsFromConfig` tests for the new `{ configPath, functions }` shape
- [x] `config_format` unit tests + `config status` resolved-view test + `--config-json` stdout test
- [ ] Manual: run `neon dev` with a multi-function `neon.ts`, then add / remove / edit a function entry and confirm the others keep serving uninterrupted