### PR TITLE
feat(dev): make injected env transparent in the dev server

### DIFF
--- a/src/commands/dev.test.ts
+++ b/src/commands/dev.test.ts
@@ -2,7 +2,12 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { test } from '../test_utils/fixtures';
-import { diffUnits, type RunningUnit, type ServedUnit } from './dev.js';
+import {
+  diffUnits,
+  formatEnvSummary,
+  type RunningUnit,
+  type ServedUnit,
+} from './dev.js';
 
 describe('dev', () => {
   test('exits 1 when no --source and no neon.ts is found', async ({
@@ -133,5 +138,39 @@ describe('diffUnits', () => {
     expect(plan.restart.map((r) => r.unit.slug)).toEqual(['change']);
     // 'keep' is never in any bucket and its object identity is preserved.
     expect(running[0].unit).toBe(keep);
+  });
+});
+
+/**
+ * The transparent env line in the dev banner: shows the *names* of the env vars injected
+ * into each function (Neon branch vars + the function's own neon.ts env keys), never values.
+ */
+describe('formatEnvSummary', () => {
+  it('lists Neon branch vars and neon.ts keys, each sorted, in distinct groups', () => {
+    expect(
+      formatEnvSummary({
+        neon: ['DATABASE_URL_UNPOOLED', 'DATABASE_URL'],
+        fn: ['STRIPE_KEY', 'RESEND_API_KEY'],
+      }),
+    ).toBe(
+      'env: DATABASE_URL, DATABASE_URL_UNPOOLED · neon.ts: RESEND_API_KEY, STRIPE_KEY',
+    );
+  });
+
+  it('shows only the Neon group when the function declares no env', () => {
+    expect(formatEnvSummary({ neon: ['DATABASE_URL'], fn: [] })).toBe(
+      'env: DATABASE_URL',
+    );
+  });
+
+  it('shows only the neon.ts group when no Neon env was injected', () => {
+    expect(formatEnvSummary({ neon: [], fn: ['RESEND_API_KEY'] })).toBe(
+      'neon.ts: RESEND_API_KEY',
+    );
+  });
+
+  it('returns an empty string when nothing is injected (caller skips the line)', () => {
+    expect(formatEnvSummary({ neon: [], fn: [] })).toBe('');
+    expect(formatEnvSummary(undefined)).toBe('');
   });
 });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -86,7 +86,7 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
   }
 
   const branchId = await resolveBranchId(props);
-  const neonEnv = await resolveDevEnv({
+  const { vars: neonEnv, skipped } = await resolveDevEnv({
     cwd: process.cwd(),
     ...(props.projectId ? { projectId: props.projectId } : {}),
     ...(branchId ? { branchId } : {}),
@@ -99,11 +99,14 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
     bundleDir: join(process.cwd(), 'node_modules', '.neon-dev'),
     childEnv: buildChildEnv(neonEnv, portFromProps(props.port)),
     label: null,
+    envSummary: { neon: Object.keys(neonEnv), fn: [] },
   };
 
   // No config reload in single-source mode: there's exactly one file to serve, and
   // nothing to add or remove. neon.ts hot-reload is config-mode only.
-  await runSupervisor([unit]);
+  await runSupervisor([unit], {
+    ...(skipped ? { envNote: skipped.reason } : {}),
+  });
 };
 
 /**
@@ -129,7 +132,7 @@ const runFromConfig = async (props: DevProps): Promise<void> => {
     );
   }
 
-  const neonEnv = await resolveDevEnv({
+  const { vars: neonEnv, skipped } = await resolveDevEnv({
     cwd: process.cwd(),
     ...(props.projectId ? { projectId: props.projectId } : {}),
     ...(branchId ? { branchId } : {}),
@@ -148,7 +151,10 @@ const runFromConfig = async (props: DevProps): Promise<void> => {
     return planFunctionsToUnits(re.functions, neonEnv, searchBase);
   };
 
-  await runSupervisor(units, { configPath, replan });
+  await runSupervisor(units, {
+    reload: { configPath, replan },
+    ...(skipped ? { envNote: skipped.reason } : {}),
+  });
 };
 
 /** Re-resolve neon.ts into units, searching ports from `searchBase`. `null` if neon.ts vanished. */
@@ -158,6 +164,17 @@ type Replan = (searchBase: number) => Promise<ServedUnit[] | null>;
 type ConfigReload = {
   configPath: string;
   replan: Replan;
+};
+
+/** Options for {@link runSupervisor}. */
+type SupervisorOptions = {
+  /** Present in config mode: lets the supervisor watch neon.ts and reconcile the unit set. */
+  reload?: ConfigReload;
+  /**
+   * A calm, one-line reason shown in the banner when no Neon branch env could be injected
+   * (e.g. not linked). Functions still run; this just explains the absence of DATABASE_URL.
+   */
+  envNote?: string;
 };
 
 /**
@@ -250,6 +267,7 @@ const plannedToUnit = (
     bundleDir: join(process.cwd(), 'node_modules', '.neon-dev', fn.slug),
     childEnv,
     label: fn.slug,
+    envSummary: { neon: Object.keys(branchEnv), fn: Object.keys(fn.env) },
     // Signature of the function's *own* neon.ts config (NOT the dynamically-chosen search
     // base) so reconcile can tell a real change from a no-op save. A search-mode function
     // re-planned with a different base must hash identically, or it would be needlessly
@@ -302,6 +320,12 @@ export type ServedUnit = {
    * port search base. Absent in single-source mode (no reconcile there).
    */
   configKey?: string;
+  /**
+   * The env-var *names* injected into this unit, split by origin, for a transparent dev
+   * banner: `neon` are the Neon branch vars (DATABASE_URL, …), `fn` are the keys from this
+   * function's `neon.ts` `env` block. Values are intentionally omitted (secrets).
+   */
+  envSummary?: { neon: string[]; fn: string[] };
   portless?: { slug: string };
 };
 
@@ -333,8 +357,9 @@ const READY_PATTERN = /neon-dev:ready (\d+)/;
  */
 const runSupervisor = async (
   units: ServedUnit[],
-  reload?: ConfigReload,
+  options: SupervisorOptions = {},
 ): Promise<void> => {
+  const { reload, envNote } = options;
   if (hasPortlessUnit(units)) {
     assertPortlessAvailable();
   }
@@ -437,7 +462,7 @@ const runSupervisor = async (
     throw new Error('No function started. See the output above for details.');
   }
 
-  printBanner(running);
+  printBanner(running, envNote);
 
   // Config mode only: watch neon.ts and reconcile the live unit set when it changes.
   // Reconciles are serialized: a burst of saves (editor write-then-format) must not run
@@ -608,7 +633,13 @@ const reconcileOnce = async (
     await Promise.all(added.map((r) => ops.startUnit(r)));
     for (const r of added) {
       if (r.status === 'ready') {
-        logUnit(r.unit, chalk.green('ready') + ` ${urlFor(r.boundPort)}`);
+        const env = formatEnvSummary(r.unit.envSummary);
+        logUnit(
+          r.unit,
+          chalk.green('ready') +
+            ` ${urlFor(r.boundPort)}` +
+            (env ? chalk.dim(`  ${env}`) : ''),
+        );
       }
     }
   }
@@ -750,7 +781,7 @@ const pipeChildOutput = (child: ChildProcess, label: string | null): void => {
   forward('stderr');
 };
 
-const printBanner = (running: RunningUnit[]): void => {
+const printBanner = (running: RunningUnit[], envNote?: string): void => {
   log.info('');
   log.info(chalk.green.bold('  Neon Functions dev server'));
   log.info('');
@@ -758,8 +789,32 @@ const printBanner = (running: RunningUnit[]): void => {
     const name = r.unit.label ?? 'function';
     const url = urlFor(r.boundPort);
     log.info(`  ${chalk.dim(name.padEnd(20))} ${url}`);
+    const env = formatEnvSummary(r.unit.envSummary);
+    if (env) log.info(`  ${' '.repeat(20)} ${chalk.dim(env)}`);
+  }
+  if (envNote) {
+    log.info('');
+    log.info(`  ${chalk.yellow('!')} ${chalk.dim(`Neon env: ${envNote}`)}`);
   }
   log.info('');
+};
+
+/**
+ * Render a unit's injected env into one transparent line for the banner, e.g.
+ * `env: DATABASE_URL, DATABASE_URL_UNPOOLED · neon.ts: RESEND_API_KEY`. Var **names** only
+ * (never values — they're secrets). Returns `''` when nothing is injected, so the caller can
+ * skip the line. Exported for unit testing.
+ */
+export const formatEnvSummary = (summary: ServedUnit['envSummary']): string => {
+  if (!summary) return '';
+  const parts: string[] = [];
+  if (summary.neon.length > 0) {
+    parts.push(`env: ${[...summary.neon].sort().join(', ')}`);
+  }
+  if (summary.fn.length > 0) {
+    parts.push(`neon.ts: ${[...summary.fn].sort().join(', ')}`);
+  }
+  return parts.join(' · ');
 };
 
 const logUnit = (unit: ServedUnit, message: string): void => {

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -230,8 +230,10 @@ describe('resolveDevEnv', () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  it('tier 3: no neon.ts and no project/branch -> {}', async () => {
-    await expect(resolveDevEnv({ cwd })).resolves.toEqual({});
+  it('tier 3: no neon.ts and no project/branch -> empty vars + a "link a branch" note', async () => {
+    const result = await resolveDevEnv({ cwd });
+    expect(result.vars).toEqual({});
+    expect(result.skipped?.reason).toMatch(/neonctl link/);
   });
 
   it('tier 2: no neon.ts but project + branch -> pooled + unpooled DATABASE_URL', async () => {
@@ -242,10 +244,11 @@ describe('resolveDevEnv', () => {
       api: new FakeNeonApi(),
     });
 
-    expect(result.DATABASE_URL).toContain('-pooler.fake.neon.tech');
-    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
-    expect(result.DATABASE_URL_UNPOOLED).not.toContain('-pooler.');
-    expect(result.NEON_AUTH_BASE_URL).toBeUndefined();
+    expect(result.vars.DATABASE_URL).toContain('-pooler.fake.neon.tech');
+    expect(result.vars.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.vars.DATABASE_URL_UNPOOLED).not.toContain('-pooler.');
+    expect(result.vars.NEON_AUTH_BASE_URL).toBeUndefined();
+    expect(result.skipped).toBeUndefined();
   });
 
   it('tier 2 with Auth integration present: surfaces NEON_AUTH_BASE_URL too', async () => {
@@ -269,12 +272,12 @@ describe('resolveDevEnv', () => {
       api,
     });
 
-    expect(Object.keys(result).sort()).toEqual([
+    expect(Object.keys(result.vars).sort()).toEqual([
       'DATABASE_URL',
       'DATABASE_URL_UNPOOLED',
       'NEON_AUTH_BASE_URL',
     ]);
-    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+    expect(result.vars.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 
   it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {
@@ -295,9 +298,9 @@ describe('resolveDevEnv', () => {
       api,
     });
 
-    expect(result.DATABASE_URL).toBeDefined();
-    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
-    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+    expect(result.vars.DATABASE_URL).toBeDefined();
+    expect(result.vars.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.vars.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 
   it('tier 1 mismatch: neon.ts enables auth the branch lacks -> throws DevEnvMismatchError', async () => {
@@ -347,24 +350,24 @@ describe('resolveDevEnv', () => {
       api,
     });
 
-    expect(result.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+    expect(result.vars.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });
 
-  it('graceful: an api whose listBranches throws -> {} (does not throw)', async () => {
+  it('graceful: an api whose listBranches throws -> empty vars + a "could not reach Neon" note', async () => {
     const api = new FakeNeonApi({
       listBranches: async () => {
         throw new Error('network down');
       },
     });
 
-    await expect(
-      resolveDevEnv({
-        cwd,
-        projectId: PROJECT_ID,
-        branchId: BRANCH_ID,
-        api,
-      }),
-    ).resolves.toEqual({});
+    const result = await resolveDevEnv({
+      cwd,
+      projectId: PROJECT_ID,
+      branchId: BRANCH_ID,
+      api,
+    });
+    expect(result.vars).toEqual({});
+    expect(result.skipped?.reason).toMatch(/network down/);
   });
 
   it('tier 1 functions-only: never calls the functions API, still injects DATABASE_URL', async () => {
@@ -385,8 +388,8 @@ describe('resolveDevEnv', () => {
       api,
     });
 
-    expect(result.DATABASE_URL).toBeDefined();
-    expect(result.DATABASE_URL_UNPOOLED).toBeDefined();
+    expect(result.vars.DATABASE_URL).toBeDefined();
+    expect(result.vars.DATABASE_URL_UNPOOLED).toBeDefined();
     expect(api.listBranchFunctionsCalled).toBe(false);
   });
 
@@ -412,7 +415,7 @@ describe('resolveDevEnv', () => {
       api,
     });
 
-    expect(result.DATABASE_URL).toBeDefined();
+    expect(result.vars.DATABASE_URL).toBeDefined();
     expect(api.listBranchFunctionsCalled).toBe(false);
   });
 

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -106,28 +106,59 @@ export const resolveNeonEnvVars = async (
 };
 
 /**
+ * The outcome of {@link resolveDevEnv}: the resolved Neon branch vars plus, when none could
+ * be injected, a calm and actionable `skipped` reason for the dev server to surface. We
+ * return the reason rather than logging it here so the imperative shell (`neon dev`) can
+ * present it in context (in the banner, next to the URLs) — keeping this resolver a pure
+ * "compute what env we have" function.
+ */
+export type DevEnvResolution = {
+  /** Neon branch env vars to inject (DATABASE_URL[_UNPOOLED], NEON_AUTH_BASE_URL, …). */
+  vars: Record<string, string>;
+  /**
+   * Present only when `vars` is empty *because* resolution was skipped/degraded (not when
+   * the branch legitimately has no extra services). A short, actionable explanation.
+   */
+  skipped?: { reason: string };
+};
+
+/**
  * `neon dev`'s env resolver: {@link resolveNeonEnvVars} with graceful degradation.
- * A missing branch context or any failure (no Neon account, no `.neon`, no network)
- * logs a warning and returns `{}` so the function still runs locally; only a
- * {@link DevEnvMismatchError} (policy declares a resource the branch lacks) is
- * re-thrown for the caller to surface.
+ *
+ * - Success → `{ vars }` (possibly just the always-present Postgres URLs).
+ * - No linked branch / project → `{ vars: {}, skipped }` with a "link a branch" hint; the
+ *   function still runs locally, just without Neon env.
+ * - Any other failure (offline, transient API error) → `{ vars: {}, skipped }` naming the
+ *   cause; again non-fatal.
+ * - {@link DevEnvMismatchError} (policy declares a secret-bearing service the branch lacks)
+ *   is the one hard stop and is re-thrown for the caller to surface.
  */
 export const resolveDevEnv = async (
   ctx: DevEnvContext,
-): Promise<Record<string, string>> => {
+): Promise<DevEnvResolution> => {
   try {
-    return await resolveNeonEnvVars(ctx);
+    return { vars: await resolveNeonEnvVars(ctx) };
   } catch (err) {
     if (err instanceof DevEnvMismatchError) throw err;
     if (err instanceof MissingBranchContextError) {
       log.debug('dev: %s; skipping env injection', err.message);
-      return {};
+      return {
+        vars: {},
+        skipped: {
+          reason:
+            'no linked Neon branch — run `neonctl link`, then ' +
+            '`neonctl checkout <branch>`, to inject DATABASE_URL and friends',
+        },
+      };
     }
-    log.warning(
-      'Could not inject Neon env vars; the function will run without them: %s',
-      err instanceof Error ? err.message : String(err),
-    );
-    return {};
+    const detail = err instanceof Error ? err.message : String(err);
+    log.debug('dev: env resolution failed: %s', detail);
+    return {
+      vars: {},
+      skipped: {
+        reason: `could not reach Neon (${detail}); running without Neon env`,
+      },
+    };
   }
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #520 (the `neon dev` env fix that already shipped in v2.24.0). That fix stopped env injection from failing over preview functions, but the **experience** was still opaque: nothing told you what env each function actually received, and a degraded resolve surfaced as a red mid-startup warning.

This makes `neon dev` transparent about env — from first principles, the dev server should show exactly what each function gets and calmly explain any gaps.

- **Per-function env in the banner:** each function lists the injected Neon branch vars (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_AUTH_BASE_URL`, …) and its own `neon.ts` `env` keys. Names only — never values (secrets).
- **Calm, actionable note instead of a scary warning:** when no Neon branch env could be injected (e.g. not linked), the banner shows one line — `Neon env: no linked Neon branch — run \`neonctl link\`, then \`neonctl checkout <branch>\`…` — instead of a red warning mid-startup. Functions still run locally.
- **Hot-added functions** report their injected env on their ready line too.

Example:

```
  Neon Functions dev server

  hello                http://localhost:8787
                       env: DATABASE_URL, DATABASE_URL_UNPOOLED · neon.ts: RESEND_API_KEY
```

## Design

- `resolveDevEnv` now returns a structured `{ vars, skipped }` instead of swallowing failures into a `log.warning`. The resolver stays a pure "what env do we have" function (functional core); the dev command owns presentation (imperative shell).
- `runSupervisor` takes an options object `{ reload?, envNote? }` (was a positional `reload?`).
- New pure `formatEnvSummary` renderer, unit-tested.

## Test plan

- [x] `pnpm typecheck` / `eslint` / `prettier --check` clean
- [x] Unit tests for `formatEnvSummary` (both groups, each alone, empty)
- [x] `resolveDevEnv` tests updated to the `{ vars, skipped }` shape, asserting the skip reasons
- [x] Full dev/env/functions suites green (24 dev/env tests)
- [ ] Manual: `neon dev` linked (shows DATABASE_URL etc. per function) and unlinked (shows the calm note)

## Versioning

No manual `package.json` bump: this repo's release workflow owns the version (a manual bump in #520 was reverted by a maintainer, then `prepare-release.yml` cut v2.24.0). The `feat(dev):` title makes the next release **v2.25.0**.