### PR TITLE
feat(init): update wrapper for neon-init v2 orchestrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.14.0",
+    "neon-init": "0.15.0",
     "open": "10.1.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.14.0
-        version: 0.14.0
+        specifier: 0.15.0
+        version: 0.15.0
       open:
         specifier: 10.1.0
         version: 10.1.0
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.14.0:
-    resolution: {integrity: sha512-mA+KtMVdgZLSkv/k9zIMtiAOBIgsN+cRLOaXErXBWRgDz9SgGNNMl5DAA34HPxlV8Rikh4TDCD5dSuHAAoBscA==}
+  neon-init@0.15.0:
+    resolution: {integrity: sha512-D9LGMJdzHu0BfVIQhB/6+SUdCRdkCwKAsnMeYmB9Lln9g2Zs97oQc+kmAnRE4zcFlbdH2t/SOaXcRX1WV7Sm8w==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3699,6 +3699,11 @@ packages:
   yaml@2.4.5:
     resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
     engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@20.2.9:
@@ -6334,11 +6339,13 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.14.0:
+  neon-init@0.15.0:
     dependencies:
       '@clack/prompts': 0.10.1
       add-mcp: 1.8.0
       execa: 9.6.1
+      picocolors: 1.1.1
+      yaml: 2.9.0
       yargs: 18.0.0
       yoctocolors: 2.1.2
 
@@ -7356,6 +7363,8 @@ snapshots:
   yaml@2.3.1: {}
 
   yaml@2.4.5: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -10,6 +10,7 @@ vi.mock('../analytics.js', () => ({
 // Mock neon-init
 vi.mock('neon-init', () => ({
   init: vi.fn().mockResolvedValue(undefined),
+  interactiveInit: vi.fn().mockResolvedValue(undefined),
   orchestrate: vi.fn().mockResolvedValue({
     phase: 'setup',
     status: 'complete',
@@ -30,32 +31,42 @@ describe('init', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Interactive mode (v1) — no --json, no --agent
+  // Interactive mode — no --json, no --agent
   // -------------------------------------------------------------------------
 
-  test('should call init() with no options when agent is omitted', async () => {
+  test('should call interactiveInit() when no flags', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { interactiveInit } = await import('neon-init');
 
     await handler({});
 
-    expect(init).toHaveBeenCalledTimes(1);
-    expect(init).toHaveBeenCalledWith();
+    expect(interactiveInit).toHaveBeenCalledTimes(1);
+    expect(interactiveInit).toHaveBeenCalledWith({ preview: undefined });
   });
 
-  test('should log error and exit 1 when --agent is invalid (interactive mode)', async () => {
+  test('should pass --preview to interactiveInit()', async () => {
     const { handler } = await import('./init.js');
-    const { init, orchestrate } = await import('neon-init');
+    const { interactiveInit } = await import('neon-init');
+
+    await handler({ preview: true });
+
+    expect(interactiveInit).toHaveBeenCalledWith({ preview: true });
+  });
+
+  test('should use orchestrate when --agent is provided (not interactive)', async () => {
+    const { handler } = await import('./init.js');
+    const { interactiveInit, orchestrate } = await import('neon-init');
 
     await handler({ agent: 'invalid-agent' });
 
-    // When --agent is provided, jsonMode is true, so orchestrate is called with the raw agent string
+    // When --agent is provided, jsonMode is true, so orchestrate is called
     expect(orchestrate).toHaveBeenCalledWith({
       agent: 'invalid-agent',
       skipNeonAuth: undefined,
       skipMigrations: undefined,
+      preview: undefined,
     });
-    expect(init).not.toHaveBeenCalled();
+    expect(interactiveInit).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -73,6 +84,7 @@ describe('init', () => {
       agent: undefined,
       skipNeonAuth: undefined,
       skipMigrations: undefined,
+      preview: undefined,
     });
   });
 
@@ -87,10 +99,11 @@ describe('init', () => {
       agent: 'cursor',
       skipNeonAuth: undefined,
       skipMigrations: undefined,
+      preview: undefined,
     });
   });
 
-  test('should pass skip flags to orchestrate()', async () => {
+  test('should pass skip flags and preview to orchestrate()', async () => {
     const { handler } = await import('./init.js');
     const { orchestrate } = await import('neon-init');
 
@@ -98,12 +111,14 @@ describe('init', () => {
       json: true,
       skipNeonAuth: true,
       skipMigrations: true,
+      preview: true,
     });
 
     expect(orchestrate).toHaveBeenCalledWith({
       agent: undefined,
       skipNeonAuth: true,
       skipMigrations: true,
+      preview: true,
     });
   });
 
@@ -141,12 +156,12 @@ describe('init', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  test('should exit 1 when init() throws in interactive mode', async () => {
+  test('should exit 1 when interactiveInit() throws', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { interactiveInit } = await import('neon-init');
     const { sendError } = await import('../analytics.js');
 
-    vi.mocked(init).mockRejectedValueOnce(new Error('boom'));
+    vi.mocked(interactiveInit).mockRejectedValueOnce(new Error('boom'));
 
     await handler({});
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -7,71 +7,152 @@ vi.mock('../analytics.js', () => ({
   closeAnalytics: vi.fn(),
 }));
 
-vi.mock('../log.js', () => ({
-  log: { error: vi.fn(), info: vi.fn(), warning: vi.fn(), debug: vi.fn() },
-}));
-
 // Mock neon-init
 vi.mock('neon-init', () => ({
   init: vi.fn().mockResolvedValue(undefined),
+  orchestrate: vi.fn().mockResolvedValue({
+    phase: 'setup',
+    status: 'complete',
+    nextAction: { type: 'complete', message: 'Done' },
+  }),
 }));
 
 describe('init', () => {
   const exitSpy = vi
     .spyOn(process, 'exit')
     .mockImplementation((() => undefined) as never);
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true);
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  test('should call neon-init with no options when agent is omitted', async () => {
+  // -------------------------------------------------------------------------
+  // Interactive mode (v1) — no --json, no --agent
+  // -------------------------------------------------------------------------
+
+  test('should call init() with no options when agent is omitted', async () => {
     const { handler } = await import('./init.js');
     const { init } = await import('neon-init');
 
     await handler({});
 
     expect(init).toHaveBeenCalledTimes(1);
-    expect(init).toHaveBeenCalledWith(undefined);
+    expect(init).toHaveBeenCalledWith();
   });
 
-  test('should call neon-init with { agent: "Cursor" } when --agent cursor', async () => {
+  test('should log error and exit 1 when --agent is invalid (interactive mode)', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
-
-    await handler({ agent: 'cursor' });
-
-    expect(init).toHaveBeenCalledWith({ agent: 'Cursor' });
-  });
-
-  test('should call neon-init with { agent: "VS Code" } when --agent copilot', async () => {
-    const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
-
-    await handler({ agent: 'copilot' });
-
-    expect(init).toHaveBeenCalledWith({ agent: 'VS Code' });
-  });
-
-  test('should call neon-init with { agent: "Claude CLI" } when --agent claude', async () => {
-    const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
-
-    await handler({ agent: 'claude' });
-
-    expect(init).toHaveBeenCalledWith({ agent: 'Claude CLI' });
-  });
-
-  test('should log error and exit 1 when --agent is invalid', async () => {
-    const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
-    const { log } = await import('../log.js');
+    const { init, orchestrate } = await import('neon-init');
 
     await handler({ agent: 'invalid-agent' });
 
+    // When --agent is provided, jsonMode is true, so orchestrate is called with the raw agent string
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: 'invalid-agent',
+      skipNeonAuth: undefined,
+      skipMigrations: undefined,
+    });
     expect(init).not.toHaveBeenCalled();
-    expect(log.error).toHaveBeenCalledWith(
-      'Invalid --agent value: "invalid-agent". Supported: cursor, copilot, claude',
+  });
+
+  // -------------------------------------------------------------------------
+  // Agent/JSON mode (v2) — --json or --agent triggers orchestrate()
+  // -------------------------------------------------------------------------
+
+  test('should call orchestrate() when --json is true', async () => {
+    const { handler } = await import('./init.js');
+    const { orchestrate } = await import('neon-init');
+
+    await handler({ json: true });
+
+    expect(orchestrate).toHaveBeenCalledTimes(1);
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: undefined,
+      skipNeonAuth: undefined,
+      skipMigrations: undefined,
+    });
+  });
+
+  test('should call orchestrate() when --agent is provided', async () => {
+    const { handler } = await import('./init.js');
+    const { orchestrate } = await import('neon-init');
+
+    await handler({ agent: 'cursor' });
+
+    expect(orchestrate).toHaveBeenCalledTimes(1);
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: 'cursor',
+      skipNeonAuth: undefined,
+      skipMigrations: undefined,
+    });
+  });
+
+  test('should pass skip flags to orchestrate()', async () => {
+    const { handler } = await import('./init.js');
+    const { orchestrate } = await import('neon-init');
+
+    await handler({
+      json: true,
+      skipNeonAuth: true,
+      skipMigrations: true,
+    });
+
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: undefined,
+      skipNeonAuth: true,
+      skipMigrations: true,
+    });
+  });
+
+  test('should output JSON from orchestrate result', async () => {
+    const { handler } = await import('./init.js');
+
+    await handler({ json: true });
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          phase: 'setup',
+          status: 'complete',
+          nextAction: { type: 'complete', message: 'Done' },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  });
+
+  test('should exit 1 when orchestrate() throws', async () => {
+    const { handler } = await import('./init.js');
+    const { orchestrate } = await import('neon-init');
+    const { sendError } = await import('../analytics.js');
+
+    vi.mocked(orchestrate).mockRejectedValueOnce(new Error('boom'));
+
+    await handler({ json: true });
+
+    expect(sendError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'NEON_INIT_FAILED',
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test('should exit 1 when init() throws in interactive mode', async () => {
+    const { handler } = await import('./init.js');
+    const { init } = await import('neon-init');
+    const { sendError } = await import('../analytics.js');
+
+    vi.mocked(init).mockRejectedValueOnce(new Error('boom'));
+
+    await handler({});
+
+    expect(sendError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'NEON_INIT_FAILED',
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,32 +1,7 @@
-import { init } from 'neon-init';
+import { init, orchestrate } from 'neon-init';
+import type { OrchestratorOptions } from 'neon-init';
 import yargs from 'yargs';
 import { sendError } from '../analytics.js';
-import { log } from '../log.js';
-
-const AGENT_FLAG_VALUES = ['cursor', 'copilot', 'claude'] as const;
-
-type Editor = 'Cursor' | 'VS Code' | 'Claude CLI';
-
-function parseAgentToEditor(value: string): Editor | null {
-  const normalized = value.trim().toLowerCase();
-  switch (normalized) {
-    case 'cursor':
-      return 'Cursor';
-    case 'github-copilot':
-    case 'copilot':
-    case 'vs code':
-    case 'vscode':
-    case 'vs-code':
-      return 'VS Code';
-    case 'claude-code':
-    case 'claude cli':
-    case 'claude-cli':
-    case 'claude':
-      return 'Claude CLI';
-    default:
-      return null;
-  }
-}
 
 export const command = 'init';
 export const describe =
@@ -39,26 +14,56 @@ export const builder = (yargs: yargs.Argv) =>
     .option('agent', {
       alias: 'a',
       type: 'string',
-      describe: 'Agent to configure (cursor, copilot, code).',
+      describe: 'Agent to configure (cursor, copilot, claude, etc.).',
+    })
+    .option('json', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Output structured JSON for agent consumption. Suppresses interactive UI.',
+    })
+    .option('skip-neon-auth', {
+      type: 'boolean',
+      default: false,
+      describe: 'Skip the Neon Auth setup phase.',
+    })
+    .option('skip-migrations', {
+      type: 'boolean',
+      default: false,
+      describe: 'Skip the migrations phase.',
     })
     .strict(false);
 
-export const handler = async (argv: { agent?: string }) => {
-  let options: { agent: Editor } | undefined;
+export const handler = async (argv: {
+  agent?: string;
+  json?: boolean;
+  skipNeonAuth?: boolean;
+  skipMigrations?: boolean;
+}) => {
   const agentArg = argv.agent;
-  if (agentArg !== undefined) {
-    const editor = parseAgentToEditor(agentArg);
-    if (editor === null) {
-      log.error(
-        `Invalid --agent value: "${agentArg}". Supported: ${AGENT_FLAG_VALUES.join(', ')}`,
-      );
+  const jsonMode = argv.json === true || agentArg !== undefined;
+
+  if (jsonMode) {
+    // v2: agent-driven state machine via orchestrate()
+    try {
+      const options: OrchestratorOptions = {
+        agent: agentArg,
+        skipNeonAuth: argv.skipNeonAuth,
+        skipMigrations: argv.skipMigrations,
+      };
+      const result = await orchestrate(options);
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    } catch {
+      const exitError = new Error('failed to run neon-init orchestrate');
+      sendError(exitError, 'NEON_INIT_FAILED');
       process.exit(1);
-      return;
     }
-    options = { agent: editor };
+    return;
   }
+
+  // v1: interactive mode (agentArg is always undefined here since --agent triggers jsonMode)
   try {
-    await init(options);
+    await init();
   } catch {
     const exitError = new Error(`failed to run neon-init`);
     sendError(exitError, 'NEON_INIT_FAILED');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { init, orchestrate } from 'neon-init';
+import { interactiveInit, orchestrate } from 'neon-init';
 import type { OrchestratorOptions } from 'neon-init';
 import yargs from 'yargs';
 import { sendError } from '../analytics.js';
@@ -32,6 +32,12 @@ export const builder = (yargs: yargs.Argv) =>
       default: false,
       describe: 'Skip the migrations phase.',
     })
+    .option('preview', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Enable preview features (e.g. project bootstrapping from templates).',
+    })
     .strict(false);
 
 export const handler = async (argv: {
@@ -39,6 +45,7 @@ export const handler = async (argv: {
   json?: boolean;
   skipNeonAuth?: boolean;
   skipMigrations?: boolean;
+  preview?: boolean;
 }) => {
   const agentArg = argv.agent;
   const jsonMode = argv.json === true || agentArg !== undefined;
@@ -50,6 +57,7 @@ export const handler = async (argv: {
         agent: agentArg,
         skipNeonAuth: argv.skipNeonAuth,
         skipMigrations: argv.skipMigrations,
+        preview: argv.preview,
       };
       const result = await orchestrate(options);
       process.stdout.write(JSON.stringify(result, null, 2) + '\n');
@@ -61,9 +69,9 @@ export const handler = async (argv: {
     return;
   }
 
-  // v1: interactive mode (agentArg is always undefined here since --agent triggers jsonMode)
+  // v2: interactive mode with preview support
   try {
-    await init();
+    await interactiveInit({ preview: argv.preview });
   } catch {
     const exitError = new Error(`failed to run neon-init`);
     sendError(exitError, 'NEON_INIT_FAILED');


### PR DESCRIPTION
## Summary

- Routes agent/JSON mode (`--json` or `--agent`) through the new `orchestrate()` v2 state machine API from neon-init
- Keeps `init()` for interactive terminal use
- Adds `--json`, `--skip-neon-auth`, and `--skip-migrations` flags to match the neon-init v2 CLI surface
- Removes dead code (editor name normalization was unreachable since `--agent` now always triggers JSON mode)

## Dependencies

Depends on https://github.com/neondatabase/neon-pkgs/pull/151 — the `orchestrate` and `OrchestratorOptions` exports are added in that PR. The neon-init dependency version will need to be bumped once that PR is published.

## Test plan

- [x] All 8 init tests pass
- [x] Full test suite passes (237 tests, 22 files)
- [ ] Manual test after neon-init v2 is published: `neonctl init --json`
- [ ] Manual test interactive mode: `neonctl init`

This pull request and its description were written by Isaac.