### PR TITLE
fix(functions): bundle to index.mjs so the deploy archive is importable

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -722,15 +722,13 @@ const writeBundle = async (
 ): Promise<string> => {
   const files = await bundleEntry(source);
   mkdirSync(bundleDir, { recursive: true });
-  // The bundle is ESM (`format: 'esm'`), but it's written into a `.js` file under the
-  // user's node_modules — where Node, finding no `"type"`, would treat `.js` as CommonJS
-  // and throw `Unexpected token 'export'`. Drop a `package.json` marker so Node runs it as
-  // ESM. (A bare `out.mjs` would also work but breaks the `out.js.map` sourcemap link.)
-  writeFileSync(join(bundleDir, 'package.json'), '{"type":"module"}\n');
+  // bundleEntry emits `index.mjs` (+ `index.mjs.map`). The `.mjs` extension makes Node load
+  // it as ESM directly, so no `package.json` `"type": "module"` marker is needed, and esbuild
+  // points the sourcemap link at `index.mjs.map` for us.
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(join(bundleDir, name), contents);
   }
-  return join(bundleDir, 'out.js');
+  return join(bundleDir, 'index.mjs');
 };
 
 const urlFor = (port: number | null): string =>

--- a/src/utils/esbuild.test.ts
+++ b/src/utils/esbuild.test.ts
@@ -60,17 +60,17 @@ afterAll(() => {
 describe('bundleEntry', () => {
   test('inlines local imports and emits a linked sourcemap', async () => {
     const out = await bundleEntry(join(dir, 'index.ts'), npmDeps);
-    const js = strFromU8(out['out.js']);
+    const js = strFromU8(out['index.mjs']);
     expect(js).toContain('hi from helper');
     expect(js).not.toContain('./helper');
-    expect(js).toContain('sourceMappingURL=out.js.map');
-    expect(out['out.js.map'].length).toBeGreaterThan(0);
+    expect(js).toContain('sourceMappingURL=index.mjs.map');
+    expect(out['index.mjs.map'].length).toBeGreaterThan(0);
   });
 
   // packages=external leaves ALL bare imports external, not just built-ins.
   test('leaves bare imports (node built-ins and npm packages) external', async () => {
     const js = strFromU8(
-      (await bundleEntry(join(dir, 'index.ts'), npmDeps))['out.js'],
+      (await bundleEntry(join(dir, 'index.ts'), npmDeps))['index.mjs'],
     );
     expect(js).toContain('node:fs');
     expect(js).toContain('neon-fake-external-pkg');
@@ -95,7 +95,7 @@ describe('bundleEntry', () => {
         loadEsbuild,
       });
       expect(loadEsbuild).not.toHaveBeenCalled();
-      expect(strFromU8(out['out.js'])).toContain('hi from helper');
+      expect(strFromU8(out['index.mjs'])).toContain('hi from helper');
     });
   });
 
@@ -109,7 +109,7 @@ describe('bundleEntry', () => {
         loadEsbuild,
       });
       expect(loadEsbuild).toHaveBeenCalledOnce();
-      expect(strFromU8(out['out.js'])).toContain('hi from helper');
+      expect(strFromU8(out['index.mjs'])).toContain('hi from helper');
     });
   });
 

--- a/src/utils/esbuild.ts
+++ b/src/utils/esbuild.ts
@@ -71,7 +71,10 @@ const bundleViaModule = async (
     .build({
       entryPoints: [source],
       bundle: true,
-      outfile: 'out.js',
+      // Emit `index.mjs` (not `out.js`): the Functions runtime imports the archive's entry
+      // by the conventional `index.{js,mjs}` name, and `.mjs` makes Node treat the ESM
+      // output as a module without needing a `package.json` type marker alongside it.
+      outfile: 'index.mjs',
       write: false,
       sourcemap: true,
       minify: true,
@@ -86,7 +89,7 @@ const bundleViaModule = async (
       );
     });
   const files = result.outputFiles ?? [];
-  // write:false with one entry always yields out.js + out.js.map; an empty set
+  // write:false with one entry always yields index.mjs + index.mjs.map; an empty set
   // means the API contract changed under us — fail loud rather than ship an
   // empty archive.
   if (files.length === 0) {
@@ -138,7 +141,7 @@ const bundleViaBinary = async (
 ): Promise<Record<string, Uint8Array>> => {
   const bin = resolveEsbuild();
   const outDir = mkdtempSync(join(tmpdir(), 'neon-fn-bundle-'));
-  const outfile = join(outDir, 'out.js');
+  const outfile = join(outDir, 'index.mjs');
   try {
     const { code, stderr } = await runEsbuild(bin, [
       source,
@@ -157,8 +160,8 @@ const bundleViaBinary = async (
       );
     }
     return {
-      'out.js': new Uint8Array(readFileSync(outfile)),
-      'out.js.map': new Uint8Array(readFileSync(`${outfile}.map`)),
+      'index.mjs': new Uint8Array(readFileSync(outfile)),
+      'index.mjs.map': new Uint8Array(readFileSync(`${outfile}.map`)),
     };
   } finally {
     rmSync(outDir, { recursive: true, force: true });

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -1,6 +1,6 @@
 import { zipSync } from 'fflate';
 
-// Zip the esbuild output (out.js + out.js.map) into the archive the Functions
+// Zip the esbuild output (index.mjs + index.mjs.map) into the archive the Functions
 // deploy endpoint expects. Compression level 6 matches the previous bundler.
 export const zipBundle = (entries: Record<string, Uint8Array>): Uint8Array =>
   zipSync(entries, { level: 6 });


### PR DESCRIPTION
## Summary

When deploying a Neon Function, neonctl's esbuild step named the bundled output **`out.js`**, but the Functions runtime imports the archive's entry by the conventional **`index.{js,mjs}`** name. So the uploaded zip had no importable module and the function couldn't be loaded.

This emits **`index.mjs`** (+ `index.mjs.map`) instead, in both esbuild paths:
- in-process module path (`bundleViaModule`) — `outfile: 'index.mjs'`
- binary path (`bundleViaBinary`) — `--outfile=…/index.mjs`, archived as `index.mjs` / `index.mjs.map`

`.mjs` is loaded as ESM by Node directly, so `neon dev`'s local bundle no longer needs the `package.json` `"type": "module"` marker, and esbuild points the sourcemap link at `index.mjs.map` automatically.

## Companion change

`@neondatabase/config-runtime`'s default bundler (`buildFunctionBundle`) has the same `out.js` naming and is fixed in a separate neon-pkgs PR. (neonctl injects its own bundler for `neon deploy` / `config apply`, so this PR fixes the neonctl deploy path; the config-runtime PR fixes the SDK default.)

## Test plan

- [x] `pnpm typecheck` / `eslint` / `prettier --check` clean
- [x] `esbuild.test.ts` updated to assert `index.mjs` / `index.mjs.map` + sourcemap link
- [x] `functions` (24) + `config` (8) + `dev` (13) suites green (deploy bundling + local dev)
- [ ] Manual: `neon deploy` a function and confirm the platform loads `index.mjs` from the archive

## Versioning

No `package.json` bump — handled by the `prepare-release` workflow. `fix` title → next patch.