### PR TITLE
fix: pass API host overrides to dev env context and other neon-pkgs usage of APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.4.1",
-    "@neondatabase/config-runtime": "0.4.1",
-    "@neondatabase/env": "0.3.1",
+    "@neondatabase/config": "0.4.2",
+    "@neondatabase/config-runtime": "0.4.2",
+    "@neondatabase/env": "0.3.2",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       '@neondatabase/config':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       '@neondatabase/config-runtime':
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.2
+        version: 0.4.2
       '@neondatabase/env':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -884,16 +884,16 @@ packages:
   '@neondatabase/api-client@2.7.1':
     resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
 
-  '@neondatabase/config-runtime@0.4.1':
-    resolution: {integrity: sha512-vdiO2tNLwuejCp300nDcWDYztG0sMuAd0Fr+JiFLzJO0KVKIAyloOCpv7HPtfrdFyPadHKUSTZyG3rew35DS7w==}
+  '@neondatabase/config-runtime@0.4.2':
+    resolution: {integrity: sha512-WFD7iHAB0L5l6g32BZ94jJMssSdMZ8ZSrPN1cSYqFDYp/EelHE/DR/KGXs7r3eWfsBc3Qq8kKnB/3hkVE5C2cA==}
     engines: {node: '>=22'}
 
-  '@neondatabase/config@0.4.1':
-    resolution: {integrity: sha512-PpB5dmBYmr+6O1uo5XIQeoZfXZvYz/NlLBwrPiWGZJQc+/NcXDHFrKG7LvDpoIsFurxF7hwd/HX3royCUIGN5g==}
+  '@neondatabase/config@0.4.2':
+    resolution: {integrity: sha512-hZEcPcE5KOaovu4LssHLPESgsJF61aV2xmrA/e78VXfoI8CS4xU3dzeNil2cP1KknjIqzwN7BWyiyqKIn2daxQ==}
     engines: {node: '>=22'}
 
-  '@neondatabase/env@0.3.1':
-    resolution: {integrity: sha512-r0u1b5JH3ML1rXPSG4myI+q6eaM/GVKhwDhpBxrdv5y/sDOQRw2M7BsOUHQoDMaMp/V0MdFC5hNuTLUy7oIXiQ==}
+  '@neondatabase/env@0.3.2':
+    resolution: {integrity: sha512-Jsgc+vcyXhkXt4KFPj3C+qvAlDD4wkZT5OTICj6hNiHLLSKOjJkxZQGOQOCHMBgfP2L41m+T2vKQkomG0XL45g==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3882,7 +3882,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4311,16 +4311,16 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/config-runtime@0.4.1':
+  '@neondatabase/config-runtime@0.4.2':
     dependencies:
-      '@neondatabase/config': 0.4.1
+      '@neondatabase/config': 0.4.2
       esbuild: 0.25.12
       fflate: 0.8.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@neondatabase/config@0.4.1':
+  '@neondatabase/config@0.4.2':
     dependencies:
       '@neondatabase/api-client': 2.7.1
       jiti: 2.7.0
@@ -4329,9 +4329,9 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/env@0.3.1':
+  '@neondatabase/env@0.3.2':
     dependencies:
-      '@neondatabase/config': 0.4.1
+      '@neondatabase/config': 0.4.2
       yargs: 18.0.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -5225,7 +5225,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -112,6 +112,7 @@ export const handler = async (props: CheckoutProps) => {
       projectId,
       branchId,
       ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+      ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     });
   }
 

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -226,6 +226,7 @@ const createCheckoutBranch = async (
     projectId,
     branchName: name,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
   });
   if (fromPolicy) {
     return {

--- a/src/commands/config.apihost.test.ts
+++ b/src/commands/config.apihost.test.ts
@@ -44,7 +44,9 @@ const baseProps = (): ConfigProps => ({
   branch: 'main',
 });
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 const withNeonTs = async (run: (cwd: string) => Promise<void>) => {
   const cwd = mkdtempSync(join(tmpdir(), 'neonctl-cfg-'));

--- a/src/commands/config.apihost.test.ts
+++ b/src/commands/config.apihost.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@neondatabase/config-runtime', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@neondatabase/config-runtime')>();
+  return {
+    ...actual,
+    inspect: vi.fn(() => {
+      throw new Error('STOP');
+    }),
+    plan: vi.fn(() => {
+      throw new Error('STOP');
+    }),
+    apply: vi.fn(() => {
+      throw new Error('STOP');
+    }),
+  };
+});
+
+vi.mock('../utils/enrichers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/enrichers.js')>();
+  return {
+    ...actual,
+    branchIdFromProps: vi.fn(() => Promise.resolve('br-test')),
+  };
+});
+
+import { apply, inspect, plan } from '@neondatabase/config-runtime';
+import type { ConfigProps } from './config.js';
+import { applyCmd, applyPolicyOnCreate, planCmd, status } from './config.js';
+
+const HOST = 'https://stage.example/api/v2';
+
+const baseProps = (): ConfigProps => ({
+  apiClient: {} as ConfigProps['apiClient'],
+  apiKey: '',
+  apiHost: HOST,
+  contextFile: '',
+  output: 'json',
+  projectId: 'p',
+  branch: 'main',
+});
+
+afterEach(() => vi.clearAllMocks());
+
+const withNeonTs = async (run: (cwd: string) => Promise<void>) => {
+  const cwd = mkdtempSync(join(tmpdir(), 'neonctl-cfg-'));
+  writeFileSync(
+    join(cwd, 'neon.ts'),
+    `export default { branch() { return {}; } };\n`,
+  );
+  try {
+    await run(cwd);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+};
+
+describe('config handlers forward apiHost', () => {
+  it('status forwards apiHost into inspect', async () => {
+    await expect(status(baseProps())).rejects.toThrow('STOP');
+    expect(inspect).toHaveBeenCalledWith(
+      expect.objectContaining({ apiHost: HOST }),
+    );
+  });
+
+  it('planCmd forwards apiHost into plan', async () => {
+    await withNeonTs(async (cwd) => {
+      await expect(
+        planCmd({ ...baseProps(), config: join(cwd, 'neon.ts') }),
+      ).rejects.toThrow('STOP');
+      expect(plan).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    });
+  });
+
+  it('applyCmd forwards apiHost into apply', async () => {
+    await withNeonTs(async (cwd) => {
+      await expect(
+        applyCmd({ ...baseProps(), config: join(cwd, 'neon.ts') }),
+      ).rejects.toThrow('STOP');
+      expect(apply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    });
+  });
+
+  it('applyPolicyOnCreate forwards apiHost into apply', async () => {
+    await withNeonTs(async (cwd) => {
+      await expect(
+        applyPolicyOnCreate({
+          projectId: 'p',
+          branchId: 'br-test',
+          apiHost: HOST,
+          cwd,
+        }),
+      ).rejects.toThrow('STOP');
+      expect(apply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    });
+  });
+});

--- a/src/commands/config.apihost.test.ts
+++ b/src/commands/config.apihost.test.ts
@@ -17,6 +17,9 @@ vi.mock('@neondatabase/config-runtime', async (importOriginal) => {
     apply: vi.fn(() => {
       throw new Error('STOP');
     }),
+    createBranch: vi.fn(() => {
+      throw new Error('STOP');
+    }),
   };
 });
 
@@ -28,9 +31,20 @@ vi.mock('../utils/enrichers.js', async (importOriginal) => {
   };
 });
 
-import { apply, inspect, plan } from '@neondatabase/config-runtime';
+import {
+  apply,
+  createBranch,
+  inspect,
+  plan,
+} from '@neondatabase/config-runtime';
 import type { ConfigProps } from './config.js';
-import { applyCmd, applyPolicyOnCreate, planCmd, status } from './config.js';
+import {
+  applyCmd,
+  applyPolicyOnCreate,
+  createBranchFromPolicyOnCheckout,
+  planCmd,
+  status,
+} from './config.js';
 
 const HOST = 'https://stage.example/api/v2';
 
@@ -104,6 +118,23 @@ describe('config handlers forward apiHost', () => {
         }),
       ).rejects.toThrow('STOP');
       expect(apply).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    });
+  });
+
+  it('createBranchFromPolicyOnCheckout forwards apiHost into createBranch', async () => {
+    await withNeonTs(async (cwd) => {
+      await expect(
+        createBranchFromPolicyOnCheckout({
+          projectId: 'p',
+          branchName: 'feature-x',
+          apiHost: HOST,
+          cwd,
+        }),
+      ).rejects.toThrow('STOP');
+      expect(createBranch).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ apiHost: HOST }),
       );

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -178,6 +178,7 @@ export const status = async (props: ConfigProps): Promise<void> => {
     projectId: props.projectId,
     branchId,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
 
@@ -219,6 +220,7 @@ export const planCmd = async (props: ConfigProps): Promise<void> => {
     projectId: props.projectId,
     branchId,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
   reportPushResult(props, result, 'plan');
@@ -231,6 +233,7 @@ export const applyCmd = async (props: ConfigProps): Promise<void> => {
     projectId: props.projectId,
     branchId,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
     ...(props.updateExisting ? { updateExisting: true } : {}),
     ...(props.allowProtected ? { allowProtectedBranch: true } : {}),
@@ -318,6 +321,7 @@ export const applyPolicyOnCreate = async (props: {
   projectId: string;
   branchId: string;
   apiKey?: string;
+  apiHost?: string;
   runtimeApi?: NeonApi;
   /** Directory to search for `neon.ts` from. Defaults to the process cwd. */
   cwd?: string;
@@ -338,6 +342,7 @@ export const applyPolicyOnCreate = async (props: {
     projectId: props.projectId,
     branchId: props.branchId,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
     updateExisting: true,
     allowProtectedBranch: true,

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -382,6 +382,7 @@ export const createBranchFromPolicyOnCheckout = async (props: {
   projectId: string;
   branchName: string;
   apiKey?: string;
+  apiHost?: string;
   runtimeApi?: NeonApi;
   /** Directory to search for `neon.ts` from. Defaults to the process cwd. */
   cwd?: string;
@@ -403,6 +404,7 @@ export const createBranchFromPolicyOnCheckout = async (props: {
       projectId: props.projectId,
       branchName: props.branchName,
       ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+      ...(props.apiHost ? { apiHost: props.apiHost } : {}),
       ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
       bundleFunction: neonctlBundler,
     },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -91,6 +91,7 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
     ...(props.projectId ? { projectId: props.projectId } : {}),
     ...(branchId ? { branchId } : {}),
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
   });
 
   const unit: ServedUnit = {
@@ -137,6 +138,7 @@ const runFromConfig = async (props: DevProps): Promise<void> => {
     ...(props.projectId ? { projectId: props.projectId } : {}),
     ...(branchId ? { branchId } : {}),
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
   });
 
   const units = planFunctionsToUnits(functions, neonEnv, DEFAULT_PORT_BASE);

--- a/src/commands/env.apihost.test.ts
+++ b/src/commands/env.apihost.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../dev/env.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../dev/env.js')>();
+  return {
+    ...actual,
+    resolveNeonEnvVars: vi.fn(() => Promise.resolve({})),
+  };
+});
+
+vi.mock('../utils/enrichers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/enrichers.js')>();
+  return {
+    ...actual,
+    branchIdFromProps: vi.fn(() => Promise.resolve('br-test')),
+  };
+});
+
+import { resolveNeonEnvVars } from '../dev/env.js';
+import { pull, type EnvPullProps } from './env.js';
+
+const HOST = 'https://stage.example/api/v2';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('env pull wires apiHost into the resolver context', () => {
+  it('passes props.apiHost as ctx.apiHost', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'neonctl-envpull-'));
+    try {
+      const props: EnvPullProps = {
+        apiClient: {} as never,
+        apiKey: '',
+        apiHost: HOST,
+        output: 'table',
+        contextFile: '',
+        projectId: 'p',
+        branch: 'main',
+        cwd,
+      };
+      await pull(props);
+      expect(resolveNeonEnvVars).toHaveBeenCalledWith(
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -95,6 +95,7 @@ export const pull = async (props: EnvPullProps): Promise<PullOutcome> => {
     projectId: props.projectId,
     branchId,
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+    ...(props.apiHost ? { apiHost: props.apiHost } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
 

--- a/src/dev/env.apihost.test.ts
+++ b/src/dev/env.apihost.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@neondatabase/config-runtime', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@neondatabase/config-runtime')>();
+  return {
+    ...actual,
+    pullConfig: vi.fn(() => {
+      throw new Error('STOP');
+    }),
+  };
+});
+
+import { pullConfig } from '@neondatabase/config-runtime';
+import { resolveNeonEnvVars } from './env.js';
+
+const HOST = 'https://stage.example/api/v2';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('resolveNeonEnvVars forwards apiHost', () => {
+  it('forwards ctx.apiHost into pullConfig (no neon.ts tier)', async () => {
+    // Invariant: a fresh /tmp dir has no neon.ts on the walk up to root (the loader
+    // stops at $HOME, and /tmp is not under $HOME), so resolveNeonEnvVars takes the
+    // pullConfig tier. A stray /tmp/neon.ts or /neon.ts would flip the tier.
+    const cwd = mkdtempSync(`${tmpdir()}/neonctl-dev-`);
+    try {
+      await expect(
+        resolveNeonEnvVars({
+          cwd,
+          projectId: 'p',
+          branchId: 'br-1',
+          apiKey: 'k',
+          apiHost: HOST,
+        }),
+      ).rejects.toThrow('STOP');
+      expect(pullConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ apiHost: HOST }),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/dev/env.apihost.test.ts
+++ b/src/dev/env.apihost.test.ts
@@ -1,5 +1,6 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@neondatabase/config-runtime', async (importOriginal) => {
@@ -18,14 +19,16 @@ import { resolveNeonEnvVars } from './env.js';
 
 const HOST = 'https://stage.example/api/v2';
 
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('resolveNeonEnvVars forwards apiHost', () => {
   it('forwards ctx.apiHost into pullConfig (no neon.ts tier)', async () => {
-    // Invariant: a fresh /tmp dir has no neon.ts on the walk up to root (the loader
-    // stops at $HOME, and /tmp is not under $HOME), so resolveNeonEnvVars takes the
-    // pullConfig tier. A stray /tmp/neon.ts or /neon.ts would flip the tier.
-    const cwd = mkdtempSync(`${tmpdir()}/neonctl-dev-`);
+    // A `.git` dir marks the temp dir as a repo root, so the config-file walk stops
+    // there: no neon.ts is found and the resolver takes the pullConfig tier.
+    const cwd = mkdtempSync(join(tmpdir(), 'neonctl-dev-'));
+    mkdirSync(join(cwd, '.git'));
     try {
       await expect(
         resolveNeonEnvVars({

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -276,8 +276,12 @@ describe('resolveDevEnv', () => {
       'DATABASE_URL',
       'DATABASE_URL_UNPOOLED',
       'NEON_AUTH_BASE_URL',
+      'NEON_AUTH_JWKS_URL',
     ]);
     expect(result.vars.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
+    expect(result.vars.NEON_AUTH_JWKS_URL).toBe(
+      'https://auth.fake.neon.tech/.well-known/jwks.json',
+    );
   });
 
   it('tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL', async () => {

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -17,6 +17,8 @@ export type DevEnvContext = {
   projectId?: string;
   branchId?: string;
   apiKey?: string;
+  /** Neon API base URL. Falls back to `NEON_API_HOST`, then production. */
+  apiHost?: string;
   /** Injected NeonApi adapter (tests). Production builds it from `apiKey`. */
   api?: NeonApi;
 };
@@ -92,6 +94,7 @@ export const resolveNeonEnvVars = async (
       projectId: ctx.projectId,
       branchId: ctx.branchId,
       ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+      ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
       ...(ctx.api ? { api: ctx.api } : {}),
     });
     // `pulled.config` is already a `Config` (static auth/dataApi toggles + a branch
@@ -197,6 +200,7 @@ const assertPolicyMatchesBranch = async (
     projectId: ctx.projectId as string,
     branchId: ctx.branchId as string,
     ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
     ...(ctx.api ? { api: ctx.api } : {}),
   });
 
@@ -231,6 +235,7 @@ const fetchAndProject = async (
     projectId: ctx.projectId as string,
     branchId: ctx.branchId as string,
     ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+    ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
     ...(ctx.api ? { api: ctx.api } : {}),
   });
   return toEntries(env);

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -23,6 +23,13 @@ export type DevEnvContext = {
   api?: NeonApi;
 };
 
+/** The API-targeting options every runtime call forwards from the context. */
+const apiOptions = (ctx: DevEnvContext) => ({
+  ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
+  ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
+  ...(ctx.api ? { api: ctx.api } : {}),
+});
+
 /**
  * Thrown when a `neon.ts` policy declares a branch-level resource (Neon Auth,
  * Data API, a bucket, the AI Gateway) that the linked remote branch does not
@@ -93,9 +100,7 @@ export const resolveNeonEnvVars = async (
     const pulled = await pullConfig({
       projectId: ctx.projectId,
       branchId: ctx.branchId,
-      ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
-      ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
-      ...(ctx.api ? { api: ctx.api } : {}),
+      ...apiOptions(ctx),
     });
     // `pulled.config` is already a `Config` (static auth/dataApi toggles + a branch
     // tuning closure), so it feeds straight into fetchEnv — no wrapping needed.
@@ -199,9 +204,7 @@ const assertPolicyMatchesBranch = async (
   const result = await plan(config, {
     projectId: ctx.projectId as string,
     branchId: ctx.branchId as string,
-    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
-    ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
-    ...(ctx.api ? { api: ctx.api } : {}),
+    ...apiOptions(ctx),
   });
 
   const missing = result.applied.filter(isMissingResource);
@@ -234,9 +237,7 @@ const fetchAndProject = async (
   const env = await fetchEnv(config, {
     projectId: ctx.projectId as string,
     branchId: ctx.branchId as string,
-    ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
-    ...(ctx.apiHost ? { apiHost: ctx.apiHost } : {}),
-    ...(ctx.api ? { api: ctx.api } : {}),
+    ...apiOptions(ctx),
   });
   return toEntries(env);
 };


### PR DESCRIPTION
## Why?

`neonctl config status` / `config plan` / `config apply` / `deploy`, `neonctl env pull`, `neon dev`, and the automatic env-pull on `checkout`/`link` always talked to the **hardcoded production API host**, even when the user pointed neonctl at another environment.

## What?

### `src/commands/config.ts` — 4 call sites
- `status` → `inspect({ ..., apiHost })`, `planCmd` → `plan(config, { ..., apiHost })`, `applyCmd` → `apply(config, { ..., apiHost })` (covers `deploy`, which delegates to `applyCmd`).
- `applyPolicyOnCreate` gains an optional `apiHost?: string` on its props type, forwarded into its `apply` call (used when `checkout` creates a branch and applies the local `neon.ts` policy).
- All forwards use the guarded-spread style matching the adjacent `apiKey` pattern.

### `src/dev/env.ts` — the tiered env resolver
- `DevEnvContext` gains `apiHost?: string` ("Neon API base URL. Falls back to `NEON_API_HOST`, then production.").
- New module-private `apiOptions(ctx)` helper builds the `apiKey`/`apiHost`/`api` option block once; all three runtime calls (`pullConfig`, the `plan` policy gate, `fetchEnv`) now spread it — the forward exists in exactly one place.

### Context wiring — `src/commands/dev.ts`, `env.ts`, `checkout.ts`
- `dev.ts`: both `resolveDevEnv({...})` calls pass `apiHost: props.apiHost`.
- `env.ts`: `pull` passes it into `resolveNeonEnvVars` (this also covers the automatic env-pull in `checkout`/`link`, which reach `pull` via `autoPullEnvAfterPin(props)`).
- `checkout.ts`: the `applyPolicyOnCreate({...})` call passes it.

Not touched (already host-correct): `createBranch` call sites use `props.apiClient`; `resolveConfig` is pure local policy evaluation.

### Dependencies
- `@neondatabase/config` / `@neondatabase/config-runtime` `0.4.0 → 0.4.2`, `@neondatabase/env` `0.3.0 → 0.3.2`.
- `pnpm-lock.yaml` intentionally untouched — the versions are not on the registry yet; run `pnpm install` after they publish.
- The tier-2 auth expectation in `src/dev/env.test.ts` gains `NEON_AUTH_JWKS_URL` (env `0.3.2` newly surfaces it).

### Tests
- `src/commands/config.apihost.test.ts` — 4 tests: `status`/`planCmd`/`applyCmd`/`applyPolicyOnCreate` each forward `apiHost` into the mocked runtime (sentinel-mock pattern, typed `ConfigProps` fixture).
- `src/dev/env.apihost.test.ts` — pins the resolver forward via the `apiOptions` helper (`.git` dir in the temp cwd makes the no-`neon.ts` tier airtight).
- `src/commands/env.apihost.test.ts` — pins `pull` wiring `props.apiHost` into the resolver context.
- New tests live in separate `*.apihost.test.ts` files so their module mocks don't leak into the existing `runtimeApi`-injection test suites.

