### PR TITLE
feat(env,config): branch credentials in env pull + config status; adopt config/config-runtime 0.5.0 + env 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.4.1",
-    "@neondatabase/config-runtime": "0.4.1",
-    "@neondatabase/env": "0.3.1",
+    "@neondatabase/config": "1.0.0",
+    "@neondatabase/config-runtime": "1.0.0",
+    "@neondatabase/env": "1.0.0",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "1.0.0",
-    "@neondatabase/config-runtime": "1.0.0",
-    "@neondatabase/env": "1.0.0",
+    "@neondatabase/config": "0.5.0",
+    "@neondatabase/config-runtime": "0.5.0",
+    "@neondatabase/env": "0.4.0",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.4.2",
-    "@neondatabase/config-runtime": "0.4.2",
+    "@neondatabase/config": "0.5.0",
+    "@neondatabase/config-runtime": "0.5.0",
     "@neondatabase/env": "0.3.2",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       '@neondatabase/config':
-        specifier: 0.4.2
-        version: 0.4.2
+        specifier: 0.5.0
+        version: 0.5.0
       '@neondatabase/config-runtime':
-        specifier: 0.4.2
-        version: 0.4.2
+        specifier: 0.5.0
+        version: 0.5.0
       '@neondatabase/env':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.4.0
+        version: 0.4.0
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -884,16 +884,16 @@ packages:
   '@neondatabase/api-client@2.7.1':
     resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
 
-  '@neondatabase/config-runtime@0.4.2':
-    resolution: {integrity: sha512-WFD7iHAB0L5l6g32BZ94jJMssSdMZ8ZSrPN1cSYqFDYp/EelHE/DR/KGXs7r3eWfsBc3Qq8kKnB/3hkVE5C2cA==}
+  '@neondatabase/config-runtime@0.5.0':
+    resolution: {integrity: sha512-ELZAt6LKo63sGXSY9nlzNlM8MYiVw9fDe4BuqvObLIcsEJ6pkmvArpOuKniVvWiL7cI1CbQXz2L4czdXlckYRA==}
     engines: {node: '>=22'}
 
-  '@neondatabase/config@0.4.2':
-    resolution: {integrity: sha512-hZEcPcE5KOaovu4LssHLPESgsJF61aV2xmrA/e78VXfoI8CS4xU3dzeNil2cP1KknjIqzwN7BWyiyqKIn2daxQ==}
+  '@neondatabase/config@0.5.0':
+    resolution: {integrity: sha512-Jyo8dm76WN/8SHCQ8HirSxPxPodvZjwGyE+BXq7xCflFrcrBuovw0fSOHZRUMkLOWJHJNkAX9WoaWSvCyF2Z3g==}
     engines: {node: '>=22'}
 
-  '@neondatabase/env@0.3.2':
-    resolution: {integrity: sha512-Jsgc+vcyXhkXt4KFPj3C+qvAlDD4wkZT5OTICj6hNiHLLSKOjJkxZQGOQOCHMBgfP2L41m+T2vKQkomG0XL45g==}
+  '@neondatabase/env@0.4.0':
+    resolution: {integrity: sha512-wkbZYeHl02g5xztHGft115WfkoAeLvtJTHQy0E2Sm9EDsfNkOWyAjamY1+ohJgZT1Bt4FGmg3D3gSkD+rR6Zdg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3882,7 +3882,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4311,16 +4311,16 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/config-runtime@0.4.2':
+  '@neondatabase/config-runtime@0.5.0':
     dependencies:
-      '@neondatabase/config': 0.4.2
+      '@neondatabase/config': 0.5.0
       esbuild: 0.25.12
       fflate: 0.8.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@neondatabase/config@0.4.2':
+  '@neondatabase/config@0.5.0':
     dependencies:
       '@neondatabase/api-client': 2.7.1
       jiti: 2.7.0
@@ -4329,9 +4329,9 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/env@0.3.2':
+  '@neondatabase/env@0.4.0':
     dependencies:
-      '@neondatabase/config': 0.4.2
+      '@neondatabase/config': 0.5.0
       yargs: 18.0.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -5225,7 +5225,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)

--- a/src/commands/__snapshots__/functions.test.ts.snap
+++ b/src/commands/__snapshots__/functions.test.ts.snap
@@ -10,6 +10,7 @@ status: building
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://entryfunc.functions.neon.tech
 "
 `;
 
@@ -19,6 +20,7 @@ status: building
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://envfunc.functions.neon.tech
 "
 `;
 
@@ -28,6 +30,7 @@ status: building
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://nowaitfunc.functions.neon.tech
 "
 `;
 
@@ -37,6 +40,7 @@ status: failed
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://failfunc.functions.neon.tech
 "
 `;
 
@@ -46,6 +50,7 @@ status: completed
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://newfunc.functions.neon.tech
 "
 `;
 
@@ -55,6 +60,7 @@ status: completed
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://flaky.functions.neon.tech
 "
 `;
 
@@ -68,6 +74,7 @@ status: building
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://stuckbuild.functions.neon.tech
 "
 `;
 
@@ -77,6 +84,7 @@ status: completed
 memory_mib: 256
 runtime: nodejs24
 created_at: 2026-06-03T00:00:00Z
+invocation_url: https://redeploy.functions.neon.tech
 "
 `;
 

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -12,6 +12,7 @@ import type {
   GetConnectionUriInput,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
+  NeonBranchStorageSnapshot,
   NeonBucketSnapshot,
   NeonCredentialMeta,
   NeonCredentialSecret,
@@ -242,6 +243,14 @@ class FakeNeonApi implements NeonApi {
 
   async revokeCredential(): Promise<void> {
     return;
+  }
+
+  async getProjectBranchStorage(): Promise<NeonBranchStorageSnapshot | null> {
+    return {
+      s3Endpoint: 'https://fake.storage.neon.tech',
+      region: 'us-east-1',
+      forcePathStyle: true,
+    };
   }
 }
 

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -47,6 +47,8 @@ class FakeNeonApi implements NeonApi {
     slug: string;
     input: DeployFunctionInput;
   }[] = [];
+  /** Functions materialized by a deploy, keyed by slug (Neon creates on first deploy). */
+  private readonly functions = new Map<string, NeonFunctionSnapshot>();
 
   async listProjects(): Promise<NeonProjectSnapshot[]> {
     throw new Error('not implemented');
@@ -177,7 +179,7 @@ class FakeNeonApi implements NeonApi {
   }
 
   async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
-    return [];
+    return [...this.functions.values()];
   }
 
   async deleteBranchFunction(): Promise<void> {
@@ -191,6 +193,16 @@ class FakeNeonApi implements NeonApi {
     input: DeployFunctionInput,
   ): Promise<NeonFunctionDeploymentSnapshot> {
     this.deployBranchFunctionCalls.push({ projectId, branchId, slug, input });
+    // Neon creates the function on its first deployment — mirror that so a later
+    // `listBranchFunctions` (used to resolve the invocation URL) sees it.
+    if (!this.functions.has(slug)) {
+      this.functions.set(slug, {
+        id: `fn-${slug}`,
+        slug,
+        name: slug,
+        invocationUrl: `https://${branchId}.fake.neon.tech/functions/${slug}`,
+      });
+    }
     return { id: 1, status: 'completed' };
   }
 
@@ -448,6 +460,32 @@ describe('config commands', () => {
     expect(api.deployBranchFunctionCalls[0].input.environment).toEqual({
       resendApiKey: 're_from_file',
     });
+  });
+
+  it('apply surfaces each deployed function invocation URL in the output', async () => {
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    const source = join(cwd, 'hello.ts');
+    writeFileSync(
+      source,
+      "export default { fetch() { return new Response('ok'); } };\n",
+    );
+    const config = writeConfig(
+      `export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
+        source,
+      )} } } } };\n`,
+    );
+
+    // Human-readable (table) output so we exercise the dedicated Function URLs table; the
+    // JSON path already carries the URL inside the raw applied-change details.
+    await applyCmd({ ...baseProps(api, stream), output: 'table', config });
+
+    const out = read();
+    expect(out).toContain('Function URLs');
+    expect(out).toContain(
+      `https://${BRANCH_ID}.fake.neon.tech/functions/hello`,
+    );
   });
 });
 

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -7,11 +7,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { NeonApi } from '@neondatabase/config-runtime';
 import type {
   CreateBucketInput,
+  CreateCredentialInput,
   DeployFunctionInput,
   GetConnectionUriInput,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
   NeonBucketSnapshot,
+  NeonCredentialMeta,
+  NeonCredentialSecret,
   NeonDataApiSnapshot,
   NeonDatabaseSnapshot,
   NeonEndpointSnapshot,
@@ -215,6 +218,30 @@ class FakeNeonApi implements NeonApi {
 
   async disableAiGateway(): Promise<void> {
     throw new Error('not implemented');
+  }
+
+  async createCredential(
+    _projectId: string,
+    branchId: string,
+    input: CreateCredentialInput,
+  ): Promise<NeonCredentialSecret> {
+    return {
+      tokenId: 'cred-fake-0000',
+      tokenIdShort: 'credfake0000',
+      apiToken: 'nt_live_credfake0000_secret',
+      s3SecretAccessKey: 's3secret'.padEnd(64, '0'),
+      scopes: input.scopes,
+      branchId,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+  }
+
+  async listCredentials(): Promise<NeonCredentialMeta[]> {
+    return [];
+  }
+
+  async revokeCredential(): Promise<void> {
+    return;
   }
 }
 

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -176,21 +176,6 @@ class FakeNeonApi implements NeonApi {
     return [];
   }
 
-  async createBranchFunction(
-    projectId: string,
-    branchId: string,
-    input: { slug: string; name: string },
-  ): Promise<NeonFunctionSnapshot> {
-    void projectId;
-    void branchId;
-    return {
-      id: `fn-${input.slug}`,
-      slug: input.slug,
-      name: input.name,
-      invocationUrl: `https://${input.slug}.${BRANCH_ID}.fake.neon.tech`,
-    };
-  }
-
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -33,6 +33,7 @@ const neonctlBundler: FunctionBundler = async (fn) =>
 
 const INSPECT_FIELDS = ['project', 'branch', 'config'] as const;
 const APPLIED_FIELDS = ['action', 'kind', 'identifier', 'details'] as const;
+const FUNCTION_FIELDS = ['slug', 'invocation_url'] as const;
 const CONFLICT_FIELDS = [
   'identifier',
   'field',
@@ -275,6 +276,23 @@ const reportPushResult = (
     reason: conflict.reason,
   }));
 
+  // Deployed functions carry their invocation URL in the change details — pull them into a
+  // dedicated table so users can see where to call each function without digging through the
+  // raw details blob. Keyed by slug so a function never shows twice.
+  const functionUrlBySlug = new Map<string, string>();
+  for (const change of result.applied) {
+    if (change.action === 'noop') continue;
+    const slug = change.details?.slug;
+    const invocationUrl = change.details?.invocationUrl;
+    if (typeof slug === 'string' && typeof invocationUrl === 'string') {
+      functionUrlBySlug.set(slug, invocationUrl);
+    }
+  }
+  const functions = [...functionUrlBySlug].map(([slug, invocation_url]) => ({
+    slug,
+    invocation_url,
+  }));
+
   if (changes.length === 0 && conflicts.length === 0) {
     log.info(
       `No changes — branch ${result.branchName} already matches the policy.`,
@@ -287,6 +305,12 @@ const reportPushResult = (
     out.write(changes, {
       fields: APPLIED_FIELDS,
       title: mode === 'plan' ? 'Planned changes' : 'Applied changes',
+    });
+  }
+  if (functions.length > 0) {
+    out.write(functions, {
+      fields: FUNCTION_FIELDS,
+      title: mode === 'plan' ? 'Function URLs (after apply)' : 'Function URLs',
     });
   }
   if (conflicts.length > 0) {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -183,7 +183,7 @@ type SupervisorOptions = {
  * Map a list of {@link PlannedFunction}s to {@link ServedUnit}s, coordinating the search
  * base across them so search-mode functions don't all probe the same starting port.
  *
- * Each search-mode (no `dev.port`, non-portless) function gets a distinct base starting at
+ * Each search-mode (no `dev.port`) function gets a distinct base starting at
  * `searchBase`; the runtime still walks upward from its base, so an occupied base
  * self-resolves and this never fails — the offset just makes startup deterministic.
  */
@@ -195,7 +195,7 @@ const planFunctionsToUnits = (
   let searchOffset = 0;
   return functions.map((fn) => {
     const base = searchBase + searchOffset;
-    if (!fn.portless && fn.port === undefined) searchOffset += 1;
+    if (fn.port === undefined) searchOffset += 1;
     return plannedToUnit(fn, neonEnv, base);
   });
 };
@@ -231,9 +231,7 @@ type PortSpec =
   // Bind exactly this port (fail if taken) via NEON_DEV_PORT.
   | { mode: 'explicit'; port: number }
   // Search upward from `from` via NEON_DEV_PORT_BASE.
-  | { mode: 'search'; from: number }
-  // Set no port env at all — let an injected PORT (portless) drive the runtime.
-  | { mode: 'inherit' };
+  | { mode: 'search'; from: number };
 
 const portFromProps = (port: number | undefined): PortSpec => {
   if (port !== undefined) return { mode: 'explicit', port };
@@ -245,9 +243,6 @@ const portFromProps = (port: number | undefined): PortSpec => {
 
 /**
  * Translate a {@link PlannedFunction} into a {@link ServedUnit}. Port rules:
- *   - portless: portless assigns the port and injects PORT, which the runtime honors — so
- *     we set no port env (`inherit`) and `dev.port` is ignored. Wrapped with
- *     `portless <slug>` for a stable `slug.localhost` URL.
  *   - explicit `dev.port`: bind exactly, fail if taken.
  *   - no `dev.port`: search for a free port (base coordinated by the caller).
  * Per-function neon.ts env layers over the shared branch env.
@@ -257,9 +252,8 @@ const plannedToUnit = (
   branchEnv: Record<string, string>,
   searchBase: number,
 ): ServedUnit => {
-  const port: PortSpec = fn.portless
-    ? { mode: 'inherit' }
-    : fn.port !== undefined
+  const port: PortSpec =
+    fn.port !== undefined
       ? { mode: 'explicit', port: fn.port }
       : { mode: 'search', from: searchBase };
   const childEnv = buildChildEnv({ ...branchEnv, ...fn.env }, port);
@@ -277,10 +271,8 @@ const plannedToUnit = (
     configKey: JSON.stringify({
       source: fn.source,
       port: fn.port ?? null,
-      portless: fn.portless,
       env: fn.env,
     }),
-    ...(fn.portless ? { portless: { slug: fn.slug } } : {}),
   };
 };
 
@@ -302,13 +294,12 @@ const buildChildEnv = (
   } else if (port.mode === 'search') {
     env.NEON_DEV_PORT_BASE = String(port.from);
   }
-  // 'inherit': set neither, so an injected PORT (portless) drives the runtime.
   return env;
 };
 
 /**
  * One function being served locally. `slug`/`label` are null in single-source mode
- * (one unnamed server). `portless`, when set, wraps the child with `portless run`.
+ * (one unnamed server).
  */
 export type ServedUnit = {
   slug: string | null;
@@ -317,7 +308,7 @@ export type ServedUnit = {
   childEnv: NodeJS.ProcessEnv;
   label: string | null;
   /**
-   * Signature of the function's own neon.ts config (source/port/portless/env), used by the
+   * Signature of the function's own neon.ts config (source/port/env), used by the
    * config reconciler to detect a real change vs a no-op save. Independent of the dynamic
    * port search base. Absent in single-source mode (no reconcile there).
    */
@@ -328,7 +319,6 @@ export type ServedUnit = {
    * function's `neon.ts` `env` block. Values are intentionally omitted (secrets).
    */
   envSummary?: { neon: string[]; fn: string[] };
-  portless?: { slug: string };
 };
 
 export type RunningUnit = {
@@ -348,13 +338,12 @@ const READY_PATTERN = /neon-dev:ready (\d+)/;
  * its inputs for hot reload, and tear everything down cleanly on shutdown. Units are
  * independent — one crashing or failing to start does not stop the others (it is shown
  * as errored and recovered on the next edit). A single SIGINT/SIGTERM shuts all of them
- * down, tree-killing each child so no descendant (e.g. a portless-wrapped runtime) is
- * orphaned.
+ * down, tree-killing each child so no descendant it spawned is orphaned.
  *
  * In config mode, `reload` lets the supervisor watch `neon.ts` and reconcile the live set
  * of units when it changes: a newly-declared function is hot-added (its own child, watcher,
  * and port) and a removed one is torn down — all without disturbing the functions that
- * stayed the same. A function whose config (env/port/portless/source) changed is restarted
+ * stayed the same. A function whose config (env/port/source) changed is restarted
  * in place; siblings are untouched.
  */
 const runSupervisor = async (
@@ -362,9 +351,6 @@ const runSupervisor = async (
   options: SupervisorOptions = {},
 ): Promise<void> => {
   const { reload, envNote } = options;
-  if (hasPortlessUnit(units)) {
-    assertPortlessAvailable();
-  }
 
   const runtimePath = resolveRuntimePath();
   let shuttingDown = false;
@@ -549,7 +535,7 @@ export type ReconcilePlan = {
  * Pure slug-keyed diff of the live units against the freshly-resolved desired set:
  *   - a slug present now but not before → **add** (new child + watcher + port),
  *   - a slug gone from neon.ts → **remove** (torn down),
- *   - a slug whose config (source/port/portless/env) changed → **restart** in place,
+ *   - a slug whose config (source/port/env) changed → **restart** in place,
  *   - an unchanged slug → left out of the plan entirely (never touched).
  * Functions that stayed the same never die, so an edit that only adds a function is
  * non-disruptive. `desired === null` (neon.ts deleted) is treated as "no functions".
@@ -612,8 +598,6 @@ const reconcileOnce = async (
   }
   if (ops.isShuttingDown()) return;
 
-  if (hasPortlessUnit(desired ?? [])) assertPortlessAvailable();
-
   const plan = diffUnits(running, desired);
 
   for (const r of plan.remove) {
@@ -660,62 +644,21 @@ const nextSearchBase = (running: RunningUnit[]): number => {
   return max + 1;
 };
 
-const hasPortlessUnit = (units: ServedUnit[]): boolean =>
-  units.some((u) => u.portless !== undefined);
-
 /**
- * Spawn the child for a unit. A portless unit is wrapped as `portless <slug> node
- * <runtime> <bundle>`: portless assigns a port, injects it as PORT (which the runtime
- * honors), and exposes the server at `slug.localhost`. A plain unit runs the bundled
- * output directly under `node`.
+ * Spawn the child for a unit: the bundled output run directly under `node`.
  *
- * Spawned detached (own process group) so killTree can reap the whole group — important
- * for the portless case, where the tree is portless -> node runtime.
+ * Spawned detached (own process group) so killTree can reap the whole group.
  */
 const spawnChild = (
   unit: ServedUnit,
   runtimePath: string,
   bundlePath: string,
 ): ChildProcess => {
-  if (unit.portless) {
-    return spawn(
-      'portless',
-      [unit.portless.slug, process.execPath, runtimePath, bundlePath],
-      {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: unit.childEnv,
-        detached: true,
-      },
-    );
-  }
   return spawn(process.execPath, [runtimePath, bundlePath], {
     stdio: ['ignore', 'pipe', 'pipe'],
     env: unit.childEnv,
     detached: true,
   });
-};
-
-/** Fail early with an actionable message if a portless unit is requested but the binary is missing. */
-const assertPortlessAvailable = (): void => {
-  const result = spawnSyncCheck('portless');
-  if (!result) {
-    throw new Error(
-      'A function sets `dev.portless: true`, but the `portless` command was not ' +
-        'found on your PATH. Install it globally (e.g. `npm i -g portless`) or ' +
-        'remove `dev.portless` from the function in neon.ts.',
-    );
-  }
-};
-
-const spawnSyncCheck = (bin: string): boolean => {
-  try {
-    // Synchronous, no-side-effect probe: `which`/`where` resolves the binary.
-    const probe = process.platform === 'win32' ? 'where' : 'which';
-    const { status } = spawnSync(probe, [bin]);
-    return status === 0;
-  } catch {
-    return false;
-  }
 };
 
 const writeBundle = async (
@@ -924,7 +867,7 @@ const startDirectoryWatcher = async (
 /**
  * Terminate a child and every descendant it spawned. The child is started `detached`, so
  * on POSIX it leads its own process group and a negative-PID signal reaps the group
- * (covering portless -> neonctl -> node). On Windows there are no POSIX groups, so we
+ * (covering the runtime and anything it spawned). On Windows there are no POSIX groups, so we
  * shell out to `taskkill /T` to kill the tree. Escalates SIGTERM -> SIGKILL after 2s.
  */
 const killTree = (child: ChildProcess): Promise<void> => {

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -144,9 +144,6 @@ class FakeNeonApi implements NeonApi {
   async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
     return [];
   }
-  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
-    throw new Error('not implemented');
-  }
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -11,10 +11,13 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { NeonApi } from '@neondatabase/config';
 import type {
+  CreateCredentialInput,
   GetConnectionUriInput,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
   NeonBucketSnapshot,
+  NeonCredentialMeta,
+  NeonCredentialSecret,
   NeonDataApiSnapshot,
   NeonDatabaseSnapshot,
   NeonEndpointSnapshot,
@@ -161,6 +164,27 @@ class FakeNeonApi implements NeonApi {
   }
   async disableAiGateway(): Promise<void> {
     throw new Error('not implemented');
+  }
+  async createCredential(
+    _projectId: string,
+    branchId: string,
+    input: CreateCredentialInput,
+  ): Promise<NeonCredentialSecret> {
+    return {
+      tokenId: 'cred-fake-0000',
+      tokenIdShort: 'credfake0000',
+      apiToken: 'nt_live_credfake0000_secret',
+      s3SecretAccessKey: 's3secret'.padEnd(64, '0'),
+      scopes: input.scopes,
+      branchId,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+  }
+  async listCredentials(): Promise<NeonCredentialMeta[]> {
+    return [];
+  }
+  async revokeCredential(): Promise<void> {
+    return;
   }
 }
 

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -15,6 +15,7 @@ import type {
   GetConnectionUriInput,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
+  NeonBranchStorageSnapshot,
   NeonBucketSnapshot,
   NeonCredentialMeta,
   NeonCredentialSecret,
@@ -185,6 +186,13 @@ class FakeNeonApi implements NeonApi {
   }
   async revokeCredential(): Promise<void> {
     return;
+  }
+  async getProjectBranchStorage(): Promise<NeonBranchStorageSnapshot | null> {
+    return {
+      s3Endpoint: 'https://fake.storage.neon.tech',
+      region: 'us-east-1',
+      forcePathStyle: true,
+    };
   }
 }
 

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -4,10 +4,12 @@ import yargs from 'yargs';
 import { type NeonApi } from '@neondatabase/config';
 import { NEON_ENV_VAR_KEYS } from '@neondatabase/env';
 
+import { existsSync } from 'node:fs';
+
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
 import { resolveNeonEnvVars } from '../dev/env.js';
-import { mergeEnvFile, resolveEnvFilePath } from '../env_file.js';
+import { mergeEnvFile, readEnvFile, resolveEnvFilePath } from '../env_file.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 
 export type EnvPullProps = BranchScopeProps & {
@@ -87,6 +89,13 @@ export const pull = async (props: EnvPullProps): Promise<PullOutcome> => {
   const cwd = props.cwd ?? process.cwd();
   const branchId = await branchIdFromProps(props);
 
+  // Resolve the target file first and layer its current contents under the resolver's env
+  // source. This lets `fetchEnv` reuse one-time secrets that are already on disk — Neon Auth
+  // keys and the unified branch credential's `api_token` / `s3_secret_access_key`, which the
+  // API returns exactly once — instead of minting a fresh credential on every pull.
+  const targetPath = resolveEnvFilePath(cwd, props.file);
+  const existingEnv = existsSync(targetPath) ? readEnvFile(targetPath) : {};
+
   // Reuse `neon dev`'s tiered resolver (neon.ts policy -> plan gate -> fetchEnv, else
   // pullConfig -> fetchEnv). Unlike dev, an unresolved context or failure is surfaced —
   // `env pull` is an explicit action, so it should error rather than write nothing.
@@ -94,6 +103,7 @@ export const pull = async (props: EnvPullProps): Promise<PullOutcome> => {
     cwd,
     projectId: props.projectId,
     branchId,
+    env: { ...process.env, ...existingEnv },
     ...(props.apiKey ? { apiKey: props.apiKey } : {}),
     ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
   });
@@ -107,7 +117,6 @@ export const pull = async (props: EnvPullProps): Promise<PullOutcome> => {
     return { status: 'empty' };
   }
 
-  const targetPath = resolveEnvFilePath(cwd, props.file);
   const { written } = mergeEnvFile(targetPath, neonVars);
   log.info(
     'Pulled %d Neon variable%s into %s: %s',

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -16,6 +16,7 @@ import {
   deleteFunction,
   getFunction,
   listFunctions,
+  NeonFunction,
   NeonFunctionDeployment,
 } from '../functions_api.js';
 
@@ -29,6 +30,17 @@ const FUNCTION_FIELDS = [
 const DEPLOYMENT_FIELDS = [
   'id',
   'status',
+  'runtime',
+  'memory_mib',
+  'created_at',
+] as const;
+
+// Deploy emits the resolved deployment plus the function's invocation_url, so a
+// successful `functions deploy` tells the user exactly where to call the function.
+const DEPLOY_RESULT_FIELDS = [
+  'id',
+  'status',
+  'invocation_url',
   'runtime',
   'memory_mib',
   'created_at',
@@ -160,6 +172,18 @@ const parseEnv = (entries: string[] | undefined): string | undefined => {
 const statusHint = (slug: string, projectId: string, branchId: string) =>
   `Check status with: neonctl functions get ${slug} --project-id ${projectId} --branch ${branchId}`;
 
+// Emit the resolved deployment together with the function's invocation_url, so the
+// deploy output shows where the function is reachable (not just the deployment id).
+const emitDeployResult = (
+  props: DeployProps,
+  deployment: NeonFunctionDeployment,
+  fn: NeonFunction | undefined,
+) =>
+  writer(props).end(
+    { ...deployment, invocation_url: fn?.invocation_url },
+    { fields: DEPLOY_RESULT_FIELDS },
+  );
+
 // A poll error worth retrying: a network error (no HTTP response), a 5xx, or a
 // 404 from eventual consistency. Anything else (e.g. 401/403) is surfaced.
 const isTransient = (err: unknown): boolean =>
@@ -241,6 +265,9 @@ const deploy = async (props: DeployProps) => {
   // any version if there was none). --no-wait stops there; --wait stops at a
   // terminal status. Bounded by POLL_TIMEOUT_MS so it never hangs.
   let resolved: NeonFunctionDeployment | undefined;
+  // The function carries the invocation_url; keep the whole record (not just its
+  // active_deployment) so we can surface that URL on success.
+  let resolvedFn: NeonFunction | undefined;
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   try {
     while (!interrupted && Date.now() < deadline) {
@@ -248,24 +275,24 @@ const deploy = async (props: DeployProps) => {
       if (interrupted) break;
       // The deploy already succeeded server-side; tolerate transient poll
       // failures and retry on the next interval. Surface anything else.
-      let dep: NeonFunctionDeployment | undefined;
+      let fn: NeonFunction | undefined;
       try {
-        dep = (
-          await getFunction(
-            props.apiClient,
-            props.projectId,
-            branchId,
-            props.slug,
-          )
-        ).active_deployment;
+        fn = await getFunction(
+          props.apiClient,
+          props.projectId,
+          branchId,
+          props.slug,
+        );
       } catch (err: unknown) {
         if (isTransient(err)) continue;
         throw err;
       }
+      const dep = fn.active_deployment;
       const isNew =
         dep !== undefined && (before === undefined || dep.id > before);
       if (isNew && dep) {
         resolved = dep;
+        resolvedFn = fn;
         if (!props.wait) break;
         if (dep.status === 'completed' || dep.status === 'failed') break;
       }
@@ -277,7 +304,7 @@ const deploy = async (props: DeployProps) => {
 
   if (interrupted) {
     log.info(statusHint(props.slug, props.projectId, branchId));
-    if (resolved) writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
+    if (resolved) emitDeployResult(props, resolved, resolvedFn);
     return;
   }
 
@@ -288,7 +315,7 @@ const deploy = async (props: DeployProps) => {
     );
   }
 
-  writer(props).end(resolved, { fields: DEPLOYMENT_FIELDS });
+  emitDeployResult(props, resolved, resolvedFn);
 
   if (!props.wait) {
     log.info(statusHint(props.slug, props.projectId, branchId));

--- a/src/config_format.test.ts
+++ b/src/config_format.test.ts
@@ -61,6 +61,7 @@ describe('toNeonConfigView', () => {
       aiGatewayEnabled: true,
       functions: [{ slug: 'hello', name: 'Hello' }],
       buckets: [{ name: 'uploads', access: 'public_read' }],
+      credentials: [],
     };
     const view = toNeonConfigView(base, preview);
     expect(view.preview).toEqual({
@@ -70,11 +71,41 @@ describe('toNeonConfigView', () => {
     });
   });
 
+  it('projects issued credentials (secret-free) into the preview view', () => {
+    const preview: PulledBranchConfig['preview'] = {
+      aiGatewayEnabled: false,
+      functions: [],
+      buckets: [],
+      credentials: [
+        {
+          tokenId: 'dc52e816-839c-462d-a7d5-f26ed768f65a',
+          tokenIdShort: 'dc52e816839c',
+          name: 'app',
+          scopes: ['storage:read', 'storage:write'],
+          principalType: 'user',
+          createdAt: '2026-06-10T17:12:01Z',
+          lastUsedAt: '2026-06-10T18:00:00Z',
+        },
+      ],
+    };
+    expect(toNeonConfigView(base, preview).preview).toEqual({
+      credentials: [
+        {
+          id: 'dc52e816839c',
+          name: 'app',
+          scopes: ['storage:read', 'storage:write'],
+          lastUsedAt: '2026-06-10T18:00:00Z',
+        },
+      ],
+    });
+  });
+
   it('omits an all-empty preview', () => {
     const preview: PulledBranchConfig['preview'] = {
       aiGatewayEnabled: false,
       functions: [],
       buckets: [],
+      credentials: [],
     };
     expect(toNeonConfigView(base, preview).preview).toBeUndefined();
   });

--- a/src/config_format.ts
+++ b/src/config_format.ts
@@ -34,6 +34,17 @@ export type NeonConfigView = {
     aiGateway?: true;
     functions?: Record<string, { name: string }>;
     buckets?: Record<string, { access: string }>;
+    /**
+     * Issued branch credentials, secret-free (id / name / scopes / last-used). Read-only
+     * live state — credentials are minted by `env pull` / `fetchEnv`, not authored in
+     * `neon.ts` — surfaced here so `config status` shows what's been issued on the branch.
+     */
+    credentials?: {
+      id: string;
+      name?: string;
+      scopes: string[];
+      lastUsedAt?: string;
+    }[];
   };
   branch?: {
     parent?: string;
@@ -92,6 +103,14 @@ const toPreviewView = (
     out.buckets = Object.fromEntries(
       preview.buckets.map((b) => [b.name, { access: b.access }]),
     );
+  }
+  if (preview.credentials.length > 0) {
+    out.credentials = preview.credentials.map((c) => ({
+      id: c.tokenIdShort,
+      ...(c.name ? { name: c.name } : {}),
+      scopes: c.scopes,
+      ...(c.lastUsedAt ? { lastUsedAt: c.lastUsedAt } : {}),
+    }));
   }
   return Object.keys(out).length > 0 ? out : undefined;
 };

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -194,10 +194,6 @@ class FakeNeonApi implements NeonApi {
     return [];
   }
 
-  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
-    throw new Error('not implemented');
-  }
-
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -4,11 +4,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type {
+  CreateCredentialInput,
   GetConnectionUriInput,
   NeonApi,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
   NeonBucketSnapshot,
+  NeonCredentialMeta,
+  NeonCredentialSecret,
   NeonDataApiSnapshot,
   NeonDatabaseSnapshot,
   NeonEndpointSnapshot,
@@ -217,6 +220,30 @@ class FakeNeonApi implements NeonApi {
   async disableAiGateway(): Promise<void> {
     throw new Error('not implemented');
   }
+
+  async createCredential(
+    _projectId: string,
+    branchId: string,
+    input: CreateCredentialInput,
+  ): Promise<NeonCredentialSecret> {
+    return {
+      tokenId: 'cred-fake-0000',
+      tokenIdShort: 'credfake0000',
+      apiToken: 'nt_live_credfake0000_secret',
+      s3SecretAccessKey: 's3secret'.padEnd(64, '0'),
+      scopes: input.scopes,
+      branchId,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+  }
+
+  async listCredentials(): Promise<NeonCredentialMeta[]> {
+    return [];
+  }
+
+  async revokeCredential(): Promise<void> {
+    return;
+  }
 }
 
 describe('resolveDevEnv', () => {
@@ -276,6 +303,7 @@ describe('resolveDevEnv', () => {
       'DATABASE_URL',
       'DATABASE_URL_UNPOOLED',
       'NEON_AUTH_BASE_URL',
+      'NEON_AUTH_JWKS_URL',
     ]);
     expect(result.vars.NEON_AUTH_BASE_URL).toBe('https://auth.fake.neon.tech');
   });

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -9,6 +9,7 @@ import type {
   NeonApi,
   NeonAuthSnapshot,
   NeonBranchSnapshot,
+  NeonBranchStorageSnapshot,
   NeonBucketSnapshot,
   NeonCredentialMeta,
   NeonCredentialSecret,
@@ -243,6 +244,14 @@ class FakeNeonApi implements NeonApi {
 
   async revokeCredential(): Promise<void> {
     return;
+  }
+
+  async getProjectBranchStorage(): Promise<NeonBranchStorageSnapshot | null> {
+    return {
+      s3Endpoint: 'https://fake.storage.neon.tech',
+      region: 'us-east-1',
+      forcePathStyle: true,
+    };
   }
 }
 

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -19,6 +19,13 @@ export type DevEnvContext = {
   apiKey?: string;
   /** Injected NeonApi adapter (tests). Production builds it from `apiKey`. */
   api?: NeonApi;
+  /**
+   * Env source layered under `process.env` when resolving the branch env. Lets callers
+   * supply already-persisted values (e.g. the existing `.env` for `env pull`) so one-time
+   * secrets — Neon Auth keys and the unified branch credential's `api_token` /
+   * `s3_secret_access_key` — are **reused** rather than re-minted on every run.
+   */
+  env?: NodeJS.ProcessEnv;
 };
 
 /**
@@ -232,6 +239,7 @@ const fetchAndProject = async (
     branchId: ctx.branchId as string,
     ...(ctx.apiKey ? { apiKey: ctx.apiKey } : {}),
     ...(ctx.api ? { api: ctx.api } : {}),
+    ...(ctx.env ? { env: ctx.env } : {}),
   });
   return toEntries(env);
 };

--- a/src/dev/functions.test.ts
+++ b/src/dev/functions.test.ts
@@ -53,12 +53,11 @@ describe('resolveFunctionsFromConfig', () => {
         preview: {
           functions: {
             hello: { name: 'Hello', source: './hello.ts', dev: { port: 8788 } },
-            api: { name: 'Api', source: './api.ts', dev: { portless: true } },
             bare: { name: 'Bare', source: './bare.ts' },
           },
         },
       };\n`,
-      ['hello.ts', 'api.ts', 'bare.ts'],
+      ['hello.ts', 'bare.ts'],
     );
 
     const resolved = await resolveFunctionsFromConfig(cwd);
@@ -67,22 +66,14 @@ describe('resolveFunctionsFromConfig', () => {
     const fns = resolved?.functions;
     const bySlug = Object.fromEntries((fns ?? []).map((f) => [f.slug, f]));
 
+    // Explicit `dev.port` is carried through.
     expect(bySlug.hello).toMatchObject({
       slug: 'hello',
       name: 'Hello',
       source: join(cwd, 'hello.ts'),
       port: 8788,
-      portless: false,
     });
-    expect(bySlug.api).toMatchObject({
-      slug: 'api',
-      source: join(cwd, 'api.ts'),
-      portless: true,
-    });
-    // portless function gets no port (portless assigns it).
-    expect(bySlug.api.port).toBeUndefined();
-    // bare function: no port, not portless.
-    expect(bySlug.bare.portless).toBe(false);
+    // No `dev.port`: the supervisor searches for a free port, so none is set here.
     expect(bySlug.bare.port).toBeUndefined();
   });
 

--- a/src/dev/functions.ts
+++ b/src/dev/functions.ts
@@ -10,16 +10,14 @@ import {
 /**
  * A function from `neon.ts`, resolved into everything `neon dev` needs to serve it
  * locally. `source` is absolute (resolved against the `neon.ts` location). `port` is the
- * function's explicit `dev.port`, or `undefined` to let the supervisor find a free one
- * (only allowed when not `portless`). `env` is the function's own `neon.ts` env, layered
- * over the shared branch env per child.
+ * function's explicit `dev.port`, or `undefined` to let the supervisor find a free one.
+ * `env` is the function's own `neon.ts` env, layered over the shared branch env per child.
  */
 export type PlannedFunction = {
   slug: string;
   name: string;
   source: string;
   port?: number;
-  portless: boolean;
   env: Record<string, string>;
 };
 
@@ -71,7 +69,6 @@ export const resolveFunctionsFromConfig = async (
       slug: fn.slug,
       name: fn.name,
       source,
-      portless: fn.dev?.portless === true,
       ...(devPort(fn.dev) !== undefined
         ? { port: devPort(fn.dev) as number }
         : {}),
@@ -83,9 +80,8 @@ export const resolveFunctionsFromConfig = async (
 };
 
 /**
- * Read the `port` off a {@link FunctionDevConfig}. The discriminated union guarantees a
- * `port` is present whenever `portless` is true, so this is `undefined` only for the
- * non-portless, port-omitted case (the supervisor then searches for a free port).
+ * Read the `port` off a {@link FunctionDevConfig}. `undefined` when no `dev.port` is set
+ * (the supervisor then searches for a free port).
  */
 const devPort = (dev: FunctionDevConfig | undefined): number | undefined =>
   dev?.port;

--- a/src/dev/runtime.test.ts
+++ b/src/dev/runtime.test.ts
@@ -92,7 +92,7 @@ describe('portSelectionFromEnv', () => {
     );
   });
 
-  it('binds an injected PORT (e.g. from portless) when NEON_DEV_PORT is unset', () => {
+  it('binds an injected PORT (e.g. PORT=3000) when NEON_DEV_PORT is unset', () => {
     expect(portSelectionFromEnv({ PORT: '4123' })).toEqual({
       mode: 'explicit',
       port: 4123,

--- a/src/dev/runtime.ts
+++ b/src/dev/runtime.ts
@@ -72,7 +72,7 @@ export const withErrorBoundary = (handler: FetchHandler): FetchHandler => {
 /**
  * How the runtime picks its port:
  *   - `explicit`: bind this exact port and crash on conflict (an explicit choice
- *     — `--port` or portless's `PORT` — that is taken is an error).
+ *     — `--port` or an injected `PORT` — that is taken is an error).
  *   - `search`: walk upward from `from` until a free port is found; never crash.
  */
 export type PortSelection =
@@ -162,8 +162,8 @@ export const startRuntime = async ({
  * Build a {@link PortSelection} from the environment. Precedence:
  *   1. `NEON_DEV_PORT` -> explicit bind (crash if taken). Set by `neon dev` from an
  *      explicit `--port` / `dev.port`.
- *   2. `PORT`          -> explicit bind. This is what `portless` injects (and what a bare
- *      `PORT=3000 neon dev` sets), so the runtime binds the port chosen for it.
+ *   2. `PORT`          -> explicit bind. A bare `PORT=3000 neon dev` sets this, so the
+ *      runtime binds the port chosen for it.
  *   3. otherwise        -> search upward from `NEON_DEV_PORT_BASE` (or the default base).
  */
 export const portSelectionFromEnv = (env: NodeJS.ProcessEnv): PortSelection => {


### PR DESCRIPTION
> **Draft — blocked on the neon-pkgs release.** Every change here needs the unreleased `@neondatabase/config` / `config-runtime` **0.5.0** + `@neondatabase/env` **0.4.0** (neondatabase/neon-pkgs#184). Until those publish, `pnpm install --frozen-lockfile` can't resolve them, so CI stays red. Once they're on npm: run `pnpm install` to refresh the lockfile → CI goes green → ready to merge.

The single neonctl PR for this batch. Folds in the former #535 (closed) — its `createBranchFunction` fake cleanup is now part of this branch — so the whole CLI-side change ships as one PR.

## Summary

Consume the new branch-scoped credentials from neon-pkgs and wire them into the user-facing flows, with **zero behavior change** for branches that don't use the credential-bearing Preview features (object storage / AI Gateway). Also adopts the platform deps' next release.

- **`env pull`** reads the target `.env` first and layers it under the env source handed to `fetchEnv`, so the unified branch credential's one-time `api_token` / `s3_secret_access_key` (and Neon Auth keys) are **reused** on re-pull instead of minting a fresh credential every time. The new `NEON_API_TOKEN` / `NEON_S3_ACCESS_KEY_ID` / `NEON_S3_SECRET_ACCESS_KEY` / `NEON_CREDENTIAL_ID` / `NEON_CREDENTIAL_SCOPES` vars flow through the existing `NEON_ENV_VAR_KEYS`-driven picker automatically.
- **`resolveNeonEnvVars`** (shared by `neon dev` / `env pull`) gains an optional `env` source threaded into `fetchEnv` (composed with the existing `apiOptions`, so the `NEON_API_HOST` override from #529 is preserved).
- **`config status`** surfaces secret-free issued-credential metadata (`id` / `name` / `scopes` / `lastUsedAt`) under `preview.credentials`.
- **`config apply` / `deploy` show deployed function URLs.** The human-readable output now renders a dedicated **"Function URLs"** table mapping each deployed function `slug` → its `invocation_url`, read from the `invocationUrl` config-runtime 0.5.0 now attaches to each `function:<slug>` change's details (neon-pkgs#184). Users see where to call a function right after `neonctl deploy`, without a follow-up `functions get`. JSON/YAML output carries the URL inside the raw applied-change details unchanged.
- **`functions deploy` shows the invocation URL too.** The standalone `neonctl functions deploy <slug>` command now surfaces the function's `invocation_url` alongside the resolved deployment in its output (not just the deployment id), so the imperative deploy path matches the `neon.ts` policy path. The deploy poll already fetches the full function record; we keep it instead of discarding everything but `active_deployment`.
- **AI Gateway env (via `@neondatabase/env` 0.4.0, neon-pkgs#184).** `env pull` / `neon dev` now write a **branch-scoped** `OPENAI_BASE_URL` (`https://<branchId>-api.ai.<region>.…/ai-gateway/openai/v1`) — fixing the old value that pointed at the control-plane API origin (`403`/CSRF) — and additionally emit `NEON_AI_GATEWAY_TOKEN` + `NEON_AI_GATEWAY_BASE_URL` next to the OpenAI vars. No neonctl code change; it flows through the existing picker. Verified against staging (`databricks-gpt-5` / `mlflow` → `200`).
- **Folded in from #535:** `createBranchFunction` is removed from the `NeonApi` test fakes (`commands/config.test.ts`, `commands/env.test.ts`, `dev/env.test.ts`) — it no longer exists on the interface in config 0.5.0 (functions are created on first deploy; see neon-pkgs#184). No production neonctl code referenced it.
- **Drop the `dev.portless` function option (breaking).** config 0.5.0 removes `dev.portless` from the schema (neon-pkgs#184), so `neon dev` no longer wraps functions with the external `portless` proxy. That proxy needed a separately-installed global `portless` binary and only produced a clean `slug.localhost` URL behind a privileged (80/443) proxy — otherwise the URL still carried a proxy port (e.g. `:1355`), defeating the purpose. Functions now always serve on a plain `http://localhost:<port>` (explicit `dev.port`, or an auto-selected free port). Removes the `inherit` `PortSpec` mode, the `portless` `spawnChild` wrapping, the `assertPortlessAvailable` PATH check, and `ServedUnit.portless` / `PlannedFunction.portless`.
- **`build(deps)`**: `@neondatabase/config` / `@neondatabase/config-runtime` → **0.5.0**, `@neondatabase/env` → **0.4.0**.

## Why this can't merge yet

The deps `0.5.0` / `0.4.0` are produced by neon-pkgs#184 and are **not published**. `package.json` targets them, but the lockfile still pins the current `0.4.2` / `0.3.2`, so `--frozen-lockfile` fails. This is the one blocker.

## Test plan

Because the deps aren't published, this was verified by symlinking the **built** neon-pkgs `0.5.0`/`0.4.0` packages into `node_modules` (the real next-release code):

- [x] `tsc --noEmit` clean against the new API.
- [x] Affected tests green (67 passed): credential fakes (`createCredential` / `listCredentials` / `revokeCredential` / `getProjectBranchStorage`, no `createBranchFunction`); `config_format` credential projection; `dev/env` auth key-set incl. `NEON_AUTH_JWKS_URL`; and the dev supervisor / `functions` / `runtime` tests after the portless removal.
- [x] New `config.test.ts` case: `apply` renders the "Function URLs" table with the deployed function's `invocation_url` (fake made stateful so the post-deploy re-list returns the function). Green against the symlinked 0.5.0 packages; the function tests in this file can't run against the stale published 0.4.2 (same create-on-first-deploy reason as the rest of the suite).
- [x] `functions deploy` snapshots updated to include `invocation_url` (verified the exact YAML rendering via the `yaml` lib). These tests fork the compiled `dist`, so they only execute once `pnpm build` succeeds — which is itself gated on the unpublished 0.5.0 deps; they pass against the next-release build and will re-validate in CI once deps publish.
- [x] Verified against staging earlier in this branch's history: `env pull` mints + writes all five credential vars; a second `env pull` **reuses** the same `NEON_CREDENTIAL_ID` (no re-mint); a branch without buckets/AI Gateway pulls only `DATABASE_URL[_UNPOOLED]` and makes no credential calls.
- [ ] Re-run CI after neon-pkgs `0.5.0` / `0.4.0` publish + `pnpm install` refreshes the lockfile.


