### PR TITLE
fix(branch-picker): use [default]/[protected] word labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ step to pick which branch to pin — the same `＋ Create a new branch…` + lis
 ```bash
 ? Which organization would you like to link? › Personal Org (org-abc123)
 ? Which project would you like to link? › my-app (polished-snowflake-12345678)
-? Which branch would you like to link? › ✱ main (br-main-branch-87654321)
+? Which branch would you like to link? › [default] main (br-main-branch-87654321)
 ```
 
 **Non-interactive (flags or `--params` JSON)** — for scripts and CI:

--- a/src/utils/branch_picker.ts
+++ b/src/utils/branch_picker.ts
@@ -18,6 +18,22 @@ export type PickedBranch =
 const CREATE_BRANCH_CHOICE = Symbol('create-branch');
 
 /**
+ * Render a branch's display name with the same word labels as `neonctl branch list`
+ * (`[default]`, `[protected]`) instead of symbols, so the picker reads clearly.
+ */
+const branchLabel = (branch: Branch): string => {
+  const labels: string[] = [];
+  if (branch.default) {
+    labels.push('[default]');
+  }
+  if (branch.protected) {
+    labels.push('[protected]');
+  }
+  labels.push(branch.name);
+  return labels.join(' ');
+};
+
+/**
  * Prompt the user to pick a branch from `branches`, with a "＋ Create a new branch…" option
  * pinned to the top (mirroring the project/org pickers). The default selection is the
  * project's default branch (the create option sits at index 0, so the default index is
@@ -42,7 +58,7 @@ export const pickBranchInteractively = async (
     choices: [
       { title: '＋ Create a new branch…', value: CREATE_BRANCH_CHOICE },
       ...branches.map((b: Branch) => ({
-        title: `${b.default ? '✱ ' : ''}${b.name} (${b.id})`,
+        title: `${branchLabel(b)} (${b.id})`,
         value: b.id,
       })),
     ],


### PR DESCRIPTION
## Summary
- The interactive branch picker (`neonctl checkout` / `neonctl link`) still rendered the project default branch with a `✱` symbol. This replaces it with the `[default]` word label, matching the convention adopted by `neonctl branch list` (commit cf2f5d8).
- The picker also now surfaces protected branches with `[protected]`, consistent with the list command, so the selector reads clearly without relying on symbols.
- Updated the `link` README example accordingly.

Before:
```
? Which branch would you like to link? › ✱ main (br-...)
```
After:
```
? Which branch would you like to link? › [default] main (br-...)
```

## Test plan
- [x] `pnpm typecheck`
- [x] `eslint` + `prettier --check` on changed files
- [x] `vitest run src/utils/branch_picker.test.ts`