### PR TITLE
fix(config): adopt function create-on-first-deploy (config/config-runtime 0.5.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.4.2",
-    "@neondatabase/config-runtime": "0.4.2",
+    "@neondatabase/config": "0.5.0",
+    "@neondatabase/config-runtime": "0.5.0",
     "@neondatabase/env": "0.3.2",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -176,21 +176,6 @@ class FakeNeonApi implements NeonApi {
     return [];
   }
 
-  async createBranchFunction(
-    projectId: string,
-    branchId: string,
-    input: { slug: string; name: string },
-  ): Promise<NeonFunctionSnapshot> {
-    void projectId;
-    void branchId;
-    return {
-      id: `fn-${input.slug}`,
-      slug: input.slug,
-      name: input.name,
-      invocationUrl: `https://${input.slug}.${BRANCH_ID}.fake.neon.tech`,
-    };
-  }
-
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -144,9 +144,6 @@ class FakeNeonApi implements NeonApi {
   async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
     return [];
   }
-  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
-    throw new Error('not implemented');
-  }
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -194,10 +194,6 @@ class FakeNeonApi implements NeonApi {
     return [];
   }
 
-  async createBranchFunction(): Promise<NeonFunctionSnapshot> {
-    throw new Error('not implemented');
-  }
-
   async deleteBranchFunction(): Promise<void> {
     throw new Error('not implemented');
   }


### PR DESCRIPTION
## Summary

Consumer-side counterpart to neondatabase/neon-pkgs#184, which fixes `config apply` failing with **HTTP 405** when creating a function (Neon has no standalone create-function endpoint — the first deployment creates the function).

- Bump `@neondatabase/config` and `@neondatabase/config-runtime` to `0.5.0`.
- Remove `createBranchFunction` from the `NeonApi` test fakes (`commands/config.test.ts`, `commands/env.test.ts`, `dev/env.test.ts`), since it no longer exists on the interface.

No production neonctl code referenced `createBranchFunction`; the fix lives entirely in the packages.

## Draft / blocked on publish

- ⛔ **Blocked**: `@neondatabase/config@0.5.0` / `@neondatabase/config-runtime@0.5.0` are not published yet (PR neon-pkgs#184). Until then this branch can't `pnpm install` or pass CI.
- ⚠️ A full bump to the next release also requires syncing the `NeonApi` test fakes for the **already-unreleased** branch-credentials / storage methods (`getProjectBranchStorage`, `createCredential`, `listCredentials`, `revokeCredential`) and `PulledPreview.credentials`. That drift is pre-existing (independent of this fix) and is out of scope here.

## Test plan

- [x] Verified end-to-end locally by `pnpm`-linking the local `neon-pkgs` build into this CLI and running `config apply` against staging from an example app: first run creates the function (deploymentId 1), re-run updates it (deploymentId 2) — no HTTP 405.
- [ ] Re-run CI once config/config-runtime `0.5.0` are published and the remaining fakes are synced.