### PR TITLE
fix(functions): bundle dependencies into the function deploy archive

### DIFF
--- a/src/utils/esbuild.test.ts
+++ b/src/utils/esbuild.test.ts
@@ -46,7 +46,6 @@ beforeAll(() => {
     [
       'import { greet } from "./helper";',
       'import { readFileSync } from "node:fs";',
-      'import "neon-fake-external-pkg";',
       'export default { greet, readFileSync };',
       '',
     ].join('\n'),
@@ -67,13 +66,14 @@ describe('bundleEntry', () => {
     expect(out['index.mjs.map'].length).toBeGreaterThan(0);
   });
 
-  // packages=external leaves ALL bare imports external, not just built-ins.
-  test('leaves bare imports (node built-ins and npm packages) external', async () => {
+  // Node built-ins stay external on platform:'node'; the createRequire banner is injected
+  // so bundled CommonJS deps can `require(...)` inside the ESM output.
+  test('keeps node built-ins external and injects a createRequire banner', async () => {
     const js = strFromU8(
       (await bundleEntry(join(dir, 'index.ts'), npmDeps))['index.mjs'],
     );
     expect(js).toContain('node:fs');
-    expect(js).toContain('neon-fake-external-pkg');
+    expect(js).toContain('createRequire');
   });
 
   test('surfaces a bundle error without falling back to a binary search', async () => {

--- a/src/utils/esbuild.ts
+++ b/src/utils/esbuild.ts
@@ -9,6 +9,14 @@ const NOT_FOUND =
   'this, install esbuild and ensure it is on your PATH (e.g. `npm i -g ' +
   'esbuild`), or set NEON_ESBUILD_PATH to an esbuild binary.';
 
+// Prepended to the ESM bundle. Bundled dependencies are frequently CommonJS, but an ESM
+// output (`--format=esm`) has no `require` / `__filename` / `__dirname` in scope — so any
+// bundled CJS code that calls `require(...)` would fail at load with
+// `Dynamic require of "x" is not supported`. Re-create those globals via `createRequire`
+// so CJS and ESM dependencies coexist in the single `index.mjs`.
+const ESM_CJS_INTEROP_BANNER =
+  "import{createRequire as ___cr}from'module';import{fileURLToPath as ___f}from'url';import{dirname as ___d}from'path';const require=___cr(import.meta.url);const __filename=___f(import.meta.url);const __dirname=___d(__filename);";
+
 // esbuild's JS module, narrowed to the one call we use. Typed structurally so
 // we never statically import from 'esbuild' (see bundleViaModule for why).
 type EsbuildModule = {
@@ -80,7 +88,10 @@ const bundleViaModule = async (
       minify: true,
       format: 'esm',
       platform: 'node',
-      packages: 'external',
+      // Bundle dependencies into the entry so the deployed archive is self-contained (the
+      // Functions runtime has no node_modules). Node built-ins stay external on
+      // platform:'node'. The banner re-creates require/__filename/__dirname for bundled CJS.
+      banner: { js: ESM_CJS_INTEROP_BANNER },
       logLevel: 'silent',
     })
     .catch((err: unknown) => {
@@ -151,7 +162,7 @@ const bundleViaBinary = async (
       '--minify',
       '--format=esm',
       '--platform=node',
-      '--packages=external',
+      `--banner:js=${ESM_CJS_INTEROP_BANNER}`,
       '--log-level=error',
     ]);
     if (code !== 0) {


### PR DESCRIPTION
## Summary

`neonctl`'s function bundler (`src/utils/esbuild.ts`) ran esbuild with `--packages=external`, so every npm dependency was left as a bare import and **none** were shipped. The Functions runtime has no `node_modules`, so any function importing a third-party package fails to load at runtime with `Cannot find package '…'`. This affects **both** deploy paths, since they share this bundler: `neonctl functions deploy` and `neonctl config apply` (which injects this bundler into `pushConfig`).

The bundler now produces a **self-contained** ESM bundle (applied to both the in-process module path and the shelled-out binary path):

```diff
- packages: 'external',
+ banner: { js: ESM_CJS_INTEROP_BANNER },
```
```diff
- '--packages=external',
+ `--banner:js=${ESM_CJS_INTEROP_BANNER}`,
```

- **Bundle dependencies** into `index.mjs` (Node built-ins stay external automatically on `platform: 'node'`).
- **Add a `createRequire` banner** so bundled CommonJS deps work inside the ESM output — otherwise bundled CJS code that calls `require(...)` dies with `Dynamic require of "fs" is not supported`. It re-creates `require` / `__filename` / `__dirname`:

```
import{createRequire as ___cr}from'module';import{fileURLToPath as ___f}from'url';import{dirname as ___d}from'path';const require=___cr(import.meta.url);const __filename=___f(import.meta.url);const __dirname=___d(__filename);
```

(`--sourcemap` / `--minify` kept as-is.)

## Test plan

- [x] `src/utils/esbuild.test.ts` passes (6 tests). Updated: the fixture no longer imports a non-existent package (that only "worked" because `--packages=external` skips resolution), and the externalization test now asserts Node built-ins stay external **and** the `createRequire` banner is injected.
- [x] Verified end-to-end against staging: a Hono app importing `dotenv`/`hono`/`drizzle-orm`/`pg`, bundled this way, loads and serves `HTTP 200` (previously `502 function_load_failed: Cannot find package 'dotenv'`).

## Notes

- Standalone fix — independent of the create-function/405 PR (neonctl#535).
- Mirrors the library-side default bundler change in neon-pkgs#185 (`config-runtime`'s `buildFunctionBundle`).
- Known follow-up (runtime-side, separate): the Functions runtime only accepts a *bare function* default export, so `export default { fetch }` (Hono/Workers style) still needs `export default app.fetch`. Not addressed here.