### PR TITLE
feat(bootstrap): add `bootstrap` command to scaffold from Neon templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,29 +356,46 @@ neon deploy --branch my-feature --update-existing
 
 Function deploys declared under `preview.functions` are bundled by neonctl's own esbuild helper and uploaded as part of `apply`, so the policy stays declarative and the packaged CLI never has to embed esbuild's native binary.
 
+## Scaffold a project (`bootstrap`)
+
+`neonctl bootstrap` copies a Neon starter template into a new (or current) directory — conceptually like `degit`, but it only pulls from a small set of templates we maintain in the public [`neondatabase/examples`](https://github.com/neondatabase/examples) repo. It requires no Neon login: it just downloads files from GitHub.
+
+Pass a target directory (or `.` for the current one). In an interactive terminal you pick the template from a list; in CI / non-interactive contexts pass `--template <id>`.
+
+```bash
+# Pick a template interactively and scaffold it into ./my-app
+$ neonctl bootstrap my-app
+
+# Scaffold a specific template into the current directory (no prompts)
+$ neonctl bootstrap . --template hono
+```
+
+The target directory must be empty unless you pass `--force` (a lone `.git` is ignored, so a freshly `git init`ed folder is fine). Symlinks and executable bits in the template are preserved.
+
 ## Commands
 
-| Command                                                                    | Subcommands                                                                                    | Description                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------- |
-| [auth](https://neon.com/docs/reference/cli-auth)                           |                                                                                                | Authenticate                     |
-| [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                    | Manage projects                  |
-| [ip-allow](https://neon.com/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                                               | Manage IP Allow                  |
-| [me](https://neon.com/docs/reference/cli-me)                               |                                                                                                | Show current user                |
-| [branches](https://neon.com/docs/reference/cli-branches)                   | `list`, `create`, `rename`, `add-compute`, `set-default`, `set-expiration`, `delete`, `get`    | Manage branches                  |
-| [databases](https://neon.com/docs/reference/cli-databases)                 | `list`, `create`, `delete`                                                                     | Manage databases                 |
-| functions                                                                  | `deploy`, `list`, `get`, `delete`                                                              | Manage Neon Functions            |
-| [roles](https://neon.com/docs/reference/cli-roles)                         | `list`, `create`, `delete`                                                                     | Manage roles                     |
-| [operations](https://neon.com/docs/reference/cli-operations)               | `list`                                                                                         | Manage operations                |
-| [connection-string](https://neon.com/docs/reference/cli-connection-string) |                                                                                                | Get connection string            |
-| psql                                                                       |                                                                                                | Connect to a database via psql   |
-| [set-context](https://neon.com/docs/reference/cli-set-context)             |                                                                                                | Set context for session          |
-| env                                                                        | `pull`                                                                                         | Manage a branch's env vars       |
-| checkout                                                                   |                                                                                                | Pin a branch in `.neon`          |
-| [link](https://neon.com/docs/reference/cli-link)                           |                                                                                                | Link a directory to a project    |
-| config                                                                     | `status`, `plan`, `apply`                                                                      | Drive a branch from `neon.ts`    |
-| deploy                                                                     |                                                                                                | Alias for `config apply`         |
-| bucket                                                                     | `create`, `list`, `delete`, `object list`, `object get`, `object delete` (incl. `--recursive`) | Manage buckets and their objects |
-| [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                                | Generate a completion script     |
+| Command                                                                    | Subcommands                                                                                    | Description                        |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------- |
+| [auth](https://neon.com/docs/reference/cli-auth)                           |                                                                                                | Authenticate                       |
+| [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                    | Manage projects                    |
+| [ip-allow](https://neon.com/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                                               | Manage IP Allow                    |
+| [me](https://neon.com/docs/reference/cli-me)                               |                                                                                                | Show current user                  |
+| [branches](https://neon.com/docs/reference/cli-branches)                   | `list`, `create`, `rename`, `add-compute`, `set-default`, `set-expiration`, `delete`, `get`    | Manage branches                    |
+| [databases](https://neon.com/docs/reference/cli-databases)                 | `list`, `create`, `delete`                                                                     | Manage databases                   |
+| functions                                                                  | `deploy`, `list`, `get`, `delete`                                                              | Manage Neon Functions              |
+| [roles](https://neon.com/docs/reference/cli-roles)                         | `list`, `create`, `delete`                                                                     | Manage roles                       |
+| [operations](https://neon.com/docs/reference/cli-operations)               | `list`                                                                                         | Manage operations                  |
+| [connection-string](https://neon.com/docs/reference/cli-connection-string) |                                                                                                | Get connection string              |
+| psql                                                                       |                                                                                                | Connect to a database via psql     |
+| [set-context](https://neon.com/docs/reference/cli-set-context)             |                                                                                                | Set context for session            |
+| env                                                                        | `pull`                                                                                         | Manage a branch's env vars         |
+| checkout                                                                   |                                                                                                | Pin a branch in `.neon`            |
+| [link](https://neon.com/docs/reference/cli-link)                           |                                                                                                | Link a directory to a project      |
+| config                                                                     | `status`, `plan`, `apply`                                                                      | Drive a branch from `neon.ts`      |
+| deploy                                                                     |                                                                                                | Alias for `config apply`           |
+| bootstrap                                                                  |                                                                                                | Scaffold a project from a template |
+| bucket                                                                     | `create`, `list`, `delete`, `object list`, `object get`, `object delete` (incl. `--recursive`) | Manage buckets and their objects   |
+| [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                                | Generate a completion script       |
 
 ## Global options
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -169,6 +169,12 @@ export const ensureAuth = async (
   // present, otherwise run with no API client (env injection is skipped).
   const isLocalDev = props._[0] === 'dev';
 
+  // `bootstrap` only copies a public template repo; it never calls the Neon
+  // API, so it must work without credentials and must never pop a browser
+  // login. It uses an API key / stored credentials when present (harmless),
+  // otherwise it proceeds with no API client.
+  const isBootstrap = props._[0] === 'bootstrap';
+
   // Use existing API key or handle auth command
   if (props.apiKey || props._[0] === 'auth') {
     if (props.apiKey) {
@@ -227,6 +233,11 @@ export const ensureAuth = async (
   // and the function still runs locally.
   if (isLocalDev) {
     log.debug('dev: no usable credentials; running without env injection');
+    return;
+  }
+
+  if (isBootstrap) {
+    log.debug('bootstrap: no usable credentials; continuing without auth');
     return;
   }
 

--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -1,0 +1,201 @@
+import { fork } from 'node:child_process';
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+// A fixture file in the template repo: its git `mode` decides whether it lands
+// as a regular file, an executable, or a symlink (whose content is the target).
+type FixtureFile = { mode: string; content: string };
+
+// Keyed by full repo path. The `with-hono` subdir mirrors what the real `hono`
+// template uses; `with-remix/...` must be filtered out as a sibling example.
+const FIXTURE: Record<string, FixtureFile> = {
+  'with-hono/package.json': {
+    mode: '100644',
+    content: '{\n  "name": "with-hono"\n}\n',
+  },
+  'with-hono/src/index.ts': {
+    mode: '100644',
+    content: 'export const app = "hono";\n',
+  },
+  'with-hono/scripts/run.sh': {
+    mode: '100755',
+    content: '#!/bin/sh\necho hi\n',
+  },
+  // A symlink: in git the blob content is the (relative) link target.
+  'with-hono/.claude/skills/neon': {
+    mode: '120000',
+    content: '../../package.json',
+  },
+  'with-remix/package.json': {
+    mode: '100644',
+    content: '{ "name": "with-remix" }\n',
+  },
+};
+
+const COMMIT_SHA = 'commit0000000000000000000000000000000000';
+const TREE_SHA = 'tree00000000000000000000000000000000000000';
+
+// A real local HTTP server standing in for the GitHub API + raw host, so the
+// whole download/extract path runs end to end with no mocking of our own code.
+const startGithubFixtureServer = (): Promise<Server> => {
+  const app = express();
+
+  app.get('/repos/:owner/:repo/commits/:ref', (_req, res) => {
+    res.json({ sha: COMMIT_SHA, commit: { tree: { sha: TREE_SHA } } });
+  });
+
+  app.get('/repos/:owner/:repo/git/trees/:treeSha', (_req, res) => {
+    const tree = Object.entries(FIXTURE).map(([path, file]) => ({
+      path,
+      mode: file.mode,
+      type: 'blob',
+    }));
+    res.json({ sha: TREE_SHA, truncated: false, tree });
+  });
+
+  app.get('/raw/:owner/:repo/:sha/*', (req, res) => {
+    const { owner, repo, sha } = req.params;
+    const repoPath = decodeURIComponent(
+      req.path.slice(`/raw/${owner}/${repo}/${sha}/`.length),
+    );
+    const file = FIXTURE[repoPath];
+    if (!file) {
+      res.status(404).send('Not Found');
+      return;
+    }
+    res.type('application/octet-stream').send(Buffer.from(file.content));
+  });
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      resolve(server);
+    });
+  });
+};
+
+const runBootstrap = (
+  server: Server,
+  args: string[],
+): Promise<{ code: number; stderr: string }> => {
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  return new Promise((resolve, reject) => {
+    const cp = fork(
+      join(process.cwd(), './dist/index.js'),
+      [
+        'bootstrap',
+        ...args,
+        '--api-key',
+        'test-key',
+        '--no-analytics',
+        '--output',
+        'yaml',
+      ],
+      {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          CI: 'true',
+          NEON_BOOTSTRAP_GITHUB_API: base,
+          NEON_BOOTSTRAP_GITHUB_RAW: `${base}/raw`,
+        },
+      },
+    );
+    let stderr = '';
+    cp.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+    cp.on('error', reject);
+    cp.on('close', (code) => {
+      resolve({ code: code ?? -1, stderr });
+    });
+  });
+};
+
+describe('bootstrap', () => {
+  let server: Server;
+  let dest: string;
+
+  beforeEach(async () => {
+    server = await startGithubFixtureServer();
+    dest = mkdtempSync(join(tmpdir(), 'neonctl-bootstrap-'));
+  });
+
+  afterEach(async () => {
+    rmSync(dest, { recursive: true, force: true });
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  test('copies the template subtree, preserving files, exec bits, and symlinks', async () => {
+    const { code, stderr } = await runBootstrap(server, [
+      dest,
+      '--template',
+      'hono',
+      '--force',
+    ]);
+    expect(code, stderr).toBe(0);
+
+    // Regular + nested files are written with the subdir prefix stripped.
+    expect(readFileSync(join(dest, 'package.json'), 'utf8')).toBe(
+      '{\n  "name": "with-hono"\n}\n',
+    );
+    expect(readFileSync(join(dest, 'src/index.ts'), 'utf8')).toBe(
+      'export const app = "hono";\n',
+    );
+
+    // The executable bit survives the round-trip.
+    expect(lstatSync(join(dest, 'scripts/run.sh')).mode & 0o111).not.toBe(0);
+
+    // The symlink is recreated as a real symlink pointing at its target.
+    const link = join(dest, '.claude/skills/neon');
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe('../../package.json');
+
+    // A sibling example in the same repo must not leak into the copy.
+    expect(() => readFileSync(join(dest, 'with-remix/package.json'))).toThrow();
+  });
+
+  test('refuses a non-empty directory without --force', async () => {
+    writeFileSync(join(dest, 'keep.txt'), 'mine\n');
+    const { code, stderr } = await runBootstrap(server, [
+      dest,
+      '--template',
+      'hono',
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).toContain('not empty');
+    // The existing file is left untouched and nothing was scaffolded.
+    expect(readFileSync(join(dest, 'keep.txt'), 'utf8')).toBe('mine\n');
+    expect(() => readFileSync(join(dest, 'package.json'))).toThrow();
+  });
+
+  test('rejects an unknown template id', async () => {
+    const { code, stderr } = await runBootstrap(server, [
+      dest,
+      '--template',
+      'does-not-exist',
+      '--force',
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).toContain('Unknown template');
+  });
+});

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -1,0 +1,293 @@
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import prompts, { InitialReturnValue } from 'prompts';
+import yargs from 'yargs';
+
+import { isCi } from '../env.js';
+import { log } from '../log.js';
+import { CommonProps } from '../types.js';
+import {
+  BootstrapTemplate,
+  fetchFileBytes,
+  fetchSymlinkTarget,
+  findTemplate,
+  resolveTemplate,
+  TEMPLATES,
+  templateIds,
+} from '../utils/bootstrap.js';
+
+type BootstrapProps = CommonProps & {
+  directory?: string;
+  template?: string;
+  force: boolean;
+};
+
+// The directory positional is optional: omitting it in an interactive terminal
+// prompts for one. In a non-interactive context a missing directory is an error.
+export const command = 'bootstrap [directory]';
+export const describe = 'Scaffold a new project from a Neon starter template';
+
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 bootstrap [directory] [options]')
+    .positional('directory', {
+      describe:
+        'Directory to scaffold into. Use "." for the current directory. Omit to be prompted.',
+      type: 'string',
+    })
+    .options({
+      template: {
+        describe: `Template to use (skips the interactive picker). One of: ${templateIds()}.`,
+        type: 'string',
+      },
+      force: {
+        describe:
+          'Scaffold into the target directory even if it is not empty (colliding files are overwritten).',
+        type: 'boolean',
+        default: false,
+      },
+    })
+    .example(
+      '$0 bootstrap my-app',
+      'Create ./my-app from an interactively chosen template',
+    )
+    .example(
+      '$0 bootstrap . --template hono',
+      'Scaffold the Hono template into the current directory',
+    )
+    .strict();
+
+export const handler = async (props: BootstrapProps): Promise<void> => {
+  const interactive = Boolean(process.stdout.isTTY) && !isCi();
+  const template = await resolveSelectedTemplate(props, interactive);
+  const targetDir = await resolveTargetDir(props, interactive, template);
+  ensureTargetUsable(targetDir, props.force);
+  await scaffold(template, targetDir);
+  printNextSteps(template, targetDir);
+};
+
+const resolveSelectedTemplate = async (
+  props: BootstrapProps,
+  interactive: boolean,
+): Promise<BootstrapTemplate> => {
+  if (props.template) {
+    const template = findTemplate(props.template);
+    if (!template) {
+      throw new Error(
+        `Unknown template "${props.template}". Available templates: ${templateIds()}.`,
+      );
+    }
+    return template;
+  }
+
+  if (!interactive) {
+    throw new Error(
+      `No template selected. Re-run in an interactive terminal to pick one, or pass --template <id>. Available templates: ${templateIds()}.`,
+    );
+  }
+
+  const { id } = await prompts({
+    onState: onPromptState,
+    type: 'select',
+    name: 'id',
+    message: 'Which template would you like to use?',
+    choices: TEMPLATES.map((template) => ({
+      title: template.title,
+      description: template.description,
+      value: template.id,
+    })),
+    initial: 0,
+  });
+  const template = findTemplate(id);
+  if (!template) {
+    throw new Error('No template selected.');
+  }
+  return template;
+};
+
+const resolveTargetDir = async (
+  props: BootstrapProps,
+  interactive: boolean,
+  template: BootstrapTemplate,
+): Promise<string> => {
+  let dir = props.directory;
+  if (dir === undefined) {
+    if (!interactive) {
+      throw new Error(
+        'No target directory given. Pass one, e.g. `neon bootstrap my-app` (or "." for the current directory).',
+      );
+    }
+    const { value } = await prompts({
+      onState: onPromptState,
+      type: 'text',
+      name: 'value',
+      message: 'Where should we scaffold your project?',
+      initial: defaultDirName(template),
+      validate: (input: string) =>
+        input && input.trim().length > 0
+          ? true
+          : 'Enter a directory (use "." for the current directory).',
+    });
+    dir = String(value).trim();
+  }
+  return resolve(process.cwd(), dir === '.' ? '' : dir);
+};
+
+const defaultDirName = (template: BootstrapTemplate): string =>
+  template.source.subdir.split('/').pop() || template.id;
+
+const ensureTargetUsable = (dir: string, force: boolean): void => {
+  if (!existsSync(dir)) {
+    return;
+  }
+  if (!statSync(dir).isDirectory()) {
+    throw new Error(`Target ${dir} already exists and is not a directory.`);
+  }
+  // A lone `.git` is ignored so you can scaffold into a freshly `git init`ed
+  // (otherwise empty) directory without reaching for --force.
+  const contents = readdirSync(dir).filter((name) => name !== '.git');
+  if (contents.length > 0 && !force) {
+    throw new Error(
+      `Target directory ${dir} is not empty. Use --force to scaffold into it anyway (colliding files will be overwritten), or choose an empty directory.`,
+    );
+  }
+};
+
+const scaffold = async (
+  template: BootstrapTemplate,
+  targetDir: string,
+): Promise<void> => {
+  log.info('Fetching template "%s" from GitHub…', template.id);
+  const { commitSha, entries } = await resolveTemplate(template);
+
+  mkdirSync(targetDir, { recursive: true });
+  log.info('Scaffolding %d files into %s…', entries.length, targetDir);
+
+  await mapWithConcurrency(entries, 8, async (entry) => {
+    const dest = join(targetDir, entry.path);
+    mkdirSync(dirname(dest), { recursive: true });
+    if (entry.kind === 'symlink') {
+      const target = await fetchSymlinkTarget(
+        template,
+        commitSha,
+        entry.repoPath,
+      );
+      writeSymlink(dest, target);
+    } else {
+      const bytes = await fetchFileBytes(template, commitSha, entry.repoPath);
+      writeFileSync(dest, bytes);
+      if (entry.executable) {
+        chmodSync(dest, 0o755);
+      }
+    }
+  });
+};
+
+const writeSymlink = (dest: string, target: string): void => {
+  if (isSymlink(dest)) {
+    rmSync(dest, { force: true });
+  }
+  try {
+    symlinkSync(target, dest);
+  } catch (err) {
+    // Windows refuses symlinks without elevated rights / developer mode. The
+    // template still works for most tooling if we drop a regular file holding
+    // the link target, so we degrade gracefully instead of failing the copy.
+    if (errnoCode(err) === 'EPERM' || process.platform === 'win32') {
+      log.warning(
+        'Could not create symlink %s -> %s; wrote it as a regular file instead.',
+        dest,
+        target,
+      );
+      writeFileSync(dest, target);
+      return;
+    }
+    throw err;
+  }
+};
+
+const printNextSteps = (
+  template: BootstrapTemplate,
+  targetDir: string,
+): void => {
+  const rel = relative(process.cwd(), targetDir);
+  // Show the bare relative path for the common `bootstrap my-app` case, fall
+  // back to the absolute path when the target sits outside the cwd (a deep
+  // `../../..` is noise), and special-case the current directory.
+  const isCurrent = rel === '';
+  const display = isCurrent ? '.' : rel.startsWith('..') ? targetDir : rel;
+  log.info('');
+  log.info(
+    'Done. Scaffolded "%s" into %s.',
+    template.title,
+    isCurrent ? 'the current directory' : display,
+  );
+  log.info('');
+  log.info('Next steps:');
+  if (!isCurrent) {
+    log.info('  cd %s', display);
+  }
+  log.info('  Install dependencies, then see the README to run it.');
+  log.info('');
+};
+
+const mapWithConcurrency = async <T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> => {
+  const queue = [...items];
+  const worker = async (): Promise<void> => {
+    for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
+      await fn(next);
+    }
+  };
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+};
+
+const isSymlink = (path: string): boolean => {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+};
+
+const errnoCode = (err: unknown): string | undefined => {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof err.code === 'string'
+  ) {
+    return err.code;
+  }
+  return undefined;
+};
+
+const onPromptState = (state: {
+  value: InitialReturnValue;
+  aborted: boolean;
+  exited: boolean;
+}) => {
+  if (state.aborted) {
+    process.stdout.write('\x1B[?25h');
+    process.stdout.write('\n');
+    process.exit(1);
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,6 +22,7 @@ import * as config from './config.js';
 import * as deploy from './deploy.js';
 import * as env from './env.js';
 import * as bucket from './bucket.js';
+import * as bootstrap from './bootstrap.js';
 
 export default [
   auth,
@@ -48,4 +49,5 @@ export default [
   deploy,
   env,
   bucket,
+  bootstrap,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'deploy',
 
+  'bootstrap',
+
   // aliases
 ];
 

--- a/src/utils/bootstrap.test.ts
+++ b/src/utils/bootstrap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { GitTreeNode, selectSubtreeEntries } from './bootstrap.js';
+
+const tree: GitTreeNode[] = [
+  { path: 'with-hono', mode: '040000', type: 'tree' },
+  { path: 'with-hono/package.json', mode: '100644', type: 'blob' },
+  { path: 'with-hono/src', mode: '040000', type: 'tree' },
+  { path: 'with-hono/src/index.ts', mode: '100644', type: 'blob' },
+  { path: 'with-hono/scripts/run.sh', mode: '100755', type: 'blob' },
+  { path: 'with-hono/.claude/skills/neon', mode: '120000', type: 'blob' },
+  // A different example in the same repo must never leak into the copy.
+  { path: 'with-remix/package.json', mode: '100644', type: 'blob' },
+  // A submodule (commit) is not a copyable blob.
+  { path: 'with-hono/vendor', mode: '160000', type: 'commit' },
+];
+
+describe('selectSubtreeEntries', () => {
+  it('keeps only blobs under the subdir and strips the prefix', () => {
+    const entries = selectSubtreeEntries(tree, 'with-hono');
+    expect(entries.map((e) => e.path).sort()).toEqual([
+      '.claude/skills/neon',
+      'package.json',
+      'scripts/run.sh',
+      'src/index.ts',
+    ]);
+  });
+
+  it('classifies symlinks, executables, and regular files by git mode', () => {
+    const byPath = Object.fromEntries(
+      selectSubtreeEntries(tree, 'with-hono').map((e) => [e.path, e]),
+    );
+
+    expect(byPath['.claude/skills/neon']).toMatchObject({ kind: 'symlink' });
+    expect(byPath['scripts/run.sh']).toMatchObject({
+      kind: 'file',
+      executable: true,
+    });
+    expect(byPath['package.json']).toMatchObject({
+      kind: 'file',
+      executable: false,
+    });
+  });
+
+  it('preserves the full repo path for fetching raw content', () => {
+    const entries = selectSubtreeEntries(tree, 'with-hono');
+    const pkg = entries.find((e) => e.path === 'package.json');
+    expect(pkg?.repoPath).toBe('with-hono/package.json');
+  });
+
+  it('tolerates a trailing slash on the subdir', () => {
+    expect(selectSubtreeEntries(tree, 'with-hono/')).toHaveLength(4);
+  });
+
+  it('returns nothing for a subdir that does not exist', () => {
+    expect(selectSubtreeEntries(tree, 'nope')).toEqual([]);
+  });
+});

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -1,0 +1,286 @@
+import axios, { isAxiosError } from 'axios';
+
+import { log } from '../log.js';
+
+/**
+ * A scaffold template that lives in a subdirectory of a public GitHub repo we
+ * control. `neon bootstrap` copies that subdirectory into a target folder —
+ * conceptually the same as `degit user/repo/subdir`, but implemented in-house
+ * so the download host stays configurable (and therefore end-to-end testable)
+ * and so we never pull in a heavy dependency tree just to copy a few files.
+ */
+export type BootstrapTemplate = {
+  /** Stable id used by `--template` and analytics. */
+  id: string;
+  /** Human label shown in the interactive selector. */
+  title: string;
+  /** One-line description shown under the title in the selector. */
+  description: string;
+  source: {
+    owner: string;
+    repo: string;
+    /** Branch (or tag) the template is pulled from. */
+    ref: string;
+    /** Subdirectory within the repo to copy (no leading/trailing slash). */
+    subdir: string;
+  };
+};
+
+export const TEMPLATES: BootstrapTemplate[] = [
+  {
+    id: 'hono',
+    title: 'Hono API (Drizzle, Neon Postgres) on Neon Functions',
+    description:
+      'A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function.',
+    source: {
+      owner: 'neondatabase',
+      repo: 'examples',
+      ref: 'main',
+      subdir: 'with-hono',
+    },
+  },
+];
+
+export const templateIds = (): string => TEMPLATES.map((t) => t.id).join(', ');
+
+export const findTemplate = (id: string): BootstrapTemplate | undefined =>
+  TEMPLATES.find((t) => t.id === id);
+
+/** A single file or symlink to materialize, resolved from the repo tree. */
+export type TemplateEntry =
+  | {
+      kind: 'file';
+      /** Path relative to the target directory (subdir prefix stripped). */
+      path: string;
+      /** Path within the repo, used to fetch the raw bytes. */
+      repoPath: string;
+      executable: boolean;
+    }
+  | {
+      kind: 'symlink';
+      path: string;
+      repoPath: string;
+    };
+
+export type GitTreeNode = {
+  path: string;
+  mode: string;
+  type: string;
+};
+
+// Hosts are overridable so the e2e tests can point the downloader at a local
+// server (the same trick `--api-host` uses to redirect the Neon API in tests).
+// The defaults hit public GitHub; copying a public template needs no auth.
+const githubApiBase = (): string =>
+  process.env.NEON_BOOTSTRAP_GITHUB_API ?? 'https://api.github.com';
+
+const githubRawBase = (): string =>
+  process.env.NEON_BOOTSTRAP_GITHUB_RAW ?? 'https://raw.githubusercontent.com';
+
+const githubToken = (): string =>
+  process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? '';
+
+const apiHeaders = (): Record<string, string> => ({
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'neonctl',
+  ...(githubToken() ? { Authorization: `Bearer ${githubToken()}` } : {}),
+});
+
+const rawHeaders = (): Record<string, string> => ({
+  'User-Agent': 'neonctl',
+  ...(githubToken() ? { Authorization: `Bearer ${githubToken()}` } : {}),
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const malformed = (what: string): Error =>
+  new Error(`Unexpected GitHub API response while resolving ${what}.`);
+
+type ResolvedCommit = { commitSha: string; treeSha: string };
+
+const parseCommit = (data: unknown): ResolvedCommit => {
+  if (!isRecord(data) || typeof data.sha !== 'string') {
+    throw malformed('the template commit');
+  }
+  const { commit } = data;
+  if (
+    !isRecord(commit) ||
+    !isRecord(commit.tree) ||
+    typeof commit.tree.sha !== 'string'
+  ) {
+    throw malformed('the template tree');
+  }
+  return { commitSha: data.sha, treeSha: commit.tree.sha };
+};
+
+type ParsedTree = { truncated: boolean; tree: GitTreeNode[] };
+
+const parseTree = (data: unknown): ParsedTree => {
+  if (!isRecord(data) || !Array.isArray(data.tree)) {
+    throw malformed('the template file tree');
+  }
+  const tree: GitTreeNode[] = [];
+  for (const item of data.tree) {
+    if (
+      isRecord(item) &&
+      typeof item.path === 'string' &&
+      typeof item.mode === 'string' &&
+      typeof item.type === 'string'
+    ) {
+      tree.push({ path: item.path, mode: item.mode, type: item.type });
+    }
+  }
+  return { truncated: data.truncated === true, tree };
+};
+
+const friendlyGithubError = (err: unknown, url: string): Error => {
+  if (isAxiosError(err)) {
+    const status = err.response?.status;
+    if (status === 404) {
+      return new Error(
+        `GitHub returned 404 for ${url}. The template repo, ref, or subdirectory may have moved.`,
+      );
+    }
+    if (
+      status === 403 &&
+      err.response?.headers['x-ratelimit-remaining'] === '0'
+    ) {
+      return new Error(
+        'GitHub API rate limit exceeded. Set a GITHUB_TOKEN environment variable to raise the limit, then retry.',
+      );
+    }
+  }
+  return err instanceof Error ? err : new Error(String(err));
+};
+
+const getJson = async (url: string): Promise<unknown> => {
+  try {
+    const res = await axios.get<unknown>(url, { headers: apiHeaders() });
+    return res.data;
+  } catch (err) {
+    throw friendlyGithubError(err, url);
+  }
+};
+
+/**
+ * Map a flat (recursive) git tree to the entries under `subdir`, with the
+ * `subdir/` prefix stripped from each `path`. Pure so it can be unit tested
+ * without touching the network. Directory nodes are dropped — git never
+ * stores empty directories, and writing files re-creates their parents.
+ */
+export const selectSubtreeEntries = (
+  tree: GitTreeNode[],
+  subdir: string,
+): TemplateEntry[] => {
+  const prefix = `${subdir.replace(/\/+$/, '')}/`;
+  const entries: TemplateEntry[] = [];
+  for (const node of tree) {
+    if (node.type !== 'blob') {
+      continue;
+    }
+    if (!node.path.startsWith(prefix)) {
+      continue;
+    }
+    const path = node.path.slice(prefix.length);
+    if (node.mode === '120000') {
+      entries.push({ kind: 'symlink', path, repoPath: node.path });
+    } else {
+      entries.push({
+        kind: 'file',
+        path,
+        repoPath: node.path,
+        executable: node.mode === '100755',
+      });
+    }
+  }
+  return entries;
+};
+
+export type ResolvedTemplate = {
+  /** Immutable commit the whole copy is pinned to (no time-of-check races). */
+  commitSha: string;
+  entries: TemplateEntry[];
+};
+
+/**
+ * Resolve a template to the exact set of files to write. Pins everything to a
+ * single immutable commit: the ref is resolved to a commit sha, the tree is
+ * read from that commit's tree, and every blob is later fetched by that same
+ * commit — so a push to the template repo mid-copy can't produce a mismatched
+ * checkout.
+ */
+export const resolveTemplate = async (
+  template: BootstrapTemplate,
+): Promise<ResolvedTemplate> => {
+  const { owner, repo, ref, subdir } = template.source;
+  const api = githubApiBase();
+
+  const commit = parseCommit(
+    await getJson(`${api}/repos/${owner}/${repo}/commits/${ref}`),
+  );
+  const { truncated, tree } = parseTree(
+    await getJson(
+      `${api}/repos/${owner}/${repo}/git/trees/${commit.treeSha}?recursive=1`,
+    ),
+  );
+  if (truncated) {
+    throw new Error(
+      `GitHub returned a truncated file tree for ${owner}/${repo}; cannot reliably copy template "${template.id}".`,
+    );
+  }
+
+  const entries = selectSubtreeEntries(tree, subdir);
+  if (entries.length === 0) {
+    throw new Error(
+      `Template subdirectory "${subdir}" was not found in ${owner}/${repo}@${ref}.`,
+    );
+  }
+  log.debug(
+    'bootstrap: resolved %d files for template "%s" at %s',
+    entries.length,
+    template.id,
+    commit.commitSha,
+  );
+  return { commitSha: commit.commitSha, entries };
+};
+
+const rawUrl = (
+  template: BootstrapTemplate,
+  commitSha: string,
+  repoPath: string,
+): string =>
+  `${githubRawBase()}/${template.source.owner}/${template.source.repo}/${commitSha}/${repoPath}`;
+
+/** Download a file's raw bytes, pinned to the resolved commit. */
+export const fetchFileBytes = async (
+  template: BootstrapTemplate,
+  commitSha: string,
+  repoPath: string,
+): Promise<Buffer> => {
+  const url = rawUrl(template, commitSha, repoPath);
+  try {
+    const res = await axios.get<ArrayBuffer>(url, {
+      responseType: 'arraybuffer',
+      headers: rawHeaders(),
+    });
+    return Buffer.from(res.data);
+  } catch (err) {
+    throw friendlyGithubError(err, url);
+  }
+};
+
+/**
+ * Read a symlink's target. In a git blob a symlink is stored as a regular file
+ * whose contents are the (relative) link target, so the raw bytes are exactly
+ * the string we pass to `symlink(2)`.
+ */
+export const fetchSymlinkTarget = async (
+  template: BootstrapTemplate,
+  commitSha: string,
+  repoPath: string,
+): Promise<string> => {
+  const bytes = await fetchFileBytes(template, commitSha, repoPath);
+  return bytes.toString('utf8');
+};


### PR DESCRIPTION
## Summary

Adds `neon bootstrap [directory]`, a scaffolding command that copies a Neon starter template into a target folder — conceptually like `degit`, but implemented in-house.

- Currently ships one template: **Hono API (Drizzle, Neon Postgres) on Neon Functions** (`with-hono` in [`neondatabase/examples`](https://github.com/neondatabase/examples)). The registry in `src/utils/bootstrap.ts` makes adding more a one-line change.
- Interactive template picker in a TTY; `--template <id>` for non-interactive / CI use.
- Target dir comes from the positional (`.` for the current dir, or a name to create); prompted when omitted in a TTY.
- Requires the target be empty unless `--force` (a lone `.git` is ignored).
- **No Neon login required** — it only downloads files from public GitHub (`bootstrap` is added to the auth-skip list alongside `dev`).

### Why not `degit` / `tiged`?

`tiged`/`degit` only know fixed hosts (github.com, …) with no localhost override, so they can't be exercised against a local server the way the rest of neonctl is tested, and they drag in a heavy dependency tree + a global cache. Instead this does what they do under the hood — resolve a ref, read the tree, copy a subdir — with **no new dependencies** (reuses `axios`), a **configurable host** (so it's fully e2e-testable), and correct **symlink + exec-bit** preservation (the `with-hono` template relies on `.claude/skills/*` symlinks, which a zip+`fflate` approach would have silently flattened).

### How it works

1. Resolve the template's ref to an immutable commit (`/repos/:o/:r/commits/:ref`) so a push mid-copy can't produce a mismatched checkout.
2. Read the recursive file tree from that commit's tree (`/git/trees/:sha?recursive=1`), filter to the template subdir, and classify each blob as file / executable / symlink by its git `mode`.
3. Download each blob from the raw host (no API rate limit), pinned to the resolved commit. `GITHUB_TOKEN`/`GH_TOKEN` is used if present.

## Test plan

- [x] `pnpm lint` (typecheck + eslint + prettier) clean
- [x] `pnpm test` — full suite green (2878 passed, 7 skipped), no snapshot/regression changes
- [x] Unit test for the pure subtree→entries mapping (`src/utils/bootstrap.test.ts`)
- [x] E2E test against a local GitHub fixture server (`src/commands/bootstrap.test.ts`): verifies files, nested dirs, exec bits, symlinks, subdir filtering, the non-empty-dir guard, and unknown-template handling
- [x] Manual smoke test against **real** GitHub: `node dist/index.js bootstrap /tmp/x --template hono` → 17 files extracted with `.claude/skills/*` preserved as real symlinks, no auth prompt