### PR TITLE
feat(bootstrap): fetch template list from remote manifest

### DIFF
--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -215,4 +215,11 @@ describe('bootstrap', () => {
     expect(code).toBe(1);
     expect(stderr).toContain('Unknown template');
   });
+
+  test('--list prints available templates from the remote manifest', async () => {
+    const { code, stderr } = await runBootstrap(server, ['--list']);
+    expect(code, stderr).toBe(0);
+    expect(stderr).toContain('hono');
+    expect(stderr).toContain('A Hono API using Drizzle ORM and Neon Postgres');
+  });
 });

--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -47,10 +47,26 @@ const FIXTURE: Record<string, FixtureFile> = {
 const COMMIT_SHA = 'commit0000000000000000000000000000000000';
 const TREE_SHA = 'tree00000000000000000000000000000000000000';
 
+const MANIFEST_YAML = `templates:
+  - id: hono
+    title: "Hono API (Drizzle, Neon Postgres) on Neon Functions"
+    description: "A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function."
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+
 // A real local HTTP server standing in for the GitHub API + raw host, so the
 // whole download/extract path runs end to end with no mocking of our own code.
 const startGithubFixtureServer = (): Promise<Server> => {
   const app = express();
+
+  // Serve the bootstrap manifest
+  app.get('/manifest/bootstrap.yaml', (_req, res) => {
+    res.type('text/yaml').send(MANIFEST_YAML);
+  });
 
   app.get('/repos/:owner/:repo/commits/:ref', (_req, res) => {
     res.json({ sha: COMMIT_SHA, commit: { tree: { sha: TREE_SHA } } });
@@ -109,6 +125,7 @@ const runBootstrap = (
           CI: 'true',
           NEON_BOOTSTRAP_GITHUB_API: base,
           NEON_BOOTSTRAP_GITHUB_RAW: `${base}/raw`,
+          NEON_BOOTSTRAP_MANIFEST_URL: `${base}/manifest/bootstrap.yaml`,
         },
       },
     );

--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -104,7 +104,7 @@ const startGithubFixtureServer = (): Promise<Server> => {
 const runBootstrap = (
   server: Server,
   args: string[],
-): Promise<{ code: number; stderr: string }> => {
+): Promise<{ code: number; stdout: string; stderr: string }> => {
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
   return new Promise((resolve, reject) => {
     const cp = fork(
@@ -129,13 +129,17 @@ const runBootstrap = (
         },
       },
     );
+    let stdout = '';
     let stderr = '';
+    cp.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
     cp.stderr?.on('data', (data: Buffer) => {
       stderr += data.toString();
     });
     cp.on('error', reject);
     cp.on('close', (code) => {
-      resolve({ code: code ?? -1, stderr });
+      resolve({ code: code ?? -1, stdout, stderr });
     });
   });
 };
@@ -216,10 +220,10 @@ describe('bootstrap', () => {
     expect(stderr).toContain('Unknown template');
   });
 
-  test('--list prints available templates from the remote manifest', async () => {
-    const { code, stderr } = await runBootstrap(server, ['--list']);
+  test('--list prints available templates to stdout from the remote manifest', async () => {
+    const { code, stdout, stderr } = await runBootstrap(server, ['--list']);
     expect(code, stderr).toBe(0);
-    expect(stderr).toContain('hono');
-    expect(stderr).toContain('A Hono API using Drizzle ORM and Neon Postgres');
+    expect(stdout).toContain('hono');
+    expect(stdout).toContain('A Hono API using Drizzle ORM and Neon Postgres');
   });
 });

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -31,7 +31,7 @@ type BootstrapProps = CommonProps & {
   directory?: string;
   template?: string;
   force: boolean;
-  list: boolean;
+  listTemplates: boolean;
 };
 
 // The directory positional is optional: omitting it in an interactive terminal
@@ -50,10 +50,11 @@ export const builder = (argv: yargs.Argv) =>
     .options({
       template: {
         describe:
-          'Template to use (skips the interactive picker). Run with --list to see available templates.',
+          'Template to use (skips the interactive picker). Run with --list-templates to see available templates.',
         type: 'string',
       },
-      list: {
+      'list-templates': {
+        alias: ['list', 'ls'],
         describe: 'List available templates and exit.',
         type: 'boolean',
         default: false,
@@ -78,7 +79,7 @@ export const builder = (argv: yargs.Argv) =>
 export const handler = async (props: BootstrapProps): Promise<void> => {
   const templates = await fetchTemplates();
 
-  if (props.list) {
+  if (props.listTemplates) {
     for (const t of templates) {
       log.info('%s — %s', t.id, t.description);
     }

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -19,6 +19,7 @@ import { log } from '../log.js';
 import { CommonProps } from '../types.js';
 import {
   BootstrapTemplate,
+  FALLBACK_TEMPLATES,
   fetchFileBytes,
   fetchSymlinkTarget,
   fetchTemplates,
@@ -77,14 +78,21 @@ export const builder = (argv: yargs.Argv) =>
     .strict();
 
 export const handler = async (props: BootstrapProps): Promise<void> => {
-  const templates = await fetchTemplates();
-
   if (props.listTemplates) {
+    const templates = await fetchTemplates();
     for (const t of templates) {
-      log.info('%s — %s', t.id, t.description);
+      process.stdout.write(`${t.id} — ${t.description}\n`);
     }
     return;
   }
+
+  // When --template is provided, try the fallback list first to avoid a
+  // network round-trip. Only fetch the remote manifest if the id isn't found.
+  const templates = props.template
+    ? findTemplate(FALLBACK_TEMPLATES, props.template)
+      ? FALLBACK_TEMPLATES
+      : await fetchTemplates()
+    : await fetchTemplates();
 
   const interactive = Boolean(process.stdout.isTTY) && !isCi();
   const template = await resolveSelectedTemplate(props, interactive, templates);

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -21,9 +21,9 @@ import {
   BootstrapTemplate,
   fetchFileBytes,
   fetchSymlinkTarget,
+  fetchTemplates,
   findTemplate,
   resolveTemplate,
-  TEMPLATES,
   templateIds,
 } from '../utils/bootstrap.js';
 
@@ -31,6 +31,7 @@ type BootstrapProps = CommonProps & {
   directory?: string;
   template?: string;
   force: boolean;
+  list: boolean;
 };
 
 // The directory positional is optional: omitting it in an interactive terminal
@@ -48,8 +49,14 @@ export const builder = (argv: yargs.Argv) =>
     })
     .options({
       template: {
-        describe: `Template to use (skips the interactive picker). One of: ${templateIds()}.`,
+        describe:
+          'Template to use (skips the interactive picker). Run with --list to see available templates.',
         type: 'string',
+      },
+      list: {
+        describe: 'List available templates and exit.',
+        type: 'boolean',
+        default: false,
       },
       force: {
         describe:
@@ -69,8 +76,17 @@ export const builder = (argv: yargs.Argv) =>
     .strict();
 
 export const handler = async (props: BootstrapProps): Promise<void> => {
+  const templates = await fetchTemplates();
+
+  if (props.list) {
+    for (const t of templates) {
+      log.info('%s — %s', t.id, t.description);
+    }
+    return;
+  }
+
   const interactive = Boolean(process.stdout.isTTY) && !isCi();
-  const template = await resolveSelectedTemplate(props, interactive);
+  const template = await resolveSelectedTemplate(props, interactive, templates);
   const targetDir = await resolveTargetDir(props, interactive, template);
   ensureTargetUsable(targetDir, props.force);
   await scaffold(template, targetDir);
@@ -80,12 +96,13 @@ export const handler = async (props: BootstrapProps): Promise<void> => {
 const resolveSelectedTemplate = async (
   props: BootstrapProps,
   interactive: boolean,
+  templates: BootstrapTemplate[],
 ): Promise<BootstrapTemplate> => {
   if (props.template) {
-    const template = findTemplate(props.template);
+    const template = findTemplate(templates, props.template);
     if (!template) {
       throw new Error(
-        `Unknown template "${props.template}". Available templates: ${templateIds()}.`,
+        `Unknown template "${props.template}". Available templates: ${templateIds(templates)}.`,
       );
     }
     return template;
@@ -93,7 +110,7 @@ const resolveSelectedTemplate = async (
 
   if (!interactive) {
     throw new Error(
-      `No template selected. Re-run in an interactive terminal to pick one, or pass --template <id>. Available templates: ${templateIds()}.`,
+      `No template selected. Re-run in an interactive terminal to pick one, or pass --template <id>. Available templates: ${templateIds(templates)}.`,
     );
   }
 
@@ -102,14 +119,14 @@ const resolveSelectedTemplate = async (
     type: 'select',
     name: 'id',
     message: 'Which template would you like to use?',
-    choices: TEMPLATES.map((template) => ({
+    choices: templates.map((template) => ({
       title: template.title,
       description: template.description,
       value: template.id,
     })),
     initial: 0,
   });
-  const template = findTemplate(id);
+  const template = findTemplate(templates, id);
   if (!template) {
     throw new Error('No template selected.');
   }

--- a/src/utils/bootstrap.test.ts
+++ b/src/utils/bootstrap.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { GitTreeNode, selectSubtreeEntries } from './bootstrap.js';
+import {
+  GitTreeNode,
+  parseManifest,
+  selectSubtreeEntries,
+} from './bootstrap.js';
 
 const tree: GitTreeNode[] = [
   { path: 'with-hono', mode: '040000', type: 'tree' },
@@ -54,5 +58,74 @@ describe('selectSubtreeEntries', () => {
 
   it('returns nothing for a subdir that does not exist', () => {
     expect(selectSubtreeEntries(tree, 'nope')).toEqual([]);
+  });
+});
+
+describe('parseManifest', () => {
+  it('parses a valid manifest', () => {
+    const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+    const templates = parseManifest(yaml);
+    expect(templates).toHaveLength(1);
+    expect(templates[0]).toEqual({
+      id: 'hono',
+      title: 'Hono API',
+      description: 'A Hono template.',
+      source: {
+        owner: 'neondatabase',
+        repo: 'examples',
+        ref: 'main',
+        subdir: 'with-hono',
+      },
+    });
+  });
+
+  it('skips malformed entries and keeps valid ones', () => {
+    const yaml = `templates:
+  - id: good
+    title: Good
+    description: A good template.
+    source:
+      owner: org
+      repo: repo
+      ref: main
+      subdir: good
+  - id: bad-no-source
+    title: Bad
+    description: Missing source field.
+  - not-even-an-object
+`;
+    const templates = parseManifest(yaml);
+    expect(templates).toHaveLength(1);
+    expect(templates[0].id).toBe('good');
+  });
+
+  it('returns an empty array when all entries are malformed', () => {
+    const yaml = `templates:
+  - id: 123
+    title: numeric id
+`;
+    expect(parseManifest(yaml)).toEqual([]);
+  });
+
+  it('throws when the top-level structure is invalid', () => {
+    expect(() => parseManifest('not-yaml: []')).toThrow(
+      'missing "templates" array',
+    );
+    expect(() => parseManifest('templates: not-an-array')).toThrow(
+      'missing "templates" array',
+    );
+  });
+
+  it('handles an empty templates array', () => {
+    expect(parseManifest('templates: []')).toEqual([]);
   });
 });

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -43,77 +43,6 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
   },
 ];
 
-const manifestUrl = (): string =>
-  process.env.NEON_BOOTSTRAP_MANIFEST_URL ??
-  `${githubRawBase()}/neondatabase/examples/main/bootstrap.yaml`;
-
-const parseManifest = (text: string): BootstrapTemplate[] => {
-  const data: unknown = YAML.parse(text);
-  if (!isRecord(data) || !Array.isArray(data.templates)) {
-    throw new Error('Invalid bootstrap manifest: missing "templates" array.');
-  }
-  const templates: BootstrapTemplate[] = [];
-  for (const item of data.templates) {
-    if (
-      !isRecord(item) ||
-      typeof item.id !== 'string' ||
-      typeof item.title !== 'string' ||
-      typeof item.description !== 'string' ||
-      !isRecord(item.source) ||
-      typeof item.source.owner !== 'string' ||
-      typeof item.source.repo !== 'string' ||
-      typeof item.source.ref !== 'string' ||
-      typeof item.source.subdir !== 'string'
-    ) {
-      continue;
-    }
-    templates.push({
-      id: item.id,
-      title: item.title,
-      description: item.description,
-      source: {
-        owner: item.source.owner,
-        repo: item.source.repo,
-        ref: item.source.ref,
-        subdir: item.source.subdir,
-      },
-    });
-  }
-  return templates;
-};
-
-/**
- * Fetch the template manifest from the remote `bootstrap.yaml` in the
- * neondatabase/examples repo. Falls back to the hardcoded list on any error
- * so the command never fails just because GitHub is unreachable.
- */
-export const fetchTemplates = async (): Promise<BootstrapTemplate[]> => {
-  const url = manifestUrl();
-  try {
-    const res = await axios.get<string>(url, {
-      responseType: 'text',
-      headers: rawHeaders(),
-      timeout: 10_000,
-    });
-    const templates = parseManifest(res.data);
-    if (templates.length === 0) {
-      log.warning(
-        'Remote bootstrap manifest at %s contained no templates; using built-in defaults.',
-        url,
-      );
-      return FALLBACK_TEMPLATES;
-    }
-    return templates;
-  } catch (err) {
-    log.debug(
-      'bootstrap: failed to fetch manifest from %s: %s — using built-in defaults.',
-      url,
-      err instanceof Error ? err.message : String(err),
-    );
-    return FALLBACK_TEMPLATES;
-  }
-};
-
 export const templateIds = (templates: BootstrapTemplate[]): string =>
   templates.map((t) => t.id).join(', ');
 
@@ -170,6 +99,86 @@ const rawHeaders = (): Record<string, string> => ({
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
+
+// ---------------------------------------------------------------------------
+// Remote template manifest
+// ---------------------------------------------------------------------------
+
+const manifestUrl = (): string =>
+  process.env.NEON_BOOTSTRAP_MANIFEST_URL ??
+  `${githubRawBase()}/neondatabase/examples/main/bootstrap.yaml`;
+
+export const parseManifest = (text: string): BootstrapTemplate[] => {
+  const data: unknown = YAML.parse(text);
+  if (!isRecord(data) || !Array.isArray(data.templates)) {
+    throw new Error('Invalid bootstrap manifest: missing "templates" array.');
+  }
+  const templates: BootstrapTemplate[] = [];
+  for (let i = 0; i < data.templates.length; i++) {
+    const item: unknown = data.templates[i];
+    if (
+      !isRecord(item) ||
+      typeof item.id !== 'string' ||
+      typeof item.title !== 'string' ||
+      typeof item.description !== 'string' ||
+      !isRecord(item.source) ||
+      typeof item.source.owner !== 'string' ||
+      typeof item.source.repo !== 'string' ||
+      typeof item.source.ref !== 'string' ||
+      typeof item.source.subdir !== 'string'
+    ) {
+      log.warning(
+        'bootstrap: skipping malformed template entry at index %d in manifest.',
+        i,
+      );
+      continue;
+    }
+    templates.push({
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      source: {
+        owner: item.source.owner,
+        repo: item.source.repo,
+        ref: item.source.ref,
+        subdir: item.source.subdir,
+      },
+    });
+  }
+  return templates;
+};
+
+/**
+ * Fetch the template manifest from the remote `bootstrap.yaml` in the
+ * neondatabase/examples repo. Falls back to the hardcoded list on any error
+ * so the command never fails just because GitHub is unreachable.
+ */
+export const fetchTemplates = async (): Promise<BootstrapTemplate[]> => {
+  const url = manifestUrl();
+  try {
+    const res = await axios.get<string>(url, {
+      responseType: 'text',
+      headers: rawHeaders(),
+      timeout: 10_000,
+    });
+    const templates = parseManifest(res.data);
+    if (templates.length === 0) {
+      log.warning(
+        'Remote bootstrap manifest at %s contained no templates; using built-in defaults.',
+        url,
+      );
+      return FALLBACK_TEMPLATES;
+    }
+    return templates;
+  } catch (err) {
+    log.debug(
+      'bootstrap: failed to fetch manifest from %s: %s — using built-in defaults.',
+      url,
+      err instanceof Error ? err.message : String(err),
+    );
+    return FALLBACK_TEMPLATES;
+  }
+};
 
 const malformed = (what: string): Error =>
   new Error(`Unexpected GitHub API response while resolving ${what}.`);

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -1,4 +1,5 @@
 import axios, { isAxiosError } from 'axios';
+import YAML from 'yaml';
 
 import { log } from '../log.js';
 
@@ -26,7 +27,8 @@ export type BootstrapTemplate = {
   };
 };
 
-export const TEMPLATES: BootstrapTemplate[] = [
+/** Hardcoded fallback used when the remote manifest cannot be fetched. */
+export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
   {
     id: 'hono',
     title: 'Hono API (Drizzle, Neon Postgres) on Neon Functions',
@@ -41,10 +43,84 @@ export const TEMPLATES: BootstrapTemplate[] = [
   },
 ];
 
-export const templateIds = (): string => TEMPLATES.map((t) => t.id).join(', ');
+const manifestUrl = (): string =>
+  process.env.NEON_BOOTSTRAP_MANIFEST_URL ??
+  `${githubRawBase()}/neondatabase/examples/main/bootstrap.yaml`;
 
-export const findTemplate = (id: string): BootstrapTemplate | undefined =>
-  TEMPLATES.find((t) => t.id === id);
+const parseManifest = (text: string): BootstrapTemplate[] => {
+  const data: unknown = YAML.parse(text);
+  if (!isRecord(data) || !Array.isArray(data.templates)) {
+    throw new Error('Invalid bootstrap manifest: missing "templates" array.');
+  }
+  const templates: BootstrapTemplate[] = [];
+  for (const item of data.templates) {
+    if (
+      !isRecord(item) ||
+      typeof item.id !== 'string' ||
+      typeof item.title !== 'string' ||
+      typeof item.description !== 'string' ||
+      !isRecord(item.source) ||
+      typeof item.source.owner !== 'string' ||
+      typeof item.source.repo !== 'string' ||
+      typeof item.source.ref !== 'string' ||
+      typeof item.source.subdir !== 'string'
+    ) {
+      continue;
+    }
+    templates.push({
+      id: item.id,
+      title: item.title,
+      description: item.description,
+      source: {
+        owner: item.source.owner,
+        repo: item.source.repo,
+        ref: item.source.ref,
+        subdir: item.source.subdir,
+      },
+    });
+  }
+  return templates;
+};
+
+/**
+ * Fetch the template manifest from the remote `bootstrap.yaml` in the
+ * neondatabase/examples repo. Falls back to the hardcoded list on any error
+ * so the command never fails just because GitHub is unreachable.
+ */
+export const fetchTemplates = async (): Promise<BootstrapTemplate[]> => {
+  const url = manifestUrl();
+  try {
+    const res = await axios.get<string>(url, {
+      responseType: 'text',
+      headers: rawHeaders(),
+      timeout: 10_000,
+    });
+    const templates = parseManifest(res.data);
+    if (templates.length === 0) {
+      log.warning(
+        'Remote bootstrap manifest at %s contained no templates; using built-in defaults.',
+        url,
+      );
+      return FALLBACK_TEMPLATES;
+    }
+    return templates;
+  } catch (err) {
+    log.debug(
+      'bootstrap: failed to fetch manifest from %s: %s — using built-in defaults.',
+      url,
+      err instanceof Error ? err.message : String(err),
+    );
+    return FALLBACK_TEMPLATES;
+  }
+};
+
+export const templateIds = (templates: BootstrapTemplate[]): string =>
+  templates.map((t) => t.id).join(', ');
+
+export const findTemplate = (
+  templates: BootstrapTemplate[],
+  id: string,
+): BootstrapTemplate | undefined => templates.find((t) => t.id === id);
 
 /** A single file or symlink to materialize, resolved from the repo tree. */
 export type TemplateEntry =


### PR DESCRIPTION
## Summary
- Bootstrap now fetches the template list from `bootstrap.yaml` in `neondatabase/examples` at runtime instead of using a hardcoded array
- Falls back to built-in defaults if the manifest is unreachable (network errors, GitHub downtime)
- Adds `--list` flag to print available templates and exit (`neon bootstrap --list`)
- Manifest URL is overridable via `NEON_BOOTSTRAP_MANIFEST_URL` env var for testing

Depends on https://github.com/neondatabase/examples/pull/224 which adds the `bootstrap.yaml` manifest file.

## Test plan
- [x] All existing bootstrap tests pass (unit + e2e)
- [x] E2e test updated to serve the manifest from the local fixture server
- [x] `neon bootstrap --list` fetches from remote and prints templates
- [x] Fallback works when manifest URL is unreachable
- [ ] Verify in CI

This pull request and its description were written by Isaac.