### PR TITLE
feat(bootstrap): --agent mode, --default quick start, and post-scaffold setup

### DIFF
--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -1,5 +1,6 @@
 import { fork } from 'node:child_process';
 import {
+  existsSync,
   lstatSync,
   mkdtempSync,
   readFileSync,
@@ -144,6 +145,16 @@ const runBootstrap = (
   });
 };
 
+// `--agent` writes a single JSON state-machine object to stdout (logs go to
+// stderr), so the structured output stays machine-parseable.
+const parseAgentOutput = (stdout: string): Record<string, unknown> => {
+  const parsed: unknown = JSON.parse(stdout.trim());
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`Expected a JSON object, got: ${stdout}`);
+  }
+  return parsed as Record<string, unknown>;
+};
+
 describe('bootstrap', () => {
   let server: Server;
   let dest: string;
@@ -225,5 +236,115 @@ describe('bootstrap', () => {
     expect(code, stderr).toBe(0);
     expect(stdout).toContain('hono');
     expect(stdout).toContain('A Hono API using Drizzle ORM and Neon Postgres');
+  });
+
+  test('--default scaffolds and inits git without prompting', async () => {
+    // --no-install keeps the test offline/fast; git init still runs.
+    const { code, stderr } = await runBootstrap(server, [
+      dest,
+      '--default',
+      '--no-install',
+      '--force',
+    ]);
+    expect(code, stderr).toBe(0);
+
+    // The default template was scaffolded with no template/dir prompt.
+    expect(readFileSync(join(dest, 'package.json'), 'utf8')).toBe(
+      '{\n  "name": "with-hono"\n}\n',
+    );
+    // git init ran as part of the quick start.
+    expect(existsSync(join(dest, '.git'))).toBe(true);
+  });
+
+  describe('--agent (JSON state machine)', () => {
+    test('asks for a template when none is given', async () => {
+      const { code, stdout, stderr } = await runBootstrap(server, ['--agent']);
+      expect(code, stderr).toBe(0);
+      const res = parseAgentOutput(stdout);
+      expect(res.status).toBe('needs_template');
+      // Options come from the remote manifest.
+      expect(res.options).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'hono' })]),
+      );
+      expect(res.next_command_template).toContain('--template <template_id>');
+    });
+
+    test('asks for a directory when only the template is given', async () => {
+      const { code, stdout, stderr } = await runBootstrap(server, [
+        '--agent',
+        '--template',
+        'hono',
+      ]);
+      expect(code, stderr).toBe(0);
+      const res = parseAgentOutput(stdout);
+      expect(res.status).toBe('needs_directory');
+      expect(res.next_command_template).toContain('<directory>');
+      expect(res.next_command_template).toContain('--template hono');
+    });
+
+    test('scaffolds and returns the install + git + link next steps', async () => {
+      const { code, stdout, stderr } = await runBootstrap(server, [
+        '--agent',
+        dest,
+        '--template',
+        'hono',
+        '--force',
+      ]);
+      expect(code, stderr).toBe(0);
+      const res = parseAgentOutput(stdout);
+      expect(res.status).toBe('scaffolded');
+      expect(res.template).toEqual({
+        id: 'hono',
+        title: expect.any(String),
+      });
+      expect(res.files_written).toBeGreaterThan(0);
+
+      // The files really landed on disk (end to end, no mocks).
+      expect(readFileSync(join(dest, 'package.json'), 'utf8')).toBe(
+        '{\n  "name": "with-hono"\n}\n',
+      );
+
+      // All follow-ups come back as structured, runnable next steps.
+      const steps = res.next_steps as Record<string, unknown>[];
+      const actions = steps.map((step) => step.action);
+      expect(actions).toEqual([
+        'install_dependencies',
+        'initialize_git',
+        'link_neon_project',
+      ]);
+      expect(steps[0].command).toContain('npm install');
+      expect(steps[1].command).toContain('git init');
+      expect(steps[2].command).toContain('neon link --agent');
+    });
+
+    test('errors with UNKNOWN_TEMPLATE for a bad template id', async () => {
+      const { code, stdout } = await runBootstrap(server, [
+        '--agent',
+        dest,
+        '--template',
+        'does-not-exist',
+        '--force',
+      ]);
+      expect(code).toBe(1);
+      const res = parseAgentOutput(stdout);
+      expect(res.status).toBe('error');
+      expect(res.code).toBe('UNKNOWN_TEMPLATE');
+    });
+
+    test('errors with TARGET_NOT_EMPTY when the directory is not empty', async () => {
+      writeFileSync(join(dest, 'keep.txt'), 'mine\n');
+      const { code, stdout } = await runBootstrap(server, [
+        '--agent',
+        dest,
+        '--template',
+        'hono',
+      ]);
+      expect(code).toBe(1);
+      const res = parseAgentOutput(stdout);
+      expect(res.status).toBe('error');
+      expect(res.code).toBe('TARGET_NOT_EMPTY');
+      // Nothing was scaffolded over the existing contents.
+      expect(readFileSync(join(dest, 'keep.txt'), 'utf8')).toBe('mine\n');
+    });
   });
 });

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import {
   chmodSync,
   existsSync,
@@ -33,7 +34,52 @@ type BootstrapProps = CommonProps & {
   template?: string;
   force: boolean;
   listTemplates: boolean;
+  agent: boolean;
+  default: boolean;
+  install: boolean;
+  git: boolean;
+  link: boolean;
 };
+
+// ----------------------------------------------------------------------------
+// Agent mode (JSON state machine)
+// ----------------------------------------------------------------------------
+
+type AgentTemplateOption = { id: string; title: string; description: string };
+
+/**
+ * One follow-up the caller should offer the user after scaffolding. The agent
+ * is expected to ask the user, then run `command` from the project directory
+ * (the `link` step intentionally chains into `neon link --agent`'s own state
+ * machine). Mirrors `link --agent`'s instruction/next_command_template style.
+ */
+type AgentNextStep = {
+  action: 'install_dependencies' | 'initialize_git' | 'link_neon_project';
+  instruction: string;
+  command: string;
+};
+
+type AgentResponse =
+  | {
+      status: 'needs_template';
+      instruction: string;
+      options: AgentTemplateOption[];
+      next_command_template: string;
+    }
+  | {
+      status: 'needs_directory';
+      instruction: string;
+      next_command_template: string;
+    }
+  | {
+      status: 'scaffolded';
+      directory: string;
+      template: { id: string; title: string };
+      files_written: number;
+      next_steps: AgentNextStep[];
+      message: string;
+    }
+  | { status: 'error'; code: string; message: string };
 
 // The directory positional is optional: omitting it in an interactive terminal
 // prompts for one. In a non-interactive context a missing directory is an error.
@@ -66,6 +112,37 @@ export const builder = (argv: yargs.Argv) =>
         type: 'boolean',
         default: false,
       },
+      agent: {
+        describe:
+          'Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.',
+        type: 'boolean',
+        default: false,
+      },
+      default: {
+        alias: 'y',
+        describe:
+          'Quick start: scaffold the default template (or --template) and run the usual setup (install dependencies, git init) without prompting. Linking is left to you since it needs a project choice.',
+        type: 'boolean',
+        default: false,
+      },
+      install: {
+        describe:
+          'Install dependencies after scaffolding. In interactive mode this is offered as a prompt; use --no-install to skip without being asked.',
+        type: 'boolean',
+        default: true,
+      },
+      git: {
+        describe:
+          'Initialize a git repository after scaffolding. In interactive mode this is offered as a prompt; use --no-git to skip without being asked.',
+        type: 'boolean',
+        default: true,
+      },
+      link: {
+        describe:
+          'Run `neon link` in the scaffolded directory after installing. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.',
+        type: 'boolean',
+        default: true,
+      },
     })
     .example(
       '$0 bootstrap my-app',
@@ -74,6 +151,14 @@ export const builder = (argv: yargs.Argv) =>
     .example(
       '$0 bootstrap . --template hono',
       'Scaffold the Hono template into the current directory',
+    )
+    .example(
+      '$0 bootstrap my-app --default',
+      'Quick start: scaffold the default template and run setup without prompting',
+    )
+    .example(
+      '$0 bootstrap my-app --template hono --agent',
+      'Scaffold without prompting and emit the JSON state machine for AI agents',
     )
     .strict();
 
@@ -86,21 +171,36 @@ export const handler = async (props: BootstrapProps): Promise<void> => {
     return;
   }
 
-  // When --template is provided, try the fallback list first to avoid a
-  // network round-trip. Only fetch the remote manifest if the id isn't found.
-  const templates = props.template
-    ? findTemplate(FALLBACK_TEMPLATES, props.template)
-      ? FALLBACK_TEMPLATES
-      : await fetchTemplates()
-    : await fetchTemplates();
+  if (props.agent) {
+    await runAgentSafely(props);
+    return;
+  }
 
-  const interactive = Boolean(process.stdout.isTTY) && !isCi();
+  const templates = await resolveTemplateList(props);
+  // --default is a non-interactive quick start: it fills in the template and
+  // directory and runs setup without asking, so it must not fall into the
+  // prompt path even on a TTY.
+  const interactive =
+    !props.default && Boolean(process.stdout.isTTY) && !isCi();
   const template = await resolveSelectedTemplate(props, interactive, templates);
   const targetDir = await resolveTargetDir(props, interactive, template);
   ensureTargetUsable(targetDir, props.force);
   await scaffold(template, targetDir);
-  printNextSteps(template, targetDir);
+  printScaffolded(template, targetDir);
+  await runPostScaffoldSteps(props, targetDir, interactive);
 };
+
+/**
+ * The template list to choose from. When --template is given we try the
+ * built-in fallback list first to avoid a network round-trip, only fetching the
+ * remote manifest if the id isn't one of the defaults.
+ */
+const resolveTemplateList = async (
+  props: BootstrapProps,
+): Promise<BootstrapTemplate[]> =>
+  props.template && findTemplate(FALLBACK_TEMPLATES, props.template)
+    ? FALLBACK_TEMPLATES
+    : fetchTemplates();
 
 const resolveSelectedTemplate = async (
   props: BootstrapProps,
@@ -115,6 +215,16 @@ const resolveSelectedTemplate = async (
       );
     }
     return template;
+  }
+
+  // --default with no --template falls back to the first (default) template so
+  // a bare `neon bootstrap my-app --default` works end to end.
+  if (props.default) {
+    const fallback = templates[0];
+    if (!fallback) {
+      throw new Error('No templates available to scaffold from.');
+    }
+    return fallback;
   }
 
   if (!interactive) {
@@ -149,6 +259,11 @@ const resolveTargetDir = async (
 ): Promise<string> => {
   let dir = props.directory;
   if (dir === undefined) {
+    // --default supplies a directory (the template's name) so the quick start
+    // needs nothing but a template.
+    if (props.default) {
+      return resolve(process.cwd(), defaultDirName(template));
+    }
     if (!interactive) {
       throw new Error(
         'No target directory given. Pass one, e.g. `neon bootstrap my-app` (or "." for the current directory).',
@@ -173,19 +288,38 @@ const resolveTargetDir = async (
 const defaultDirName = (template: BootstrapTemplate): string =>
   template.source.subdir.split('/').pop() || template.id;
 
+/**
+ * A bad user-supplied input that an agent (or human) can correct: an unknown
+ * template id or a non-empty target directory. Carries an `agentCode` so
+ * `--agent` mode reports a precise `status: error` code instead of a generic
+ * INTERNAL_ERROR, while the human path just surfaces the clear `message`.
+ */
+class BootstrapInputError extends Error {
+  readonly agentCode: string;
+  constructor(message: string, agentCode: string) {
+    super(message);
+    this.name = 'BootstrapInputError';
+    this.agentCode = agentCode;
+  }
+}
+
 const ensureTargetUsable = (dir: string, force: boolean): void => {
   if (!existsSync(dir)) {
     return;
   }
   if (!statSync(dir).isDirectory()) {
-    throw new Error(`Target ${dir} already exists and is not a directory.`);
+    throw new BootstrapInputError(
+      `Target ${dir} already exists and is not a directory.`,
+      'TARGET_NOT_DIRECTORY',
+    );
   }
   // A lone `.git` is ignored so you can scaffold into a freshly `git init`ed
   // (otherwise empty) directory without reaching for --force.
   const contents = readdirSync(dir).filter((name) => name !== '.git');
   if (contents.length > 0 && !force) {
-    throw new Error(
+    throw new BootstrapInputError(
       `Target directory ${dir} is not empty. Use --force to scaffold into it anyway (colliding files will be overwritten), or choose an empty directory.`,
+      'TARGET_NOT_EMPTY',
     );
   }
 };
@@ -193,7 +327,7 @@ const ensureTargetUsable = (dir: string, force: boolean): void => {
 const scaffold = async (
   template: BootstrapTemplate,
   targetDir: string,
-): Promise<void> => {
+): Promise<number> => {
   log.info('Fetching template "%s" from GitHub…', template.id);
   const { commitSha, entries } = await resolveTemplate(template);
 
@@ -218,6 +352,7 @@ const scaffold = async (
       }
     }
   });
+  return entries.length;
 };
 
 const writeSymlink = (dest: string, target: string): void => {
@@ -243,29 +378,344 @@ const writeSymlink = (dest: string, target: string): void => {
   }
 };
 
-const printNextSteps = (
+// ----------------------------------------------------------------------------
+// Post-scaffold steps (install dependencies, git init, link to a Neon project)
+// ----------------------------------------------------------------------------
+
+/**
+ * After a human scaffold, offer the things you almost always do next: install
+ * dependencies, initialize a git repo, and link the directory to a Neon
+ * project. In an interactive terminal each is a y/n prompt (skippable up front
+ * with --no-install / --no-git / --no-link); `--default` runs install + git
+ * without asking; otherwise we just print the manual steps so nothing runs
+ * behind the user's back. Agent mode never reaches here — it returns these as
+ * structured `next_steps` instead (see {@link runAgent}).
+ */
+const runPostScaffoldSteps = async (
+  props: BootstrapProps,
+  targetDir: string,
+  interactive: boolean,
+): Promise<void> => {
+  const pm = detectPackageManager();
+
+  if (props.default) {
+    await runDefaultSteps(props, targetDir, pm);
+    return;
+  }
+
+  if (!interactive) {
+    printNextSteps(targetDir, pm, { installed: false, suggestLink: true });
+    return;
+  }
+
+  let installed = false;
+  if (props.install && (await confirm(`Install dependencies with ${pm}?`))) {
+    installed = await runCommand(pm, ['install'], targetDir);
+  }
+
+  if (
+    props.git &&
+    !isGitRepo(targetDir) &&
+    (await confirm('Initialize a git repository?'))
+  ) {
+    await initGitRepo(targetDir);
+  }
+
+  if (
+    props.link &&
+    (await confirm('Link this project to a Neon project now? (runs neon link)'))
+  ) {
+    await runNeonLink(props, targetDir);
+    // link prints its own summary (and pulls env), so end with just the run hint.
+    printNextSteps(targetDir, pm, { installed, suggestLink: false });
+    return;
+  }
+
+  printNextSteps(targetDir, pm, { installed, suggestLink: true });
+};
+
+/**
+ * `--default` quick start: run install + git init without prompting, honoring
+ * --no-install / --no-git. Linking is intentionally skipped — it needs an
+ * org/project choice we can't make non-interactively — so we point at it in the
+ * closing hint instead.
+ */
+const runDefaultSteps = async (
+  props: BootstrapProps,
+  targetDir: string,
+  pm: PackageManager,
+): Promise<void> => {
+  log.info('Quick start (--default): running setup without prompting.');
+  let installed = false;
+  if (props.install) {
+    installed = await runCommand(pm, ['install'], targetDir);
+  }
+  if (props.git && !isGitRepo(targetDir)) {
+    await initGitRepo(targetDir);
+  }
+  printNextSteps(targetDir, pm, { installed, suggestLink: true });
+};
+
+const isGitRepo = (dir: string): boolean => existsSync(join(dir, '.git'));
+
+/**
+ * Initialize a git repository in the scaffolded directory. Just `git init` — we
+ * deliberately don't auto-commit, both to avoid failing on a machine with no
+ * git identity configured and to leave the first commit to the user.
+ */
+const initGitRepo = async (dir: string): Promise<void> => {
+  await runCommand('git', ['init'], dir);
+};
+
+const confirm = async (message: string): Promise<boolean> => {
+  const { value } = await prompts({
+    onState: onPromptState,
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: true,
+  });
+  return value === true;
+};
+
+/**
+ * The package manager to use for the suggested install. Inferred from the
+ * `npm_config_user_agent` npm sets when the CLI is invoked via
+ * `npm exec`/`npx`, `pnpm dlx`, `yarn dlx`, or `bunx`, so `pnpm dlx neonctl
+ * bootstrap` offers a `pnpm install`. Defaults to npm — the safe universal
+ * choice, and what a globally-installed `neon`/`neonctl` resolves to.
+ */
+type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+const detectPackageManager = (): PackageManager => {
+  const ua = process.env.npm_config_user_agent ?? '';
+  if (ua.startsWith('pnpm')) return 'pnpm';
+  if (ua.startsWith('yarn')) return 'yarn';
+  if (ua.startsWith('bun')) return 'bun';
+  return 'npm';
+};
+
+/**
+ * Run a command inheriting our stdio so the user sees install / link output
+ * live and can answer any prompts the child raises. Resolves to whether it
+ * exited cleanly; a non-zero exit is reported but never aborts bootstrap — the
+ * scaffold already succeeded, so we let the user retry the step by hand.
+ */
+const runCommand = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+): Promise<boolean> =>
+  new Promise((resolvePromise) => {
+    // npm/pnpm/yarn ship as .cmd shims on Windows, which need a shell to run.
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    child.on('error', (err) => {
+      log.warning(
+        'Could not run `%s %s`: %s',
+        cmd,
+        args.join(' '),
+        err instanceof Error ? err.message : String(err),
+      );
+      resolvePromise(false);
+    });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        log.warning('`%s %s` exited with code %d.', cmd, args.join(' '), code);
+      }
+      resolvePromise(code === 0);
+    });
+  });
+
+/**
+ * Re-invoke this same CLI as `neon link` inside the scaffolded directory, so the
+ * new project's `.neon` context (and pulled `.env`) land in the right place and
+ * link's own interactive picker drives org/project/branch selection. Re-execing
+ * (rather than calling the handler in-process) keeps link running with `cwd` set
+ * to the target dir, which is where its env pull writes.
+ */
+const runNeonLink = async (
+  props: BootstrapProps,
+  targetDir: string,
+): Promise<void> => {
+  const args = [process.argv[1], 'link'];
+  if (props.apiKey) {
+    args.push('--api-key', props.apiKey);
+  }
+  args.push('--api-host', props.apiHost, '--output', props.output);
+  await runCommand(process.execPath, args, targetDir);
+};
+
+const printScaffolded = (
   template: BootstrapTemplate,
   targetDir: string,
 ): void => {
-  const rel = relative(process.cwd(), targetDir);
-  // Show the bare relative path for the common `bootstrap my-app` case, fall
-  // back to the absolute path when the target sits outside the cwd (a deep
-  // `../../..` is noise), and special-case the current directory.
-  const isCurrent = rel === '';
-  const display = isCurrent ? '.' : rel.startsWith('..') ? targetDir : rel;
   log.info('');
   log.info(
     'Done. Scaffolded "%s" into %s.',
     template.title,
-    isCurrent ? 'the current directory' : display,
+    isCurrentDir(targetDir) ? 'the current directory' : displayDir(targetDir),
   );
+};
+
+/**
+ * The closing "Next steps" hint. Skips `cd` for the current directory, omits
+ * the install line once deps are in, and only nudges `neon link` when linking
+ * wasn't already offered/run — so the user never sees a step they just did.
+ */
+const printNextSteps = (
+  targetDir: string,
+  pm: PackageManager,
+  opts: { installed: boolean; suggestLink: boolean },
+): void => {
   log.info('');
   log.info('Next steps:');
-  if (!isCurrent) {
-    log.info('  cd %s', display);
+  if (!isCurrentDir(targetDir)) {
+    log.info('  cd %s', displayDir(targetDir));
   }
-  log.info('  Install dependencies, then see the README to run it.');
+  if (!opts.installed) {
+    log.info('  %s install', pm);
+  }
+  if (opts.suggestLink) {
+    log.info('  neon link');
+  }
+  log.info('  See the README to run it.');
   log.info('');
+};
+
+const runAgentSafely = async (props: BootstrapProps): Promise<void> => {
+  try {
+    await runAgent(props);
+  } catch (err) {
+    emitAgent(toAgentError(err));
+    process.exit(1);
+  }
+};
+
+/**
+ * The `--agent` flow: resolve what the flags determine and emit one JSON object
+ * describing either the next input needed (`needs_template` / `needs_directory`)
+ * or the terminal result (`scaffolded`). Unlike interactive mode it never
+ * prompts and never runs install/git/link itself — those come back as structured
+ * `next_steps` so the agent can confirm with the user and run them (the link
+ * step chains into `neon link --agent`).
+ */
+const runAgent = async (props: BootstrapProps): Promise<void> => {
+  if (!props.template) {
+    const templates = await fetchTemplates();
+    emitAgent({
+      status: 'needs_template',
+      instruction: `Ask the user which template to scaffold, then re-run the next_command_template with the chosen --template value${
+        props.directory ? '' : ' and a target directory'
+      }.`,
+      options: templates.map((template) => ({
+        id: template.id,
+        title: template.title,
+        description: template.description,
+      })),
+      next_command_template: `neon bootstrap --agent ${
+        props.directory ? shellArg(props.directory) : '<directory>'
+      } --template <template_id>`,
+    });
+    return;
+  }
+
+  const templates = await resolveTemplateList(props);
+  const template = findTemplate(templates, props.template);
+  if (!template) {
+    throw new BootstrapInputError(
+      `Unknown template "${props.template}". Available templates: ${templateIds(templates)}.`,
+      'UNKNOWN_TEMPLATE',
+    );
+  }
+
+  if (props.directory === undefined) {
+    emitAgent({
+      status: 'needs_directory',
+      instruction:
+        'Ask the user which directory to scaffold into (use "." for the current directory), then re-run the next_command_template with it.',
+      next_command_template: `neon bootstrap --agent <directory> --template ${shellArg(
+        template.id,
+      )}`,
+    });
+    return;
+  }
+
+  const targetDir = resolve(
+    process.cwd(),
+    props.directory === '.' ? '' : props.directory,
+  );
+  ensureTargetUsable(targetDir, props.force);
+  const filesWritten = await scaffold(template, targetDir);
+
+  const dir = displayDir(targetDir);
+  const runIn = isCurrentDir(targetDir) ? '' : `cd ${shellArg(dir)} && `;
+  emitAgent({
+    status: 'scaffolded',
+    directory: targetDir,
+    template: { id: template.id, title: template.title },
+    files_written: filesWritten,
+    next_steps: [
+      {
+        action: 'install_dependencies',
+        instruction:
+          'Ask the user whether to install dependencies, then run this in the project directory.',
+        command: `${runIn}npm install`,
+      },
+      {
+        action: 'initialize_git',
+        instruction:
+          'Ask the user whether to initialize a git repository in the project directory.',
+        command: `${runIn}git init`,
+      },
+      {
+        action: 'link_neon_project',
+        instruction:
+          'Ask the user whether to link the project to a Neon project now. This runs the link state machine — follow its JSON output for the next step.',
+        command: `${runIn}neon link --agent`,
+      },
+    ],
+    message: `Scaffolded "${template.title}" (${filesWritten} files) into ${dir}. Offer the next_steps to the user: install dependencies, initialize git, then link a Neon project.`,
+  });
+};
+
+const emitAgent = (response: AgentResponse): void => {
+  process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+};
+
+const toAgentError = (
+  err: unknown,
+): Extract<AgentResponse, { status: 'error' }> => {
+  if (err instanceof BootstrapInputError) {
+    return { status: 'error', code: err.agentCode, message: err.message };
+  }
+  if (err instanceof Error) {
+    return { status: 'error', code: 'INTERNAL_ERROR', message: err.message };
+  }
+  return { status: 'error', code: 'INTERNAL_ERROR', message: String(err) };
+};
+
+// ----------------------------------------------------------------------------
+// Path display helpers
+// ----------------------------------------------------------------------------
+
+const isCurrentDir = (targetDir: string): boolean =>
+  relative(process.cwd(), targetDir) === '';
+
+/**
+ * The path to show the user: the bare relative path for the common
+ * `bootstrap my-app` case, the absolute path when the target sits outside the
+ * cwd (a deep `../../..` is noise), and "." for the current directory.
+ */
+const displayDir = (targetDir: string): string => {
+  const rel = relative(process.cwd(), targetDir);
+  if (rel === '') {
+    return '.';
+  }
+  return rel.startsWith('..') ? targetDir : rel;
 };
 
 const mapWithConcurrency = async <T>(
@@ -304,6 +754,13 @@ const errnoCode = (err: unknown): string | undefined => {
     return err.code;
   }
   return undefined;
+};
+
+const shellArg = (value: string): string => {
+  if (/^[A-Za-z0-9._:/-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 };
 
 const onPromptState = (state: {

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -430,14 +430,25 @@ const runPostScaffoldSteps = async (
     await initGitRepo(targetDir);
   }
 
-  if (
-    props.link &&
-    (await confirm('Link this project to a Neon project now? (runs neon link)'))
-  ) {
-    await runNeonLink(props, targetDir);
-    // link prints its own summary (and pulls env), so end with just the run hint.
-    printNextSteps(targetDir, pm, { installed, suggestLink: false });
-    return;
+  // `neon link` pulls env vars, which loads this project's neon.ts — and that
+  // evaluation needs the dependencies installed. So when deps weren't installed
+  // and the scaffold ships a neon.ts, skip the link prompt (it would just fail)
+  // and tell the user how to finish by hand.
+  if (props.link) {
+    if (!installed && hasNeonConfig(targetDir)) {
+      log.info(
+        "Skipping the Neon link step: `neon link` reads this project's neon.ts " +
+          `to pull env vars, which needs its dependencies. Run \`${pm} install\`, ` +
+          'then `neon link`.',
+      );
+    } else if (
+      await confirm('Link this project to a Neon project now? (runs neon link)')
+    ) {
+      await runNeonLink(props, targetDir);
+      // link prints its own summary (and pulls env), so end with just the run hint.
+      printNextSteps(targetDir, pm, { installed, suggestLink: false });
+      return;
+    }
   }
 
   printNextSteps(targetDir, pm, { installed, suggestLink: true });
@@ -469,6 +480,13 @@ const runDefaultSteps = async (
 };
 
 const isGitRepo = (dir: string): boolean => existsSync(join(dir, '.git'));
+
+// Config filenames the runtime loads (mirrors @neondatabase/config). A scaffold
+// that ships one makes `neon link`'s env pull evaluate it — which needs deps.
+const NEON_CONFIG_FILENAMES = ['neon.ts', 'neon.mts', 'neon.js', 'neon.mjs'];
+
+const hasNeonConfig = (dir: string): boolean =>
+  NEON_CONFIG_FILENAMES.some((name) => existsSync(join(dir, name)));
 
 /**
  * Initialize a git repository in the scaffolded directory. Just `git init` — we

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -13,6 +13,7 @@ import {
 import { dirname, join, relative, resolve } from 'node:path';
 
 import prompts, { InitialReturnValue } from 'prompts';
+import which from 'which';
 import yargs from 'yargs';
 
 import { isCi } from '../env.js';
@@ -396,20 +397,28 @@ const runPostScaffoldSteps = async (
   targetDir: string,
   interactive: boolean,
 ): Promise<void> => {
-  const pm = detectPackageManager();
+  const detected = detectPackageManager();
 
   if (props.default) {
-    await runDefaultSteps(props, targetDir, pm);
+    await runDefaultSteps(props, targetDir, detected ?? 'npm');
     return;
   }
 
   if (!interactive) {
-    printNextSteps(targetDir, pm, { installed: false, suggestLink: true });
+    printNextSteps(targetDir, detected ?? 'npm', {
+      installed: false,
+      suggestLink: true,
+    });
     return;
   }
 
+  // The package manager used for the install (and shown in the closing hint).
+  // When we couldn't infer it from the invocation we ask, so a globally
+  // installed `neon` doesn't silently force npm on a bun/pnpm user.
+  let pm: PackageManager = detected ?? 'npm';
   let installed = false;
-  if (props.install && (await confirm(`Install dependencies with ${pm}?`))) {
+  if (props.install && (await confirm(installPrompt(detected)))) {
+    pm = detected ?? (await selectPackageManager());
     installed = await runCommand(pm, ['install'], targetDir);
   }
 
@@ -433,6 +442,9 @@ const runPostScaffoldSteps = async (
 
   printNextSteps(targetDir, pm, { installed, suggestLink: true });
 };
+
+const installPrompt = (detected: PackageManager | undefined): string =>
+  detected ? `Install dependencies with ${detected}?` : 'Install dependencies?';
 
 /**
  * `--default` quick start: run install + git init without prompting, honoring
@@ -478,21 +490,56 @@ const confirm = async (message: string): Promise<boolean> => {
   return value === true;
 };
 
-/**
- * The package manager to use for the suggested install. Inferred from the
- * `npm_config_user_agent` npm sets when the CLI is invoked via
- * `npm exec`/`npx`, `pnpm dlx`, `yarn dlx`, or `bunx`, so `pnpm dlx neonctl
- * bootstrap` offers a `pnpm install`. Defaults to npm — the safe universal
- * choice, and what a globally-installed `neon`/`neonctl` resolves to.
- */
 type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
 
-const detectPackageManager = (): PackageManager => {
+// npm first so it's the default/preselected choice; the rest follow in rough
+// popularity order.
+const PACKAGE_MANAGERS: PackageManager[] = ['npm', 'pnpm', 'yarn', 'bun'];
+
+/**
+ * The package manager the CLI was invoked through, read from the
+ * `npm_config_user_agent` npm sets for `npm exec`/`npx`, `pnpm dlx`, `yarn
+ * dlx`, and `bunx` (so `pnpm dlx neonctl bootstrap` installs with pnpm).
+ * Returns undefined when there's nothing to infer from — e.g. a
+ * globally-installed `neon`/`neonctl` — so the caller can ask instead of
+ * silently assuming npm.
+ */
+const detectPackageManager = (): PackageManager | undefined => {
   const ua = process.env.npm_config_user_agent ?? '';
   if (ua.startsWith('pnpm')) return 'pnpm';
   if (ua.startsWith('yarn')) return 'yarn';
   if (ua.startsWith('bun')) return 'bun';
-  return 'npm';
+  if (ua.startsWith('npm')) return 'npm';
+  return undefined;
+};
+
+/** The package managers actually on PATH, in {@link PACKAGE_MANAGERS} order. */
+const installedPackageManagers = (): PackageManager[] =>
+  PACKAGE_MANAGERS.filter((pm) => which.sync(pm, { nothrow: true }) !== null);
+
+/**
+ * Ask which package manager to install with when we couldn't infer one from the
+ * invocation. Offers the managers actually installed (npm preselected); with
+ * one or none installed there's nothing to choose, so it returns that one (or
+ * npm) without prompting. A cancelled prompt falls back to npm.
+ */
+const selectPackageManager = async (): Promise<PackageManager> => {
+  const installed = installedPackageManagers();
+  if (installed.length <= 1) {
+    return installed[0] ?? 'npm';
+  }
+  const { pm } = await prompts({
+    onState: onPromptState,
+    type: 'select',
+    name: 'pm',
+    message: 'Which package manager should we use?',
+    choices: installed.map((manager) => ({
+      title: manager,
+      value: manager,
+    })),
+    initial: Math.max(0, installed.indexOf('npm')),
+  });
+  return pm ?? 'npm';
 };
 
 /**

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -22,7 +22,11 @@ import type {
   NeonRoleSnapshot,
 } from '@neondatabase/config';
 
-import { DevEnvMismatchError, resolveDevEnv } from './env.js';
+import {
+  DevEnvMismatchError,
+  resolveDevEnv,
+  resolveNeonEnvVars,
+} from './env.js';
 
 const PROJECT_ID = 'patient-art-12345';
 const BRANCH_ID = 'br-main-00000001';
@@ -454,6 +458,26 @@ describe('resolveDevEnv', () => {
     expect(result.vars.DATABASE_URL).toBeDefined();
     expect(api.listBranchFunctionsCalled).toBe(false);
   });
+
+  it('neon.ts importing an uninstalled package -> a clear "did you run npm install" error', async () => {
+    // A neon.ts that imports a package which isn't installed (no node_modules in
+    // the temp dir) fails to load with a cryptic "Cannot find module". We expect
+    // that turned into an actionable "did you run npm install" message — this is
+    // exactly what `neon link`'s env pull hits in a freshly-scaffolded project.
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      "import 'neon-bootstrap-missing-dependency-xyz';\nexport default { auth: {} };\n",
+    );
+
+    await expect(
+      resolveNeonEnvVars({
+        cwd,
+        projectId: PROJECT_ID,
+        branchId: BRANCH_ID,
+        api: new FakeNeonApi(),
+      }),
+    ).rejects.toThrow(/npm install/i);
+  }, 30_000);
 
   it('tier 1 functions + auth mismatch: a missing secret-bearing service still hard-stops', async () => {
     // Stripping functions must NOT weaken the guard for services that DO carry secrets: a

--- a/src/dev/env.ts
+++ b/src/dev/env.ts
@@ -255,6 +255,38 @@ const fetchAndProject = async (
  * root. Returns `null` when there is none (the common "no config" case), and
  * surfaces real load errors (e.g. a syntax error in an existing file).
  */
+/**
+ * Substrings that mark a module-resolution failure while loading `neon.ts` —
+ * almost always because the project's dependencies aren't installed yet (the
+ * config imports `@neondatabase/config` & friends). Deliberately specific:
+ * the generic "…or a missing dependency…" hint the loader always appends is
+ * NOT in here, so a real syntax/runtime error doesn't get mislabeled.
+ */
+const MISSING_DEPENDENCY_HINTS = [
+  'cannot find module',
+  'cannot find package',
+  'err_module_not_found',
+  'failed to resolve',
+  'could not resolve',
+  'module not found',
+];
+
+/** Flatten an error and its `cause` chain to one lowercased string for matching. */
+const errorChainText = (err: unknown): string => {
+  const parts: string[] = [];
+  let current: unknown = err;
+  for (let depth = 0; current instanceof Error && depth < 6; depth++) {
+    parts.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return parts.join('\n').toLowerCase();
+};
+
+const looksLikeMissingDependency = (err: unknown): boolean => {
+  const text = errorChainText(err);
+  return MISSING_DEPENDENCY_HINTS.some((hint) => text.includes(hint));
+};
+
 const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
   try {
     const { config } = await loadConfigFromFile({ cwd });
@@ -263,6 +295,16 @@ const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
     const message = err instanceof Error ? err.message : String(err);
     if (/Could not find a Neon config file/i.test(message)) {
       return null;
+    }
+    // A neon.ts that imports a package which isn't installed fails here with a
+    // cryptic "Cannot find module …". Turn that into the actionable thing to do.
+    if (looksLikeMissingDependency(err)) {
+      throw new Error(
+        'Could not load neon.ts: a package it imports is not installed. ' +
+          'Did you run `npm install`? Install your dependencies ' +
+          '(npm / pnpm / yarn / bun), then try again.\n' +
+          `Original error: ${message}`,
+      );
     }
     throw err;
   }


### PR DESCRIPTION
## Summary

Brings `neon bootstrap` up to par with `neon link` for both AI agents and humans, and lays the groundwork for an `init`/`create`-style wizard (`neon init` runs `bootstrap` under the hood for greenfield projects).

Rebased on top of #540 (remote template manifest), so all of this composes with the dynamic `bootstrap.yaml` template list: the `--agent` template options and the existing `--list-templates` both come from the manifest (with the built-in `FALLBACK_TEMPLATES`).

- **`--agent` (JSON state machine).** Mirrors `link --agent`: a single discriminated `status` object on stdout (logs stay on stderr). Flow: `needs_template` -> `needs_directory` -> `scaffolded` | `error`. `needs_template` options are pulled from the remote manifest. The terminal `scaffolded` state returns structured `next_steps` (install deps, git init, link) so an agent can confirm-and-run them with the user. The link step chains into `neon link --agent`.
- **Post-scaffold setup (interactive).** After a human scaffold we offer to: install dependencies, initialize a git repo, and run `neon link` in the new directory. Each is a y/n prompt, skippable up front with `--no-install` / `--no-git` / `--no-link`. `link` is re-exec'd with `cwd` = the scaffolded dir so its `.neon` context and pulled `.env` land in the right place.
- **`--default` (`-y`) quick start.** Scaffolds the default template (first in the manifest, or `--template`) and runs install + git init with no prompts. Linking is left to the user since it needs an org/project choice that can't be made non-interactively.
- **Package manager detection + selection.** Infers npm/pnpm/yarn/bun from `npm_config_user_agent` (so `pnpm dlx neonctl bootstrap` installs with pnpm). When it can't be inferred — e.g. a globally-installed `neon` — the interactive install step asks which manager to use (the ones actually on PATH, npm preselected) instead of silently forcing npm.
- **Don't run link before deps are installed.** `neon link` pulls env vars, which loads the project's `neon.ts` — and that evaluation needs the project's dependencies. Two fixes:
  - bootstrap **skips the link prompt** (with a visible note explaining why) when dependencies weren't installed and the scaffold ships a `neon.ts` — linking would just fail.
  - when loading `neon.ts` fails on a module-resolution error, the error now says **"Did you run \`npm install\`?"** instead of a raw `Cannot find module …` (matched across the error's cause chain, kept specific so real syntax/runtime errors aren't mislabeled). This helps anyone hitting it from `neon link` / `neon env pull` / `neon dev`, not just bootstrap.

### Example agent output

```json
{
  "status": "scaffolded",
  "directory": "/abs/path/my-app",
  "template": { "id": "hono", "title": "Hono API (Drizzle, Neon Postgres) on Neon Functions" },
  "files_written": 42,
  "next_steps": [
    { "action": "install_dependencies", "command": "cd my-app && npm install", "instruction": "..." },
    { "action": "initialize_git",       "command": "cd my-app && git init",    "instruction": "..." },
    { "action": "link_neon_project",     "command": "cd my-app && neon link --agent", "instruction": "..." }
  ],
  "message": "..."
}
```

## Test plan

- [x] `pnpm typecheck`, `eslint`, `prettier --check` clean on changed files
- [x] New e2e tests (no mocks, against the existing local GitHub fixture server, which now also serves the `bootstrap.yaml` manifest):
  - [x] `--agent` asks for a template (options from the manifest), then a directory
  - [x] `--agent` scaffolds and returns install + git + link `next_steps`
  - [x] `--agent` errors with `UNKNOWN_TEMPLATE` / `TARGET_NOT_EMPTY`
  - [x] `--default` scaffolds the default template and inits git without prompting
- [x] New test: a `neon.ts` importing an uninstalled package yields a "did you run npm install" error (real jiti load, no mocks)
- [x] Existing bootstrap + manifest + dev-env tests still pass (32/32 across the affected suites)
- [ ] Manual: interactive `neon bootstrap my-app` exercises the install (incl. package-manager selection when undetected) / git / link prompts on a TTY

## Follow-ups (not in this PR)

- A thin `create-neon` wrapper (`npm create neon`) that execs `neon bootstrap`, mirroring how `create-mastra` wraps the `mastra` CLI.
- Reconcile the two meanings of `--agent`: a boolean JSON state machine here / in `link`, vs. the editor string in `neon init`.
- Push the "did you run npm install" hint down into `@neondatabase/config`'s loader so every consumer benefits (this PR catches it CLI-side).