### PR TITLE
feat(bootstrap): show template services in the picker

### DIFF
--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -52,6 +52,9 @@ const MANIFEST_YAML = `templates:
   - id: hono
     title: "Hono API (Drizzle, Neon Postgres) on Neon Functions"
     description: "A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function."
+    services:
+      - Postgres
+      - Functions
     source:
       owner: neondatabase
       repo: examples
@@ -236,6 +239,8 @@ describe('bootstrap', () => {
     expect(code, stderr).toBe(0);
     expect(stdout).toContain('hono');
     expect(stdout).toContain('A Hono API using Drizzle ORM and Neon Postgres');
+    // The services from the manifest are surfaced alongside each template.
+    expect(stdout).toContain('[Postgres · Functions]');
   });
 
   test('--default scaffolds and inits git without prompting', async () => {
@@ -262,9 +267,14 @@ describe('bootstrap', () => {
       expect(code, stderr).toBe(0);
       const res = parseAgentOutput(stdout);
       expect(res.status).toBe('needs_template');
-      // Options come from the remote manifest.
+      // Options come from the remote manifest, including the services list.
       expect(res.options).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: 'hono' })]),
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'hono',
+            services: ['Postgres', 'Functions'],
+          }),
+        ]),
       );
       expect(res.next_command_template).toContain('--template <template_id>');
     });

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -12,6 +12,7 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 
+import chalk from 'chalk';
 import prompts, { InitialReturnValue } from 'prompts';
 import which from 'which';
 import yargs from 'yargs';
@@ -46,7 +47,12 @@ type BootstrapProps = CommonProps & {
 // Agent mode (JSON state machine)
 // ----------------------------------------------------------------------------
 
-type AgentTemplateOption = { id: string; title: string; description: string };
+type AgentTemplateOption = {
+  id: string;
+  title: string;
+  description: string;
+  services?: string[];
+};
 
 /**
  * One follow-up the caller should offer the user after scaffolding. The agent
@@ -167,7 +173,11 @@ export const handler = async (props: BootstrapProps): Promise<void> => {
   if (props.listTemplates) {
     const templates = await fetchTemplates();
     for (const t of templates) {
-      process.stdout.write(`${t.id} — ${t.description}\n`);
+      const services =
+        t.services && t.services.length > 0
+          ? ` [${t.services.join(' · ')}]`
+          : '';
+      process.stdout.write(`${t.id} — ${t.description}${services}\n`);
     }
     return;
   }
@@ -202,6 +212,21 @@ const resolveTemplateList = async (
   props.template && findTemplate(FALLBACK_TEMPLATES, props.template)
     ? FALLBACK_TEMPLATES
     : fetchTemplates();
+
+/**
+ * The picker label for a template: the title prefixed with the Neon services it
+ * uses as a dim badge, e.g. "[Postgres · Functions] Hono API …". The badge is
+ * styled with chalk.dim only (never a foreground color) so it survives the
+ * cyan/underline `prompts` paints over the focused row — dim resets with the
+ * intensity SGR, leaving the row's color and underline intact. The one-line
+ * description renders under the title on focus (handled by `prompts`).
+ */
+const formatTemplateTitle = (template: BootstrapTemplate): string => {
+  if (!template.services || template.services.length === 0) {
+    return template.title;
+  }
+  return `${chalk.dim(`[${template.services.join(' · ')}]`)} ${template.title}`;
+};
 
 const resolveSelectedTemplate = async (
   props: BootstrapProps,
@@ -240,7 +265,7 @@ const resolveSelectedTemplate = async (
     name: 'id',
     message: 'Which template would you like to use?',
     choices: templates.map((template) => ({
-      title: template.title,
+      title: formatTemplateTitle(template),
       description: template.description,
       value: template.id,
     })),
@@ -680,6 +705,7 @@ const runAgent = async (props: BootstrapProps): Promise<void> => {
         id: template.id,
         title: template.title,
         description: template.description,
+        ...(template.services ? { services: template.services } : {}),
       })),
       next_command_template: `neon bootstrap --agent ${
         props.directory ? shellArg(props.directory) : '<directory>'

--- a/src/utils/bootstrap.test.ts
+++ b/src/utils/bootstrap.test.ts
@@ -88,6 +88,69 @@ describe('parseManifest', () => {
     });
   });
 
+  it('parses the optional services list', () => {
+    const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services:
+      - Postgres
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+    expect(parseManifest(yaml)[0].services).toEqual(['Postgres', 'Functions']);
+  });
+
+  it('drops non-string and blank service entries', () => {
+    const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services:
+      - Postgres
+      - ""
+      - 42
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+    expect(parseManifest(yaml)[0].services).toEqual(['Postgres', 'Functions']);
+  });
+
+  it('omits services when the field is absent or not a list', () => {
+    const withoutServices = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+    expect(parseManifest(withoutServices)[0]).not.toHaveProperty('services');
+
+    const badServices = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services: nope
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+    expect(parseManifest(badServices)[0]).not.toHaveProperty('services');
+  });
+
   it('skips malformed entries and keeps valid ones', () => {
     const yaml = `templates:
   - id: good

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -17,6 +17,11 @@ export type BootstrapTemplate = {
   title: string;
   /** One-line description shown under the title in the selector. */
   description: string;
+  /**
+   * Neon services the template uses (e.g. "Postgres", "Functions"). Shown as a
+   * badge next to the title in the picker. Optional — older manifests omit it.
+   */
+  services?: string[];
   source: {
     owner: string;
     repo: string;
@@ -34,6 +39,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
     title: 'Hono API (Drizzle, Neon Postgres) on Neon Functions',
     description:
       'A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function.',
+    services: ['Postgres', 'Functions'],
     source: {
       owner: 'neondatabase',
       repo: 'examples',
@@ -100,6 +106,22 @@ const rawHeaders = (): Record<string, string> => ({
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
+/**
+ * Normalize a manifest entry's `services` into a clean string list. Tolerant by
+ * design: a missing or non-array value yields `undefined`, and non-string items
+ * are dropped, so a malformed `services` never sinks an otherwise-valid
+ * template (it just renders without its badge).
+ */
+const parseServices = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const services = value.filter(
+    (item): item is string => typeof item === 'string' && item.trim() !== '',
+  );
+  return services.length > 0 ? services : undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Remote template manifest
 // ---------------------------------------------------------------------------
@@ -133,10 +155,12 @@ export const parseManifest = (text: string): BootstrapTemplate[] => {
       );
       continue;
     }
+    const services = parseServices(item.services);
     templates.push({
       id: item.id,
       title: item.title,
       description: item.description,
+      ...(services ? { services } : {}),
       source: {
         owner: item.source.owner,
         repo: item.source.repo,


### PR DESCRIPTION
## Summary

The bootstrap manifest now carries a per-template `services` list (e.g. `Postgres`, `Functions`, `Object Storage`, `AI Gateway`). This PR parses it and surfaces it as a dim `[Postgres · Functions]` badge in front of each title in the interactive picker, so you can tell at a glance which Neon services a template uses before scaffolding. The one-line description still renders on focus.

```
? Which template would you like to use?
❯  [Postgres · Functions] Hono API (Drizzle, Neon Postgres) on Neon Functions - A Hono API using Drizzle ORM and Neon Postgres…
   [Postgres · Functions · Object Storage · AI Gateway] AI SDK agent (AI Gateway, object storage, Drizzle) on Neon Functions
   [Postgres · Functions · AI Gateway] Mastra personal agent (AI Gateway, Mastra Memory) on Neon Functions
```

## Changes

- Add an optional `services?: string[]` field to `BootstrapTemplate` and parse it tolerantly from the manifest: non-string/blank entries are dropped, and the field is omitted when absent or not a list, so a malformed `services` never sinks an otherwise-valid template.
- Add `services: ['Postgres', 'Functions']` to the hardcoded `hono` fallback so the badge shows even offline.
- Render the badge in the interactive picker. It is styled with `chalk.dim` only (never a foreground color), so it survives the cyan/underline `prompts` paints over the focused row — dim resets with the intensity SGR, leaving the row's color and underline intact.
- Also surface services in `--list-templates` output and in the `--agent` `needs_template` options (structured JSON for agents).

## Test plan

- [x] `pnpm typecheck`
- [x] `eslint` + `prettier --check` on the changed files
- [x] Unit tests for `parseManifest` services parsing (parse list, drop non-strings/blanks, omit when absent or not a list)
- [x] e2e: manifest `services` flow through to `--list-templates` output and `--agent` options
- [x] Full bootstrap suites pass (`vitest run src/commands/bootstrap.test.ts src/utils/bootstrap.test.ts` → 23 passed)