### PR TITLE
chore: bump neon-init to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.16.0",
+    "neon-init": "0.16.1",
     "open": "10.1.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.15.0",
+    "neon-init": "0.16.0",
     "open": "10.1.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.16.0
+        version: 0.16.0
       open:
         specifier: 10.1.0
         version: 10.1.0
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.15.0:
-    resolution: {integrity: sha512-D9LGMJdzHu0BfVIQhB/6+SUdCRdkCwKAsnMeYmB9Lln9g2Zs97oQc+kmAnRE4zcFlbdH2t/SOaXcRX1WV7Sm8w==}
+  neon-init@0.16.0:
+    resolution: {integrity: sha512-OcutV3J1uttG6zWqVlyYcNx6HSpumPTB3peZ9RVpHayxCUwya5o8kRbHZNG3Lib258xr4D1OYFRNhVauM8VFyg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -6339,7 +6339,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.15.0:
+  neon-init@0.16.0:
     dependencies:
       '@clack/prompts': 0.10.1
       add-mcp: 1.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.16.0
-        version: 0.16.0
+        specifier: 0.16.1
+        version: 0.16.1
       open:
         specifier: 10.1.0
         version: 10.1.0
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.16.0:
-    resolution: {integrity: sha512-OcutV3J1uttG6zWqVlyYcNx6HSpumPTB3peZ9RVpHayxCUwya5o8kRbHZNG3Lib258xr4D1OYFRNhVauM8VFyg==}
+  neon-init@0.16.1:
+    resolution: {integrity: sha512-MvMV9eAbfZNOeSTFGxcIEC9E32NXOnst0gug956AI85szzjihgRvGyzNEVYX16t67qkfgzxouGTN+CrLbU4pjA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -6339,7 +6339,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.16.0:
+  neon-init@0.16.1:
     dependencies:
       '@clack/prompts': 0.10.1
       add-mcp: 1.8.0

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -13,66 +13,79 @@ vi.mock('../log.js', () => ({
 
 // Mock neon-init
 vi.mock('neon-init', () => ({
-  init: vi.fn().mockResolvedValue(undefined),
+  interactiveInit: vi.fn().mockResolvedValue(undefined),
+  orchestrate: vi.fn().mockResolvedValue({ phase: 'complete', status: 'ok' }),
 }));
 
 describe('init', () => {
-  const exitSpy = vi
-    .spyOn(process, 'exit')
-    .mockImplementation((() => undefined) as never);
-
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  test('should call neon-init with no options when agent is omitted', async () => {
+  test('should call interactiveInit when --agent is omitted', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { interactiveInit, orchestrate } = await import('neon-init');
 
     await handler({});
 
-    expect(init).toHaveBeenCalledTimes(1);
-    expect(init).toHaveBeenCalledWith(undefined);
+    expect(interactiveInit).toHaveBeenCalledTimes(1);
+    expect(orchestrate).not.toHaveBeenCalled();
   });
 
-  test('should call neon-init with { agent: "Cursor" } when --agent cursor', async () => {
+  test('should call orchestrate when --agent is passed without a value', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { interactiveInit, orchestrate } = await import('neon-init');
+
+    await handler({ agent: '' });
+
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: undefined,
+      skipNeonAuth: undefined,
+      skipMigrations: undefined,
+      preview: undefined,
+    });
+    expect(interactiveInit).not.toHaveBeenCalled();
+  });
+
+  test('should call orchestrate with agent "cursor"', async () => {
+    const { handler } = await import('./init.js');
+    const { interactiveInit, orchestrate } = await import('neon-init');
 
     await handler({ agent: 'cursor' });
 
-    expect(init).toHaveBeenCalledWith({ agent: 'Cursor' });
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: 'cursor',
+      skipNeonAuth: undefined,
+      skipMigrations: undefined,
+      preview: undefined,
+    });
+    expect(interactiveInit).not.toHaveBeenCalled();
   });
 
-  test('should call neon-init with { agent: "VS Code" } when --agent copilot', async () => {
+  test('should pass skipNeonAuth and skipMigrations to orchestrate', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { orchestrate } = await import('neon-init');
 
-    await handler({ agent: 'copilot' });
+    await handler({
+      agent: 'claude',
+      skipNeonAuth: true,
+      skipMigrations: true,
+    });
 
-    expect(init).toHaveBeenCalledWith({ agent: 'VS Code' });
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: 'claude',
+      skipNeonAuth: true,
+      skipMigrations: true,
+      preview: undefined,
+    });
   });
 
-  test('should call neon-init with { agent: "Claude CLI" } when --agent claude', async () => {
+  test('should pass preview to interactiveInit', async () => {
     const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
+    const { interactiveInit } = await import('neon-init');
 
-    await handler({ agent: 'claude' });
+    await handler({ preview: true });
 
-    expect(init).toHaveBeenCalledWith({ agent: 'Claude CLI' });
-  });
-
-  test('should log error and exit 1 when --agent is invalid', async () => {
-    const { handler } = await import('./init.js');
-    const { init } = await import('neon-init');
-    const { log } = await import('../log.js');
-
-    await handler({ agent: 'invalid-agent' });
-
-    expect(init).not.toHaveBeenCalled();
-    expect(log.error).toHaveBeenCalledWith(
-      'Invalid --agent value: "invalid-agent". Supported: cursor, copilot, claude',
-    );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(interactiveInit).toHaveBeenCalledWith({ preview: true });
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,32 +1,7 @@
-import { init } from 'neon-init';
+import { interactiveInit, orchestrate } from 'neon-init';
 import yargs from 'yargs';
 import { sendError } from '../analytics.js';
 import { log } from '../log.js';
-
-const AGENT_FLAG_VALUES = ['cursor', 'copilot', 'claude'] as const;
-
-type Editor = 'Cursor' | 'VS Code' | 'Claude CLI';
-
-function parseAgentToEditor(value: string): Editor | null {
-  const normalized = value.trim().toLowerCase();
-  switch (normalized) {
-    case 'cursor':
-      return 'Cursor';
-    case 'github-copilot':
-    case 'copilot':
-    case 'vs code':
-    case 'vscode':
-    case 'vs-code':
-      return 'VS Code';
-    case 'claude-code':
-    case 'claude cli':
-    case 'claude-cli':
-    case 'claude':
-      return 'Claude CLI';
-    default:
-      return null;
-  }
-}
 
 export const command = 'init';
 export const describe =
@@ -39,26 +14,44 @@ export const builder = (yargs: yargs.Argv) =>
     .option('agent', {
       alias: 'a',
       type: 'string',
-      describe: 'Agent to configure (cursor, copilot, code).',
+      describe: 'Agent to configure (cursor, copilot, claude, etc.).',
+    })
+    .option('skip-neon-auth', {
+      type: 'boolean',
+      default: false,
+      describe: 'Skip the Neon Auth setup phase.',
+    })
+    .option('skip-migrations', {
+      type: 'boolean',
+      default: false,
+      describe: 'Skip the migrations phase.',
+    })
+    .option('preview', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Enable preview features (e.g. project bootstrapping from templates).',
     })
     .strict(false);
 
-export const handler = async (argv: { agent?: string }) => {
-  let options: { agent: Editor } | undefined;
-  const agentArg = argv.agent;
-  if (agentArg !== undefined) {
-    const editor = parseAgentToEditor(agentArg);
-    if (editor === null) {
-      log.error(
-        `Invalid --agent value: "${agentArg}". Supported: ${AGENT_FLAG_VALUES.join(', ')}`,
-      );
-      process.exit(1);
-      return;
-    }
-    options = { agent: editor };
-  }
+export const handler = async (argv: {
+  agent?: string;
+  skipNeonAuth?: boolean;
+  skipMigrations?: boolean;
+  preview?: boolean;
+}) => {
   try {
-    await init(options);
+    if (argv.agent !== undefined) {
+      const result = await orchestrate({
+        agent: argv.agent || undefined,
+        skipNeonAuth: argv.skipNeonAuth,
+        skipMigrations: argv.skipMigrations,
+        preview: argv.preview,
+      });
+      log.info(JSON.stringify(result, null, 2));
+    } else {
+      await interactiveInit({ preview: argv.preview });
+    }
   } catch {
     const exitError = new Error(`failed to run neon-init`);
     sendError(exitError, 'NEON_INIT_FAILED');


### PR DESCRIPTION
## Summary
- Bumps `neon-init` dependency from 0.14.0 to 0.16.0
- Bumps `neonctl` version to 2.26.0
- Updates `neon init` command to use the new neon-init 0.16.0 APIs:
  - `neon init` now calls `interactiveInit()` — the new guided CLI flow with NEON banner and feature selection
  - `neon init --agent [name]` calls `orchestrate()` — the stateless phase-based agent/JSON mode
- Adds new flags: `--skip-neon-auth`, `--skip-migrations`, `--preview`
- Removes the old `parseAgentToEditor` mapping — agent names are now passed directly to the orchestrator

## Test plan
- [x] Verify `pnpm install` succeeds
- [x] Run `neon init` and confirm it shows the new interactive UI
- [x] Run `neon init --agent` and confirm it triggers orchestrator mode
- [x] Run `neon init --agent cursor` and confirm agent is passed through
- [x] Unit tests pass (`vitest run src/commands/init.test.ts`)

This pull request and its description were written by Isaac.