### PR TITLE
feat(link): auto-select the only org in interactive mode

### DIFF
--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -788,6 +788,13 @@ const promptOrgFromList = async (orgs: Organization[]): Promise<string> => {
       `You don't belong to any organizations. Create one in the Neon Console first: https://console.neon.tech/`,
     );
   }
+  // A single organization leaves nothing to choose, so skip the prompt and link
+  // it directly — go straight on to the project step.
+  if (orgs.length === 1) {
+    const [only] = orgs;
+    log.info(`Linking organization ${only.name} (${only.id}).`);
+    return only.id;
+  }
   const { orgId } = await prompts({
     onState: onPromptState,
     type: 'select',


### PR DESCRIPTION
## Summary
- In interactive `neonctl link`, when the user belongs to exactly one organization, skip the one-item org selection prompt and link it directly, moving straight on to the project step.
- A short info line (`Linking organization <name> (<id>).`) is logged so the chosen org is still visible.

This only affects the interactive (TTY) path that previously rendered a single-choice `prompts` select. Multi-org users still get the picker, and the agent / non-interactive / `--org-id` paths are unchanged.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run src/commands/link.test.ts` (33 passed)
- [ ] Manual: run `neonctl link` interactively with an account in a single org and confirm it jumps straight to the project picker
- [ ] Manual: run `neonctl link` interactively with an account in multiple orgs and confirm the org picker still shows