### PR TITLE
chore: bump @neondatabase/config{,-runtime} to 0.7.1 and env to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.7.0",
-    "@neondatabase/config-runtime": "0.7.0",
-    "@neondatabase/env": "0.5.0",
+    "@neondatabase/config": "0.7.1",
+    "@neondatabase/config-runtime": "0.7.1",
+    "@neondatabase/env": "0.5.1",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       '@neondatabase/config':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.7.1
+        version: 0.7.1
       '@neondatabase/config-runtime':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.7.1
+        version: 0.7.1
       '@neondatabase/env':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -884,16 +884,16 @@ packages:
   '@neondatabase/api-client@2.7.1':
     resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
 
-  '@neondatabase/config-runtime@0.7.0':
-    resolution: {integrity: sha512-km0ge/UuAsC5n2kPIadEtublCRZpiVP9Q+2LJlN9+m7aMbA5FHB6mcwnVIu6ob5spNj8yktJIqHuobGea8f1cw==}
+  '@neondatabase/config-runtime@0.7.1':
+    resolution: {integrity: sha512-0GY2XRy46KF7T90/w8PJr1vBqZwUkbKvz25IwExIourgjwk04wXgSRBsSshkXpxwzHGM/YGhbwocKoFTMBeNLw==}
     engines: {node: '>=22'}
 
-  '@neondatabase/config@0.7.0':
-    resolution: {integrity: sha512-S+krOQ5+wiYDsrawQsXolHadZj6LWH6YDRo8RxyBxBUZSBubkD7CCqIYSpWz9kxpUdfimlHadOlymHRhq0VVQw==}
+  '@neondatabase/config@0.7.1':
+    resolution: {integrity: sha512-q6Mk61TKZG+V3vETj0IUQwhbM01SVM+gxqClPzfDUI18BeAYaZPJN9UkA9RkymANalJBt8K0WxMNtxcP2jDFeg==}
     engines: {node: '>=22'}
 
-  '@neondatabase/env@0.5.0':
-    resolution: {integrity: sha512-1H0vZVVlCXPDpNHk6ou/rZaLmftw45Nw22Ng5pb6U3mN88RUCz4qVOYOVGwB4Fm6LPeCwi3hIanDl97bibV4rA==}
+  '@neondatabase/env@0.5.1':
+    resolution: {integrity: sha512-lEhIyp0b5F+3aBBVeiT0WOwbEdka/UQW6/YeMzc9Iq2mmOz3kCAPJr6c74FY9gAoOAHGhcRYWy1+BOSEAdVdkg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4316,16 +4316,16 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/config-runtime@0.7.0':
+  '@neondatabase/config-runtime@0.7.1':
     dependencies:
-      '@neondatabase/config': 0.7.0
+      '@neondatabase/config': 0.7.1
       esbuild: 0.25.12
       fflate: 0.8.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@neondatabase/config@0.7.0':
+  '@neondatabase/config@0.7.1':
     dependencies:
       '@neondatabase/api-client': 2.7.1
       jiti: 2.7.0
@@ -4334,9 +4334,9 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/env@0.5.0':
+  '@neondatabase/env@0.5.1':
     dependencies:
-      '@neondatabase/config': 0.7.0
+      '@neondatabase/config': 0.7.1
       yargs: 18.0.0
       zod: 4.4.3
     transitivePeerDependencies:

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -166,6 +166,10 @@ class FakeNeonApi implements NeonApi {
     throw new Error('not implemented');
   }
 
+  async updateProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
   async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
     return [];
   }

--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -136,6 +136,9 @@ class FakeNeonApi implements NeonApi {
   async enableProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
     throw new Error('not implemented');
   }
+  async updateProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
   async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
     return [];
   }

--- a/src/dev/env.test.ts
+++ b/src/dev/env.test.ts
@@ -176,6 +176,10 @@ class FakeNeonApi implements NeonApi {
     throw new Error('not implemented');
   }
 
+  async updateProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
+    throw new Error('not implemented');
+  }
+
   async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
     return [];
   }


### PR DESCRIPTION
## Summary

Bump the Neon packages released today from [neondatabase/neon-pkgs#202](https://github.com/neondatabase/neon-pkgs/pull/202):

| Package | Version |
|---|---|
| `@neondatabase/config` | 0.7.0 → 0.7.1 |
| `@neondatabase/config-runtime` | 0.7.0 → 0.7.1 |
| `@neondatabase/env` | 0.5.0 → 0.5.1 |

(`neon-init` 0.16.1 was originally part of this PR but already landed on main via #548.)

The new versions add a required `updateProjectBranchDataApi` method to the `NeonApi` interface (rich dataApi config, neon-pkgs#200), so the `FakeNeonApi` test doubles in three test files gained a `not implemented` stub for it.

## Testing

- `pnpm typecheck` introduces no new errors over the `main` baseline (without the stubs it fails with 18 `updateProjectBranchDataApi` errors)
- The 41 tests in the four test files exercising these packages pass

This pull request and its description were written by Isaac, Databricks's AI assistant (an AI agent built on Claude Code).