### PR TITLE
fix(bootstrap): fetch templates via codeload tarball to avoid GitHub API rate limits

### DIFF
--- a/src/commands/bootstrap.test.ts
+++ b/src/commands/bootstrap.test.ts
@@ -13,40 +13,43 @@ import { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import express from 'express';
+import { gzipSync } from 'fflate';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-// A fixture file in the template repo: its git `mode` decides whether it lands
-// as a regular file, an executable, or a symlink (whose content is the target).
-type FixtureFile = { mode: string; content: string };
+// A fixture file in the template repo: its POSIX `mode`/`type` decide whether it
+// lands as a regular file, an executable, or a symlink.
+type FixtureFile =
+  | { type: 'file'; mode: number; content: string }
+  | { type: 'symlink'; target: string };
 
-// Keyed by full repo path. The `with-hono` subdir mirrors what the real `hono`
-// template uses; `with-remix/...` must be filtered out as a sibling example.
+// Keyed by repo-relative path. The `with-hono` subdir mirrors what the real
+// `hono` template uses; `with-remix/...` must be filtered out as a sibling.
 const FIXTURE: Record<string, FixtureFile> = {
   'with-hono/package.json': {
-    mode: '100644',
+    type: 'file',
+    mode: 0o644,
     content: '{\n  "name": "with-hono"\n}\n',
   },
   'with-hono/src/index.ts': {
-    mode: '100644',
+    type: 'file',
+    mode: 0o644,
     content: 'export const app = "hono";\n',
   },
   'with-hono/scripts/run.sh': {
-    mode: '100755',
+    type: 'file',
+    mode: 0o755,
     content: '#!/bin/sh\necho hi\n',
   },
-  // A symlink: in git the blob content is the (relative) link target.
   'with-hono/.claude/skills/neon': {
-    mode: '120000',
-    content: '../../package.json',
+    type: 'symlink',
+    target: '../../package.json',
   },
   'with-remix/package.json': {
-    mode: '100644',
+    type: 'file',
+    mode: 0o644,
     content: '{ "name": "with-remix" }\n',
   },
 };
-
-const COMMIT_SHA = 'commit0000000000000000000000000000000000';
-const TREE_SHA = 'tree00000000000000000000000000000000000000';
 
 const MANIFEST_YAML = `templates:
   - id: hono
@@ -62,40 +65,70 @@ const MANIFEST_YAML = `templates:
       subdir: with-hono
 `;
 
-// A real local HTTP server standing in for the GitHub API + raw host, so the
-// whole download/extract path runs end to end with no mocking of our own code.
+// Build a ustar header block, matching what GitHub's codeload tarballs emit.
+const tarHeader = (
+  name: string,
+  size: number,
+  mode: number,
+  typeflag: string,
+  linkname = '',
+): Buffer => {
+  const header = Buffer.alloc(512, 0);
+  header.write(name, 0, 'utf8');
+  header.write(`${(mode & 0o7777).toString(8).padStart(7, '0')}\0`, 100);
+  header.write('0000000\0', 108);
+  header.write('0000000\0', 116);
+  header.write(`${size.toString(8).padStart(11, '0')}\0`, 124);
+  header.write('00000000000\0', 136);
+  header.write('        ', 148);
+  header.write(typeflag, 156, 1);
+  header.write(linkname, 157, 'utf8');
+  header.write('ustar\0', 257);
+  header.write('00', 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) {
+    sum += header[i];
+  }
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148);
+  return header;
+};
+
+const padTo512 = (buf: Buffer): Buffer => {
+  const rem = buf.length % 512;
+  return rem === 0 ? buf : Buffer.concat([buf, Buffer.alloc(512 - rem)]);
+};
+
+// Pack the fixture into a gzipped tar shaped like codeload: a single
+// "examples-main/" top-level dir wrapping every repo-relative path.
+const makeTarball = (): Buffer => {
+  const blocks: Buffer[] = [tarHeader('pax_global_header', 0, 0o644, 'g')];
+  for (const [path, file] of Object.entries(FIXTURE)) {
+    const name = `examples-main/${path}`;
+    if (file.type === 'symlink') {
+      blocks.push(tarHeader(name, 0, 0o777, '2', file.target));
+    } else {
+      const content = Buffer.from(file.content);
+      blocks.push(tarHeader(name, content.length, file.mode, '0'));
+      blocks.push(padTo512(content));
+    }
+  }
+  blocks.push(Buffer.alloc(1024));
+  return Buffer.from(gzipSync(new Uint8Array(Buffer.concat(blocks))));
+};
+
+// A real local HTTP server standing in for the codeload tarball host + the
+// manifest host, so the whole download/extract path runs end to end with no
+// mocking of our own code.
 const startGithubFixtureServer = (): Promise<Server> => {
   const app = express();
 
-  // Serve the bootstrap manifest
   app.get('/manifest/bootstrap.yaml', (_req, res) => {
     res.type('text/yaml').send(MANIFEST_YAML);
   });
 
-  app.get('/repos/:owner/:repo/commits/:ref', (_req, res) => {
-    res.json({ sha: COMMIT_SHA, commit: { tree: { sha: TREE_SHA } } });
-  });
-
-  app.get('/repos/:owner/:repo/git/trees/:treeSha', (_req, res) => {
-    const tree = Object.entries(FIXTURE).map(([path, file]) => ({
-      path,
-      mode: file.mode,
-      type: 'blob',
-    }));
-    res.json({ sha: TREE_SHA, truncated: false, tree });
-  });
-
-  app.get('/raw/:owner/:repo/:sha/*', (req, res) => {
-    const { owner, repo, sha } = req.params;
-    const repoPath = decodeURIComponent(
-      req.path.slice(`/raw/${owner}/${repo}/${sha}/`.length),
-    );
-    const file = FIXTURE[repoPath];
-    if (!file) {
-      res.status(404).send('Not Found');
-      return;
-    }
-    res.type('application/octet-stream').send(Buffer.from(file.content));
+  // Mirrors https://codeload.github.com/:owner/:repo/tar.gz/:ref
+  app.get('/:owner/:repo/tar.gz/:ref', (_req, res) => {
+    res.type('application/gzip').send(makeTarball());
   });
 
   return new Promise((resolve) => {
@@ -127,8 +160,7 @@ const runBootstrap = (
         env: {
           ...process.env,
           CI: 'true',
-          NEON_BOOTSTRAP_GITHUB_API: base,
-          NEON_BOOTSTRAP_GITHUB_RAW: `${base}/raw`,
+          NEON_BOOTSTRAP_GITHUB_CODELOAD: base,
           NEON_BOOTSTRAP_MANIFEST_URL: `${base}/manifest/bootstrap.yaml`,
         },
       },

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -23,11 +23,9 @@ import { CommonProps } from '../types.js';
 import {
   BootstrapTemplate,
   FALLBACK_TEMPLATES,
-  fetchFileBytes,
-  fetchSymlinkTarget,
+  downloadTemplate,
   fetchTemplates,
   findTemplate,
-  resolveTemplate,
   templateIds,
 } from '../utils/bootstrap.js';
 
@@ -354,30 +352,24 @@ const scaffold = async (
   targetDir: string,
 ): Promise<number> => {
   log.info('Fetching template "%s" from GitHub…', template.id);
-  const { commitSha, entries } = await resolveTemplate(template);
+  const files = await downloadTemplate(template);
 
   mkdirSync(targetDir, { recursive: true });
-  log.info('Scaffolding %d files into %s…', entries.length, targetDir);
+  log.info('Scaffolding %d files into %s…', files.length, targetDir);
 
-  await mapWithConcurrency(entries, 8, async (entry) => {
-    const dest = join(targetDir, entry.path);
+  for (const file of files) {
+    const dest = join(targetDir, file.path);
     mkdirSync(dirname(dest), { recursive: true });
-    if (entry.kind === 'symlink') {
-      const target = await fetchSymlinkTarget(
-        template,
-        commitSha,
-        entry.repoPath,
-      );
-      writeSymlink(dest, target);
+    if (file.kind === 'symlink') {
+      writeSymlink(dest, file.target);
     } else {
-      const bytes = await fetchFileBytes(template, commitSha, entry.repoPath);
-      writeFileSync(dest, bytes);
-      if (entry.executable) {
+      writeFileSync(dest, file.bytes);
+      if (file.executable) {
         chmodSync(dest, 0o755);
       }
     }
-  });
-  return entries.length;
+  }
+  return files.length;
 };
 
 const writeSymlink = (dest: string, target: string): void => {
@@ -806,24 +798,6 @@ const displayDir = (targetDir: string): string => {
     return '.';
   }
   return rel.startsWith('..') ? targetDir : rel;
-};
-
-const mapWithConcurrency = async <T>(
-  items: T[],
-  limit: number,
-  fn: (item: T) => Promise<void>,
-): Promise<void> => {
-  const queue = [...items];
-  const worker = async (): Promise<void> => {
-    for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
-      await fn(next);
-    }
-  };
-  const workers = Array.from(
-    { length: Math.max(1, Math.min(limit, items.length)) },
-    () => worker(),
-  );
-  await Promise.all(workers);
 };
 
 const isSymlink = (path: string): boolean => {

--- a/src/utils/bootstrap.test.ts
+++ b/src/utils/bootstrap.test.ts
@@ -1,28 +1,147 @@
+import { gunzipSync, gzipSync } from 'fflate';
 import { describe, expect, it } from 'vitest';
 
 import {
-  GitTreeNode,
+  FALLBACK_TEMPLATES,
   parseManifest,
-  selectSubtreeEntries,
+  parseTar,
+  selectTemplateFiles,
 } from './bootstrap.js';
 
-const tree: GitTreeNode[] = [
-  { path: 'with-hono', mode: '040000', type: 'tree' },
-  { path: 'with-hono/package.json', mode: '100644', type: 'blob' },
-  { path: 'with-hono/src', mode: '040000', type: 'tree' },
-  { path: 'with-hono/src/index.ts', mode: '100644', type: 'blob' },
-  { path: 'with-hono/scripts/run.sh', mode: '100755', type: 'blob' },
-  { path: 'with-hono/.claude/skills/neon', mode: '120000', type: 'blob' },
-  // A different example in the same repo must never leak into the copy.
-  { path: 'with-remix/package.json', mode: '100644', type: 'blob' },
-  // A submodule (commit) is not a copyable blob.
-  { path: 'with-hono/vendor', mode: '160000', type: 'commit' },
+// ---------------------------------------------------------------------------
+// Minimal tar builder, used to exercise parseTar with real archive bytes (the
+// same layout codeload.github.com produces: a single top-level dir, a leading
+// pax global header, directory entries, files, and symlinks).
+// ---------------------------------------------------------------------------
+
+type TarInput =
+  | { name: string; type: 'file'; mode: number; content: string }
+  | { name: string; type: 'dir' }
+  | { name: string; type: 'symlink'; target: string }
+  | { name: string; type: 'pax-global'; content: string };
+
+const TYPEFLAG = {
+  file: '0',
+  dir: '5',
+  symlink: '2',
+  'pax-global': 'g',
+} as const;
+
+const tarHeader = (
+  name: string,
+  size: number,
+  mode: number,
+  typeflag: string,
+  linkname = '',
+): Buffer => {
+  const header = Buffer.alloc(512, 0);
+  header.write(name, 0, 'utf8');
+  header.write(`${(mode & 0o7777).toString(8).padStart(7, '0')}\0`, 100);
+  header.write('0000000\0', 108); // uid
+  header.write('0000000\0', 116); // gid
+  header.write(`${size.toString(8).padStart(11, '0')}\0`, 124);
+  header.write('00000000000\0', 136); // mtime
+  header.write('        ', 148); // checksum placeholder (8 spaces)
+  header.write(typeflag, 156, 1);
+  header.write(linkname, 157, 'utf8');
+  header.write('ustar\0', 257);
+  header.write('00', 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) {
+    sum += header[i];
+  }
+  header.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148);
+  return header;
+};
+
+const padTo512 = (buf: Buffer): Buffer => {
+  const rem = buf.length % 512;
+  return rem === 0 ? buf : Buffer.concat([buf, Buffer.alloc(512 - rem)]);
+};
+
+const buildTar = (inputs: TarInput[]): Buffer => {
+  const blocks: Buffer[] = [];
+  for (const input of inputs) {
+    if (input.type === 'file' || input.type === 'pax-global') {
+      const content = Buffer.from(input.content);
+      const mode = input.type === 'file' ? input.mode : 0o644;
+      blocks.push(
+        tarHeader(input.name, content.length, mode, TYPEFLAG[input.type]),
+      );
+      blocks.push(padTo512(content));
+    } else if (input.type === 'symlink') {
+      blocks.push(
+        tarHeader(input.name, 0, 0o777, TYPEFLAG.symlink, input.target),
+      );
+    } else {
+      blocks.push(tarHeader(input.name, 0, 0o755, TYPEFLAG.dir));
+    }
+  }
+  blocks.push(Buffer.alloc(1024)); // two zero blocks terminate the archive
+  return Buffer.concat(blocks);
+};
+
+// A tarball shaped like codeload's: top-level "examples-main/" dir, a pax
+// global header up front, and a sibling example that must be filtered out.
+const EXAMPLE_TAR: TarInput[] = [
+  {
+    name: 'pax_global_header',
+    type: 'pax-global',
+    content: '52 comment=0000\n',
+  },
+  { name: 'examples-main/', type: 'dir' },
+  { name: 'examples-main/with-hono/', type: 'dir' },
+  {
+    name: 'examples-main/with-hono/package.json',
+    type: 'file',
+    mode: 0o644,
+    content: '{\n  "name": "with-hono"\n}\n',
+  },
+  { name: 'examples-main/with-hono/src/', type: 'dir' },
+  {
+    name: 'examples-main/with-hono/src/index.ts',
+    type: 'file',
+    mode: 0o644,
+    content: 'export const app = "hono";\n',
+  },
+  {
+    name: 'examples-main/with-hono/scripts/run.sh',
+    type: 'file',
+    mode: 0o755,
+    content: '#!/bin/sh\necho hi\n',
+  },
+  {
+    name: 'examples-main/with-hono/.claude/skills/neon',
+    type: 'symlink',
+    target: '../../package.json',
+  },
+  {
+    name: 'examples-main/with-remix/package.json',
+    type: 'file',
+    mode: 0o644,
+    content: '{ "name": "with-remix" }\n',
+  },
 ];
 
-describe('selectSubtreeEntries', () => {
-  it('keeps only blobs under the subdir and strips the prefix', () => {
-    const entries = selectSubtreeEntries(tree, 'with-hono');
-    expect(entries.map((e) => e.path).sort()).toEqual([
+describe('parseTar + selectTemplateFiles', () => {
+  const entries = parseTar(buildTar(EXAMPLE_TAR));
+
+  it('skips the pax global header but keeps directory entries for the caller to filter', () => {
+    // The pax global header is consumed by the parser and never surfaces; the
+    // directory entries do (selectTemplateFiles is what drops them).
+    const names = entries.map((e) => e.name);
+    expect(names).not.toContain('pax_global_header');
+    expect(entries.some((e) => e.type === '5')).toBe(true);
+    // ...and none of those directories leak into the selected files.
+    const files = selectTemplateFiles(entries, 'with-hono');
+    expect(files.every((f) => f.path !== '' && !f.path.endsWith('/'))).toBe(
+      true,
+    );
+  });
+
+  it('keeps only files under the subdir, prefix stripped', () => {
+    const files = selectTemplateFiles(entries, 'with-hono');
+    expect(files.map((f) => f.path).sort()).toEqual([
       '.claude/skills/neon',
       'package.json',
       'scripts/run.sh',
@@ -30,34 +149,104 @@ describe('selectSubtreeEntries', () => {
     ]);
   });
 
-  it('classifies symlinks, executables, and regular files by git mode', () => {
+  it('preserves contents, exec bits, and symlink targets', () => {
     const byPath = Object.fromEntries(
-      selectSubtreeEntries(tree, 'with-hono').map((e) => [e.path, e]),
+      selectTemplateFiles(entries, 'with-hono').map((f) => [f.path, f]),
     );
 
-    expect(byPath['.claude/skills/neon']).toMatchObject({ kind: 'symlink' });
-    expect(byPath['scripts/run.sh']).toMatchObject({
-      kind: 'file',
-      executable: true,
-    });
-    expect(byPath['package.json']).toMatchObject({
-      kind: 'file',
-      executable: false,
-    });
+    const pkg = byPath['package.json'];
+    expect(pkg.kind).toBe('file');
+    if (pkg.kind === 'file') {
+      expect(pkg.bytes.toString('utf8')).toBe('{\n  "name": "with-hono"\n}\n');
+      expect(pkg.executable).toBe(false);
+    }
+
+    const script = byPath['scripts/run.sh'];
+    expect(script.kind === 'file' && script.executable).toBe(true);
+
+    const link = byPath['.claude/skills/neon'];
+    expect(link.kind).toBe('symlink');
+    if (link.kind === 'symlink') {
+      expect(link.target).toBe('../../package.json');
+    }
   });
 
-  it('preserves the full repo path for fetching raw content', () => {
-    const entries = selectSubtreeEntries(tree, 'with-hono');
-    const pkg = entries.find((e) => e.path === 'package.json');
-    expect(pkg?.repoPath).toBe('with-hono/package.json');
+  it('does not leak a sibling example from the same repo', () => {
+    const files = selectTemplateFiles(entries, 'with-hono');
+    expect(files.some((f) => f.path.includes('with-remix'))).toBe(false);
   });
 
-  it('tolerates a trailing slash on the subdir', () => {
-    expect(selectSubtreeEntries(tree, 'with-hono/')).toHaveLength(4);
+  it('tolerates a trailing or leading slash on the subdir', () => {
+    expect(selectTemplateFiles(entries, 'with-hono/')).toHaveLength(4);
+    expect(selectTemplateFiles(entries, '/with-hono')).toHaveLength(4);
   });
 
   it('returns nothing for a subdir that does not exist', () => {
-    expect(selectSubtreeEntries(tree, 'nope')).toEqual([]);
+    expect(selectTemplateFiles(entries, 'nope')).toEqual([]);
+  });
+
+  it('round-trips through gzip the way the downloader decompresses it', () => {
+    // Mirrors downloadTemplate: gzip on the wire, fflate gunzip, then parse.
+    const gz = gzipSync(new Uint8Array(buildTar(EXAMPLE_TAR)));
+    const files = selectTemplateFiles(
+      parseTar(Buffer.from(gunzipSync(gz))),
+      'with-hono',
+    );
+    expect(files).toHaveLength(4);
+  });
+});
+
+// A single pax "<len> key=value\n" record. The length prefix counts itself, so
+// it's solved by fixed-point iteration — the same shape GNU/BSD tar emit.
+const paxRecord = (key: string, value: string): string => {
+  const record = `${key}=${value}`;
+  let len = record.length + 1;
+  for (let i = 0; i < 5; i++) {
+    len = `${len} ${record}\n`.length;
+  }
+  return `${len} ${record}\n`;
+};
+
+// A pax extended header (typeflag 'x') applying to the next entry, followed by
+// that entry (built with the normal file/symlink builder, which also writes the
+// archive's terminating zero blocks).
+const buildPaxOverride = (records: string, next: TarInput): Buffer => {
+  const body = Buffer.from(records);
+  return Buffer.concat([
+    tarHeader('pax_header', body.length, 0o644, 'x'),
+    padTo512(body),
+    buildTar([next]),
+  ]);
+};
+
+describe('parseTar long paths', () => {
+  it('honors pax extended headers that override a long path', () => {
+    const longPath = `examples-main/with-hono/${'a'.repeat(120)}/deep.txt`;
+    const tar = buildPaxOverride(paxRecord('path', longPath), {
+      name: 'examples-main/with-hono/short.txt',
+      type: 'file',
+      mode: 0o644,
+      content: 'deep\n',
+    });
+
+    const match = parseTar(tar).find((e) => e.name === longPath);
+    expect(match?.data.toString('utf8')).toBe('deep\n');
+  });
+
+  it('honors pax extended headers that override a long symlink target', () => {
+    const longTarget = `../../${'b'.repeat(130)}/target`;
+    const tar = buildPaxOverride(paxRecord('linkpath', longTarget), {
+      name: 'examples-main/with-hono/link',
+      type: 'symlink',
+      target: 'placeholder',
+    });
+
+    const files = selectTemplateFiles(parseTar(tar), 'with-hono');
+    const link = files.find((f) => f.path === 'link');
+    expect(link?.kind).toBe('symlink');
+    if (link?.kind === 'symlink') {
+      expect(link.target).toBe(longTarget);
+    }
   });
 });
 
@@ -190,5 +379,15 @@ describe('parseManifest', () => {
 
   it('handles an empty templates array', () => {
     expect(parseManifest('templates: []')).toEqual([]);
+  });
+});
+
+describe('FALLBACK_TEMPLATES', () => {
+  it('offers the full starter set, not just one template', () => {
+    expect(FALLBACK_TEMPLATES.map((t) => t.id)).toEqual([
+      'hono',
+      'ai-sdk',
+      'mastra',
+    ]);
   });
 });

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -1,4 +1,5 @@
 import axios, { isAxiosError } from 'axios';
+import { gunzipSync } from 'fflate';
 import YAML from 'yaml';
 
 import { log } from '../log.js';
@@ -6,9 +7,15 @@ import { log } from '../log.js';
 /**
  * A scaffold template that lives in a subdirectory of a public GitHub repo we
  * control. `neon bootstrap` copies that subdirectory into a target folder —
- * conceptually the same as `degit user/repo/subdir`, but implemented in-house
- * so the download host stays configurable (and therefore end-to-end testable)
- * and so we never pull in a heavy dependency tree just to copy a few files.
+ * conceptually the same as `degit user/repo/subdir`, but implemented in-house.
+ *
+ * The whole template is pulled in a single request: we download the repo's
+ * gzipped tarball from `codeload.github.com` and extract only the subdir we
+ * want. That endpoint is unauthenticated and is NOT subject to the 60-requests
+ * per-hour limit of the REST API (`api.github.com`), so `neon bootstrap` works
+ * out of the box on shared/corporate networks without a GITHUB_TOKEN. We lean
+ * on `fflate` (already a dependency) for gunzip and parse the tar in-house, so
+ * we never pull in a heavy dependency tree just to copy a few files.
  */
 export type BootstrapTemplate = {
   /** Stable id used by `--template` and analytics. */
@@ -32,7 +39,12 @@ export type BootstrapTemplate = {
   };
 };
 
-/** Hardcoded fallback used when the remote manifest cannot be fetched. */
+/**
+ * Hardcoded fallback used when every remote manifest source is unreachable.
+ * Kept in sync with `neondatabase/examples/bootstrap.yaml` (the source of
+ * truth) so that, even fully offline from the manifest, the picker still offers
+ * the full set of starters rather than a single template.
+ */
 export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
   {
     id: 'hono',
@@ -47,6 +59,34 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
       subdir: 'with-hono',
     },
   },
+  {
+    id: 'ai-sdk',
+    title:
+      'AI SDK agent (AI Gateway, object storage, Drizzle) on Neon Functions',
+    description:
+      'A Vercel AI SDK agent on Neon Functions: streams chat through the Neon AI Gateway, generates an image with OpenAI image generation, and stores it in Neon object storage indexed in Postgres via Drizzle.',
+    services: ['Postgres', 'Functions', 'Object Storage', 'AI Gateway'],
+    source: {
+      owner: 'neondatabase',
+      repo: 'examples',
+      ref: 'main',
+      subdir: 'with-ai-sdk',
+    },
+  },
+  {
+    id: 'mastra',
+    title:
+      'Mastra personal agent (AI Gateway, Mastra Memory) on Neon Functions',
+    description:
+      'A Mastra personal-assistant agent on Neon Functions: streams chat through the Neon AI Gateway and uses Mastra Memory — backed by Neon Postgres — to remember the user across conversation threads via resource-scoped working memory.',
+    services: ['Postgres', 'Functions', 'AI Gateway'],
+    source: {
+      owner: 'neondatabase',
+      repo: 'examples',
+      ref: 'main',
+      subdir: 'with-mastra',
+    },
+  },
 ];
 
 export const templateIds = (templates: BootstrapTemplate[]): string =>
@@ -57,51 +97,37 @@ export const findTemplate = (
   id: string,
 ): BootstrapTemplate | undefined => templates.find((t) => t.id === id);
 
-/** A single file or symlink to materialize, resolved from the repo tree. */
-export type TemplateEntry =
+/** A single file or symlink to materialize, already resolved with its bytes. */
+export type TemplateFile =
   | {
       kind: 'file';
       /** Path relative to the target directory (subdir prefix stripped). */
       path: string;
-      /** Path within the repo, used to fetch the raw bytes. */
-      repoPath: string;
+      bytes: Buffer;
       executable: boolean;
     }
   | {
       kind: 'symlink';
       path: string;
-      repoPath: string;
+      /** The (relative) link target. */
+      target: string;
     };
-
-export type GitTreeNode = {
-  path: string;
-  mode: string;
-  type: string;
-};
-
-// Hosts are overridable so the e2e tests can point the downloader at a local
-// server (the same trick `--api-host` uses to redirect the Neon API in tests).
-// The defaults hit public GitHub; copying a public template needs no auth.
-const githubApiBase = (): string =>
-  process.env.NEON_BOOTSTRAP_GITHUB_API ?? 'https://api.github.com';
-
-const githubRawBase = (): string =>
-  process.env.NEON_BOOTSTRAP_GITHUB_RAW ?? 'https://raw.githubusercontent.com';
 
 const githubToken = (): string =>
   process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? '';
 
-const apiHeaders = (): Record<string, string> => ({
-  Accept: 'application/vnd.github+json',
-  'X-GitHub-Api-Version': '2022-11-28',
+// A token is never required for public templates, but we forward it when
+// present so the same code path works behind proxies that authenticate, and
+// (in future) for private template repos.
+const downloadHeaders = (): Record<string, string> => ({
   'User-Agent': 'neonctl',
   ...(githubToken() ? { Authorization: `Bearer ${githubToken()}` } : {}),
 });
 
-const rawHeaders = (): Record<string, string> => ({
-  'User-Agent': 'neonctl',
-  ...(githubToken() ? { Authorization: `Bearer ${githubToken()}` } : {}),
-});
+// The codeload host is overridable so the e2e tests can point the downloader at
+// a local server (the same trick `--api-host` uses to redirect the Neon API).
+const codeloadBase = (): string =>
+  process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD ?? 'https://codeload.github.com';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -126,9 +152,20 @@ const parseServices = (value: unknown): string[] | undefined => {
 // Remote template manifest
 // ---------------------------------------------------------------------------
 
-const manifestUrl = (): string =>
-  process.env.NEON_BOOTSTRAP_MANIFEST_URL ??
-  `${githubRawBase()}/neondatabase/examples/main/bootstrap.yaml`;
+// Primary manifest host is neon.com (CDN-backed, no GitHub rate limiting),
+// with the raw GitHub copy as a fallback and the hardcoded list as the last
+// resort. A single env override (used by tests) short-circuits the chain.
+const NEON_MANIFEST_URL = 'https://neon.com/bootstrap/templates.yaml';
+const GITHUB_RAW_MANIFEST_URL =
+  'https://raw.githubusercontent.com/neondatabase/examples/main/bootstrap.yaml';
+
+const manifestUrls = (): string[] => {
+  const override = process.env.NEON_BOOTSTRAP_MANIFEST_URL;
+  if (override) {
+    return [override];
+  }
+  return [NEON_MANIFEST_URL, GITHUB_RAW_MANIFEST_URL];
+};
 
 export const parseManifest = (text: string): BootstrapTemplate[] => {
   const data: unknown = YAML.parse(text);
@@ -173,75 +210,237 @@ export const parseManifest = (text: string): BootstrapTemplate[] => {
 };
 
 /**
- * Fetch the template manifest from the remote `bootstrap.yaml` in the
- * neondatabase/examples repo. Falls back to the hardcoded list on any error
- * so the command never fails just because GitHub is unreachable.
+ * Fetch the template manifest, trying each source in {@link manifestUrls} in
+ * order and returning the first that yields a non-empty template list. Falls
+ * back to the hardcoded list when every source is unreachable or empty, so the
+ * command never fails just because a host is down.
  */
 export const fetchTemplates = async (): Promise<BootstrapTemplate[]> => {
-  const url = manifestUrl();
-  try {
-    const res = await axios.get<string>(url, {
-      responseType: 'text',
-      headers: rawHeaders(),
-      timeout: 10_000,
-    });
-    const templates = parseManifest(res.data);
-    if (templates.length === 0) {
-      log.warning(
-        'Remote bootstrap manifest at %s contained no templates; using built-in defaults.',
+  for (const url of manifestUrls()) {
+    try {
+      const res = await axios.get<string>(url, {
+        responseType: 'text',
+        headers: downloadHeaders(),
+        timeout: 10_000,
+      });
+      const templates = parseManifest(res.data);
+      if (templates.length > 0) {
+        return templates;
+      }
+      log.debug(
+        'bootstrap: manifest at %s contained no templates; trying next source.',
         url,
       );
-      return FALLBACK_TEMPLATES;
-    }
-    return templates;
-  } catch (err) {
-    log.debug(
-      'bootstrap: failed to fetch manifest from %s: %s — using built-in defaults.',
-      url,
-      err instanceof Error ? err.message : String(err),
-    );
-    return FALLBACK_TEMPLATES;
-  }
-};
-
-const malformed = (what: string): Error =>
-  new Error(`Unexpected GitHub API response while resolving ${what}.`);
-
-type ResolvedCommit = { commitSha: string; treeSha: string };
-
-const parseCommit = (data: unknown): ResolvedCommit => {
-  if (!isRecord(data) || typeof data.sha !== 'string') {
-    throw malformed('the template commit');
-  }
-  const { commit } = data;
-  if (
-    !isRecord(commit) ||
-    !isRecord(commit.tree) ||
-    typeof commit.tree.sha !== 'string'
-  ) {
-    throw malformed('the template tree');
-  }
-  return { commitSha: data.sha, treeSha: commit.tree.sha };
-};
-
-type ParsedTree = { truncated: boolean; tree: GitTreeNode[] };
-
-const parseTree = (data: unknown): ParsedTree => {
-  if (!isRecord(data) || !Array.isArray(data.tree)) {
-    throw malformed('the template file tree');
-  }
-  const tree: GitTreeNode[] = [];
-  for (const item of data.tree) {
-    if (
-      isRecord(item) &&
-      typeof item.path === 'string' &&
-      typeof item.mode === 'string' &&
-      typeof item.type === 'string'
-    ) {
-      tree.push({ path: item.path, mode: item.mode, type: item.type });
+    } catch (err) {
+      log.debug(
+        'bootstrap: failed to fetch manifest from %s: %s — trying next source.',
+        url,
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
-  return { truncated: data.truncated === true, tree };
+  log.debug(
+    'bootstrap: all manifest sources exhausted; using built-in defaults.',
+  );
+  return FALLBACK_TEMPLATES;
+};
+
+// ---------------------------------------------------------------------------
+// Tar parsing
+// ---------------------------------------------------------------------------
+
+/** A raw entry decoded from a tar stream, before subdir filtering. */
+type TarEntry = {
+  /** Full path as stored in the archive (includes the top-level dir). */
+  name: string;
+  /** POSIX type flag: '0' file, '5' directory, '2' symlink, etc. */
+  type: string;
+  /** File permission bits. */
+  mode: number;
+  /** Symlink target (for type '2'). */
+  linkname: string;
+  /** File contents (for type '0'). */
+  data: Buffer;
+};
+
+const TAR_BLOCK = 512;
+
+const readTarString = (buf: Buffer, offset: number, length: number): string => {
+  let end = offset;
+  const max = offset + length;
+  while (end < max && buf[end] !== 0) {
+    end++;
+  }
+  return buf.toString('utf8', offset, end);
+};
+
+const readTarOctal = (buf: Buffer, offset: number, length: number): number => {
+  const text = readTarString(buf, offset, length).trim();
+  if (text === '') {
+    return 0;
+  }
+  const value = parseInt(text, 8);
+  return Number.isNaN(value) ? 0 : value;
+};
+
+const isZeroBlock = (buf: Buffer, offset: number): boolean => {
+  for (let i = offset; i < offset + TAR_BLOCK; i++) {
+    if (buf[i] !== 0) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Parse pax extended-header records ("<len> <key>=<value>\n"). GitHub uses
+ * these for the global header and for any path that doesn't fit the legacy
+ * 100-byte name field, so we must honor at least `path` and `linkpath`.
+ */
+const parsePaxRecords = (data: Buffer): Record<string, string> => {
+  const records: Record<string, string> = {};
+  let pos = 0;
+  const text = data.toString('utf8');
+  while (pos < text.length) {
+    const space = text.indexOf(' ', pos);
+    if (space === -1) {
+      break;
+    }
+    const len = parseInt(text.slice(pos, space), 10);
+    if (Number.isNaN(len) || len <= 0) {
+      break;
+    }
+    const record = text.slice(space + 1, pos + len - 1); // drop trailing "\n"
+    const eq = record.indexOf('=');
+    if (eq !== -1) {
+      records[record.slice(0, eq)] = record.slice(eq + 1);
+    }
+    pos += len;
+  }
+  return records;
+};
+
+/**
+ * Decode a (decompressed) tar archive into its file/symlink entries. Pure and
+ * dependency-free so it can be unit tested without touching the network.
+ * Handles the ustar `prefix` field, pax extended headers (type 'x'/'g'), and
+ * GNU long-name/long-link headers (type 'L'/'K') so deep template paths and
+ * long symlink targets round-trip correctly.
+ */
+export const parseTar = (buf: Buffer): TarEntry[] => {
+  const entries: TarEntry[] = [];
+  // Overrides carried from a preceding pax/GNU header to the next real entry.
+  let overridePath: string | undefined;
+  let overrideLink: string | undefined;
+  let offset = 0;
+
+  while (offset + TAR_BLOCK <= buf.length) {
+    if (isZeroBlock(buf, offset)) {
+      break;
+    }
+
+    let name = readTarString(buf, offset, 100);
+    const mode = readTarOctal(buf, offset + 100, 8);
+    const size = readTarOctal(buf, offset + 124, 12);
+    const typeByte = buf[offset + 156];
+    const type = typeByte === 0 ? '0' : String.fromCharCode(typeByte);
+    let linkname = readTarString(buf, offset + 157, 100);
+    const magic = readTarString(buf, offset + 257, 6);
+    if (magic.startsWith('ustar')) {
+      const prefix = readTarString(buf, offset + 345, 155);
+      if (prefix !== '') {
+        name = `${prefix}/${name}`;
+      }
+    }
+
+    offset += TAR_BLOCK;
+    const data = buf.subarray(offset, offset + size);
+    offset += Math.ceil(size / TAR_BLOCK) * TAR_BLOCK;
+
+    if (type === 'x') {
+      const records = parsePaxRecords(data);
+      if (records.path !== undefined) {
+        overridePath = records.path;
+      }
+      if (records.linkpath !== undefined) {
+        overrideLink = records.linkpath;
+      }
+      continue;
+    }
+    if (type === 'g') {
+      // Global pax header (e.g. GitHub's comment block): not per-entry state.
+      continue;
+    }
+    if (type === 'L' || type === 'K') {
+      const longValue = data.toString('utf8').replace(/\0+$/, '');
+      if (type === 'L') {
+        overridePath = longValue;
+      } else {
+        overrideLink = longValue;
+      }
+      continue;
+    }
+
+    if (overridePath !== undefined) {
+      name = overridePath;
+    }
+    if (overrideLink !== undefined) {
+      linkname = overrideLink;
+    }
+    overridePath = undefined;
+    overrideLink = undefined;
+
+    entries.push({ name, type, mode, linkname, data: Buffer.from(data) });
+  }
+
+  return entries;
+};
+
+/**
+ * Map decoded tar entries to the files under `subdir`, with the top-level
+ * archive directory and the `subdir/` prefix stripped from each path. Pure so
+ * it can be unit tested. Directory and other non-regular entries are dropped —
+ * writing files re-creates their parent directories.
+ */
+export const selectTemplateFiles = (
+  entries: TarEntry[],
+  subdir: string,
+): TemplateFile[] => {
+  const prefix = `${subdir.replace(/^\/+|\/+$/g, '')}/`;
+  const files: TemplateFile[] = [];
+  for (const entry of entries) {
+    // codeload wraps everything in a single top-level dir ("<repo>-<ref>/");
+    // strip that first segment to get the repo-relative path.
+    const slash = entry.name.indexOf('/');
+    if (slash === -1) {
+      continue;
+    }
+    const repoPath = entry.name.slice(slash + 1);
+    if (!repoPath.startsWith(prefix)) {
+      continue;
+    }
+    const path = repoPath.slice(prefix.length);
+    if (path === '') {
+      continue;
+    }
+    if (entry.type === '2') {
+      files.push({ kind: 'symlink', path, target: entry.linkname });
+    } else if (entry.type === '0' || entry.type === '7') {
+      files.push({
+        kind: 'file',
+        path,
+        bytes: entry.data,
+        executable: (entry.mode & 0o111) !== 0,
+      });
+    }
+    // Directories ('5') and any other node types are intentionally skipped.
+  }
+  return files;
+};
+
+const tarballUrl = (template: BootstrapTemplate): string => {
+  const { owner, repo, ref } = template.source;
+  return `${codeloadBase()}/${owner}/${repo}/tar.gz/${ref}`;
 };
 
 const friendlyGithubError = (err: unknown, url: string): Error => {
@@ -249,147 +448,64 @@ const friendlyGithubError = (err: unknown, url: string): Error => {
     const status = err.response?.status;
     if (status === 404) {
       return new Error(
-        `GitHub returned 404 for ${url}. The template repo, ref, or subdirectory may have moved.`,
+        `GitHub returned 404 for ${url}. The template repo or ref may have moved.`,
       );
     }
-    if (
-      status === 403 &&
-      err.response?.headers['x-ratelimit-remaining'] === '0'
-    ) {
+    if (status === 403 || status === 429) {
       return new Error(
-        'GitHub API rate limit exceeded. Set a GITHUB_TOKEN environment variable to raise the limit, then retry.',
+        `GitHub rate limited the template download (${url}). Set a GITHUB_TOKEN environment variable to raise the limit, then retry.`,
       );
     }
   }
   return err instanceof Error ? err : new Error(String(err));
 };
 
-const getJson = async (url: string): Promise<unknown> => {
+/**
+ * Download a template and resolve it to the exact set of files to write. The
+ * entire subtree is captured in one tarball request, so the copy is atomically
+ * consistent: a push to the template repo mid-download cannot produce a
+ * mismatched checkout (unlike fetching a file list and then each blob).
+ */
+export const downloadTemplate = async (
+  template: BootstrapTemplate,
+): Promise<TemplateFile[]> => {
+  const url = tarballUrl(template);
+
+  let gzipped: Buffer;
   try {
-    const res = await axios.get<unknown>(url, { headers: apiHeaders() });
-    return res.data;
+    const res = await axios.get<ArrayBuffer>(url, {
+      responseType: 'arraybuffer',
+      headers: downloadHeaders(),
+      timeout: 30_000,
+    });
+    gzipped = Buffer.from(res.data);
   } catch (err) {
     throw friendlyGithubError(err, url);
   }
-};
 
-/**
- * Map a flat (recursive) git tree to the entries under `subdir`, with the
- * `subdir/` prefix stripped from each `path`. Pure so it can be unit tested
- * without touching the network. Directory nodes are dropped — git never
- * stores empty directories, and writing files re-creates their parents.
- */
-export const selectSubtreeEntries = (
-  tree: GitTreeNode[],
-  subdir: string,
-): TemplateEntry[] => {
-  const prefix = `${subdir.replace(/\/+$/, '')}/`;
-  const entries: TemplateEntry[] = [];
-  for (const node of tree) {
-    if (node.type !== 'blob') {
-      continue;
-    }
-    if (!node.path.startsWith(prefix)) {
-      continue;
-    }
-    const path = node.path.slice(prefix.length);
-    if (node.mode === '120000') {
-      entries.push({ kind: 'symlink', path, repoPath: node.path });
-    } else {
-      entries.push({
-        kind: 'file',
-        path,
-        repoPath: node.path,
-        executable: node.mode === '100755',
-      });
-    }
-  }
-  return entries;
-};
-
-export type ResolvedTemplate = {
-  /** Immutable commit the whole copy is pinned to (no time-of-check races). */
-  commitSha: string;
-  entries: TemplateEntry[];
-};
-
-/**
- * Resolve a template to the exact set of files to write. Pins everything to a
- * single immutable commit: the ref is resolved to a commit sha, the tree is
- * read from that commit's tree, and every blob is later fetched by that same
- * commit — so a push to the template repo mid-copy can't produce a mismatched
- * checkout.
- */
-export const resolveTemplate = async (
-  template: BootstrapTemplate,
-): Promise<ResolvedTemplate> => {
-  const { owner, repo, ref, subdir } = template.source;
-  const api = githubApiBase();
-
-  const commit = parseCommit(
-    await getJson(`${api}/repos/${owner}/${repo}/commits/${ref}`),
-  );
-  const { truncated, tree } = parseTree(
-    await getJson(
-      `${api}/repos/${owner}/${repo}/git/trees/${commit.treeSha}?recursive=1`,
-    ),
-  );
-  if (truncated) {
+  let tar: Buffer;
+  try {
+    tar = Buffer.from(gunzipSync(new Uint8Array(gzipped)));
+  } catch (err) {
     throw new Error(
-      `GitHub returned a truncated file tree for ${owner}/${repo}; cannot reliably copy template "${template.id}".`,
+      `Failed to decompress the template archive from ${url}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
 
-  const entries = selectSubtreeEntries(tree, subdir);
-  if (entries.length === 0) {
+  const { owner, repo, ref, subdir } = template.source;
+  const files = selectTemplateFiles(parseTar(tar), subdir);
+  if (files.length === 0) {
     throw new Error(
       `Template subdirectory "${subdir}" was not found in ${owner}/${repo}@${ref}.`,
     );
   }
   log.debug(
-    'bootstrap: resolved %d files for template "%s" at %s',
-    entries.length,
+    'bootstrap: resolved %d files for template "%s" from %s',
+    files.length,
     template.id,
-    commit.commitSha,
+    url,
   );
-  return { commitSha: commit.commitSha, entries };
-};
-
-const rawUrl = (
-  template: BootstrapTemplate,
-  commitSha: string,
-  repoPath: string,
-): string =>
-  `${githubRawBase()}/${template.source.owner}/${template.source.repo}/${commitSha}/${repoPath}`;
-
-/** Download a file's raw bytes, pinned to the resolved commit. */
-export const fetchFileBytes = async (
-  template: BootstrapTemplate,
-  commitSha: string,
-  repoPath: string,
-): Promise<Buffer> => {
-  const url = rawUrl(template, commitSha, repoPath);
-  try {
-    const res = await axios.get<ArrayBuffer>(url, {
-      responseType: 'arraybuffer',
-      headers: rawHeaders(),
-    });
-    return Buffer.from(res.data);
-  } catch (err) {
-    throw friendlyGithubError(err, url);
-  }
-};
-
-/**
- * Read a symlink's target. In a git blob a symlink is stored as a regular file
- * whose contents are the (relative) link target, so the raw bytes are exactly
- * the string we pass to `symlink(2)`.
- */
-export const fetchSymlinkTarget = async (
-  template: BootstrapTemplate,
-  commitSha: string,
-  repoPath: string,
-): Promise<string> => {
-  const bytes = await fetchFileBytes(template, commitSha, repoPath);
-  return bytes.toString('utf8');
+  return files;
 };


### PR DESCRIPTION
## Problem

`neon bootstrap` failed with **`GitHub API rate limit exceeded`** — often on the first run on shared/corporate networks:

```
INFO: Fetching template "ai-sdk" from GitHub…
ERROR: GitHub API rate limit exceeded. Set a GITHUB_TOKEN environment variable to raise the limit, then retry.
```

Root cause: `resolveTemplate` used the GitHub **REST API** (`/repos/.../commits/<ref>` + `/git/trees/<sha>?recursive=1`) to enumerate files, then fetched each file from raw.githubusercontent. The REST API is capped at **60 requests/hour for unauthenticated callers, counted per source IP** — so behind NAT/VPN the budget is shared with everyone and is trivially exhausted, with no token set. (Note: the manifest fetch worked; the picker showed all templates — the failure was purely the REST tree-walk.)

## Fix

Download the repo as a **single gzipped tarball from `codeload.github.com`** (`/<owner>/<repo>/tar.gz/<ref>`), gunzip it with `fflate` (already a dependency), and extract just the requested subdirectory in-house. codeload is unauthenticated and **not** subject to the REST API's hourly limit — this is what `degit` / `create-next-app` do. No token, no proxy, no infra.

- `2 + N` requests → **1**. The whole subtree arrives atomically (no mid-copy mismatch), so commit-sha pinning is no longer needed.
- New dependency-free **tar parser**: handles the ustar `prefix` field, pax `x`/`g` extended headers (long paths/links), and GNU `L`/`K` long-name headers; preserves exec bits and symlinks.
- **Manifest resilience**: fetch from `neon.com` first → raw GitHub copy → built-in list. The built-in fallback now includes the full starter set (hono, ai-sdk, mastra).
- Still forwards `GITHUB_TOKEN`/`GH_TOKEN` when present (proxies / future private repos).

The `neondatabase/examples` tarball is ~1.1 MB gzipped, so the whole-repo download is sub-second.

## Tests

- Rewrote the e2e test to serve a real gzipped tarball from a local codeload-shaped endpoint — the full download → gunzip → extract → write path runs with no mocking of our own code (files, exec bits, symlinks, sibling-example filtering).
- New unit tests for `parseTar` (incl. pax long path/linkpath) and `selectTemplateFiles`.
- `pnpm lint` (typecheck + eslint + prettier) clean; 28 bootstrap tests pass.

## Merge order

Independent and safe to merge alone (manifest resolution falls back to raw GitHub, so it does not depend on the website PR). Recommended: merge + publish this **first**, then neon-pkgs (which pins `neonctl@latest`). Website manifest PR can land anytime.