### PR TITLE
chore(functions): stop emitting source maps for deployed bundles

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -667,9 +667,8 @@ const writeBundle = async (
 ): Promise<string> => {
   const files = await bundleEntry(source);
   mkdirSync(bundleDir, { recursive: true });
-  // bundleEntry emits `index.mjs` (+ `index.mjs.map`). The `.mjs` extension makes Node load
-  // it as ESM directly, so no `package.json` `"type": "module"` marker is needed, and esbuild
-  // points the sourcemap link at `index.mjs.map` for us.
+  // bundleEntry emits a single `index.mjs` (no source map). The `.mjs` extension makes Node
+  // load it as ESM directly, so no `package.json` `"type": "module"` marker is needed.
   for (const [name, contents] of Object.entries(files)) {
     writeFileSync(join(bundleDir, name), contents);
   }

--- a/src/utils/esbuild.test.ts
+++ b/src/utils/esbuild.test.ts
@@ -57,13 +57,15 @@ afterAll(() => {
 });
 
 describe('bundleEntry', () => {
-  test('inlines local imports and emits a linked sourcemap', async () => {
+  test('inlines local imports and emits no sourcemap', async () => {
     const out = await bundleEntry(join(dir, 'index.ts'), npmDeps);
     const js = strFromU8(out['index.mjs']);
     expect(js).toContain('hi from helper');
     expect(js).not.toContain('./helper');
-    expect(js).toContain('sourceMappingURL=index.mjs.map');
-    expect(out['index.mjs.map'].length).toBeGreaterThan(0);
+    // No source map is generated — the Functions runtime never consumes it, so we neither
+    // emit `index.mjs.map` nor leave a dangling `sourceMappingURL` link in the bundle.
+    expect(js).not.toContain('sourceMappingURL');
+    expect(out['index.mjs.map']).toBeUndefined();
   });
 
   // Node built-ins stay external on platform:'node'; the createRequire banner is injected

--- a/src/utils/esbuild.ts
+++ b/src/utils/esbuild.ts
@@ -84,7 +84,6 @@ const bundleViaModule = async (
       // output as a module without needing a `package.json` type marker alongside it.
       outfile: 'index.mjs',
       write: false,
-      sourcemap: true,
       minify: true,
       format: 'esm',
       platform: 'node',
@@ -100,8 +99,8 @@ const bundleViaModule = async (
       );
     });
   const files = result.outputFiles ?? [];
-  // write:false with one entry always yields index.mjs + index.mjs.map; an empty set
-  // means the API contract changed under us — fail loud rather than ship an
+  // write:false with one entry always yields index.mjs (no source map — we don't emit one);
+  // an empty set means the API contract changed under us — fail loud rather than ship an
   // empty archive.
   if (files.length === 0) {
     throw new Error(
@@ -158,7 +157,6 @@ const bundleViaBinary = async (
       source,
       '--bundle',
       `--outfile=${outfile}`,
-      '--sourcemap',
       '--minify',
       '--format=esm',
       '--platform=node',
@@ -170,9 +168,10 @@ const bundleViaBinary = async (
         `Failed to bundle function from ${source}. ${stderr.trim()}`.trim(),
       );
     }
+    // No `--sourcemap`: the Functions runtime has no source-map support, so an uploaded
+    // `index.mjs.map` is never consumed — emitting it only inflated the archive.
     return {
       'index.mjs': new Uint8Array(readFileSync(outfile)),
-      'index.mjs.map': new Uint8Array(readFileSync(`${outfile}.map`)),
     };
   } finally {
     rmSync(outDir, { recursive: true, force: true });

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -1,6 +1,6 @@
 import { zipSync } from 'fflate';
 
-// Zip the esbuild output (index.mjs + index.mjs.map) into the archive the Functions
-// deploy endpoint expects. Compression level 6 matches the previous bundler.
+// Zip the esbuild output (index.mjs) into the archive the Functions deploy endpoint
+// expects. Compression level 6 matches the previous bundler.
 export const zipBundle = (entries: Record<string, Uint8Array>): Uint8Array =>
   zipSync(entries, { level: 6 });


### PR DESCRIPTION
## Summary

The function bundler emits a source map (`index.mjs.map`) into every deploy archive, but the Neon Functions runtime does **not** run Node with source-map support. So the uploaded map is never consumed — a thrown error's stack still points into the minified `index.mjs`. It only inflates the uploaded/stored archive (and cold-start payload) with no debugging benefit today.

This drops source-map generation from both bundling paths:

- In-process esbuild module path: removed `sourcemap: true`.
- Packaged binary path: removed `--sourcemap` and stopped reading/zipping `index.mjs.map`.
- Updated `zip.ts` / `dev.ts` comments and the `esbuild.test.ts` expectations (now asserts no `sourceMappingURL` link and no `index.mjs.map`).

Note: this also affects `neon dev`, but that path spawns the bundle without `--enable-source-maps` either, so no remapping was happening there today.

If/when the runtime gains source-map support, re-enabling is a one-line change (and we'd likely add `sourcesContent: false` to keep the map small).

## Test plan

- [x] `vitest run src/utils/esbuild.test.ts` (6 passed)
- [x] `vitest run src/commands/functions.test.ts src/commands/config.test.ts` (52 passed)
- [ ] Deploy a function and confirm the archive contains only `index.mjs`