### PR TITLE
feat: show the target branch before config / env pull / checkout act on it

### DIFF
--- a/src/commands/__snapshots__/checkout.test.ts.snap
+++ b/src/commands/__snapshots__/checkout.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`checkout > announces the branch currently pinned before switching to a new one 1`] = `""`;
+
 exports[`checkout > auto-detects the project when the API key maps to a single project 1`] = `""`;
 
 exports[`checkout > errors when a branch id is not found (ids are never auto-created) 1`] = `""`;

--- a/src/commands/checkout.test.ts
+++ b/src/commands/checkout.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 
 import { test as originalTest } from '../test_utils/fixtures';
+import { ENV_PULL_SKIPPED_HINT } from './env';
 
 // All tests in this file share a single temporary directory whose path is
 // normalized in snapshots to `<TMP>` so absolute paths in command output stay
@@ -74,6 +75,30 @@ describe('checkout', () => {
       projectId: 'test',
       branch: 'main',
     });
+  });
+
+  test('announces the branch currently pinned before switching to a new one', async ({
+    testCliCommand,
+    removeFile,
+    tmpContext,
+  }) => {
+    // A `.neon` already pinned to `main`: checkout should report where we are
+    // ("Currently on branch main") before it pins the new branch, so the switch
+    // is visible and a wrong checkout is easy to spot.
+    const ctx = tmpContext('announce_current', {
+      projectId: 'test',
+      branch: 'main',
+    });
+    await testCliCommand(
+      ['checkout', 'test_branch', '--no-env-pull', '--context-file', ctx],
+      {
+        stderr:
+          `INFO: → Currently on branch main ` +
+          `INFO: Checked out branch br-sunny-branch-123456 on project test. Updated ${ctx}. ` +
+          `INFO: ${ENV_PULL_SKIPPED_HINT}`,
+      },
+    );
+    removeFile(ctx);
   });
 
   test('resolves a branch by id and writes the branch name to a fresh .neon', async ({

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -1,9 +1,10 @@
 import { Branch } from '@neondatabase/api-client';
 import { isAxiosError } from 'axios';
+import chalk from 'chalk';
 import prompts from 'prompts';
 import yargs from 'yargs';
 
-import { applyContext, readContextFile } from '../context.js';
+import { applyContext, contextBranch, readContextFile } from '../context.js';
 import { isCi } from '../env.js';
 import { log } from '../log.js';
 import { CommonProps } from '../types.js';
@@ -71,6 +72,18 @@ export const builder = (argv: yargs.Argv) =>
     ]);
 
 export const handler = async (props: CheckoutProps) => {
+  // Show where the context is pinned *before* we switch it, so the user sees the move
+  // ("currently on X" → "checked out Y") and can catch a checkout they didn't mean to make.
+  // Read straight from `.neon` (a name, no API call); silent when nothing is pinned yet.
+  const previousBranch = contextBranch(readContextFile(props.contextFile));
+  if (previousBranch) {
+    log.info(
+      '%s Currently on branch %s',
+      chalk.dim('→'),
+      chalk.cyan.bold(previousBranch),
+    );
+  }
+
   // Branch listing is project-scoped, so `projectId` is the only thing
   // `checkout` actually needs. Resolve it through the standard chain
   // (--project-id flag > .neon file > single-project auto-detect); when

--- a/src/commands/config.apihost.test.ts
+++ b/src/commands/config.apihost.test.ts
@@ -28,6 +28,13 @@ vi.mock('../utils/enrichers.js', async (importOriginal) => {
   return {
     ...actual,
     branchIdFromProps: vi.fn(() => Promise.resolve('br-test')),
+    resolveBranchRef: vi.fn(() =>
+      Promise.resolve({
+        branchId: 'br-test',
+        branchName: 'main',
+        usedDefault: false,
+      }),
+    ),
   };
 });
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,7 +17,8 @@ import { toNeonConfigView } from '../config_format.js';
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
 import { loadEnvFileIntoProcess } from '../env_file.js';
-import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+import { fillSingleProject, resolveBranchRef } from '../utils/enrichers.js';
+import { announceTargetBranch } from '../utils/branch_notice.js';
 import { bundleEntry } from '../utils/esbuild.js';
 import { zipBundle } from '../utils/zip.js';
 import { writer } from '../writer.js';
@@ -203,7 +204,13 @@ const loadConfig = async (props: ConfigProps): Promise<Config> => {
 };
 
 export const status = async (props: ConfigProps): Promise<void> => {
-  const branchId = await branchIdFromProps(props);
+  const branch = await resolveBranchRef(props);
+  // `--config-json` is a script-friendly mode that emits only JSON to stdout, so keep it
+  // pristine; the regular human view gets the "which branch am I inspecting" guardrail.
+  if (!props.configJson) {
+    announceTargetBranch(props, branch, 'Inspecting branch');
+  }
+  const branchId = branch.branchId;
   const live = await inspect({
     projectId: props.projectId,
     branchId,
@@ -243,7 +250,9 @@ export const status = async (props: ConfigProps): Promise<void> => {
 
 export const planCmd = async (props: ConfigProps): Promise<void> => {
   const config = await loadConfig(props);
-  const branchId = await branchIdFromProps(props);
+  const branch = await resolveBranchRef(props);
+  announceTargetBranch(props, branch, 'Planning against branch');
+  const branchId = branch.branchId;
   // `plan` is a dry run that never bundles, so its options don't accept (or need)
   // an injected bundler — only `apply` does (it uses neonctlBundler).
   const result = await plan(config, {
@@ -258,7 +267,9 @@ export const planCmd = async (props: ConfigProps): Promise<void> => {
 
 export const applyCmd = async (props: ConfigProps): Promise<void> => {
   const config = await loadConfig(props);
-  const branchId = await branchIdFromProps(props);
+  const branch = await resolveBranchRef(props);
+  announceTargetBranch(props, branch, 'Applying to branch');
+  const branchId = branch.branchId;
   const result = await apply(config, {
     projectId: props.projectId,
     branchId,

--- a/src/commands/env.apihost.test.ts
+++ b/src/commands/env.apihost.test.ts
@@ -16,6 +16,13 @@ vi.mock('../utils/enrichers.js', async (importOriginal) => {
   return {
     ...actual,
     branchIdFromProps: vi.fn(() => Promise.resolve('br-test')),
+    resolveBranchRef: vi.fn(() =>
+      Promise.resolve({
+        branchId: 'br-test',
+        branchName: 'main',
+        usedDefault: false,
+      }),
+    ),
   };
 });
 

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -10,7 +10,8 @@ import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
 import { resolveNeonEnvVars } from '../dev/env.js';
 import { mergeEnvFile, readEnvFile, resolveEnvFilePath } from '../env_file.js';
-import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
+import { fillSingleProject, resolveBranchRef } from '../utils/enrichers.js';
+import { announceTargetBranch } from '../utils/branch_notice.js';
 
 export type EnvPullProps = BranchScopeProps & {
   /** Target dotenv file. Defaults to an existing `.env`, else `.env.local`. */
@@ -64,7 +65,11 @@ export const builder = (argv: yargs.Argv) =>
             'Pull a specific branch into a specific file',
           ),
       async (args) => {
-        await pull(args as any);
+        // Explicit `env pull` announces the branch it's reading from up front so the user
+        // can catch "pulled env from the wrong branch" before it overwrites their .env. The
+        // bundled auto-pull (link / checkout / apply) stays quiet — those already report the
+        // branch they pinned/applied to.
+        await pull(args as any, { announce: true });
       },
     )
     .demandCommand(1);
@@ -85,9 +90,16 @@ export type PullOutcome =
   | { status: 'written'; written: string[]; file: string }
   | { status: 'empty' };
 
-export const pull = async (props: EnvPullProps): Promise<PullOutcome> => {
+export const pull = async (
+  props: EnvPullProps,
+  opts: { announce?: boolean } = {},
+): Promise<PullOutcome> => {
   const cwd = props.cwd ?? process.cwd();
-  const branchId = await branchIdFromProps(props);
+  const branch = await resolveBranchRef(props);
+  if (opts.announce) {
+    announceTargetBranch(props, branch, 'Pulling env from branch');
+  }
+  const branchId = branch.branchId;
 
   // Resolve the target file first and layer its current contents under the resolver's env
   // source. This lets `fetchEnv` reuse one-time secrets that are already on disk — Neon Auth

--- a/src/utils/branch_notice.test.ts
+++ b/src/utils/branch_notice.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import strip from 'strip-ansi';
+
+import { announceTargetBranch } from './branch_notice';
+import type { ResolvedBranchRef } from './enrichers';
+
+const ref: ResolvedBranchRef = {
+  branchId: 'br-snowy-frost-12345',
+  branchName: 'main',
+  usedDefault: false,
+};
+
+/** Capture everything written to stderr (where the notice goes), ANSI stripped. */
+const captureStderr = (): { read: () => string; restore: () => void } => {
+  let buffer = '';
+  const spy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      buffer += chunk.toString();
+      return true;
+    });
+  return {
+    read: () => strip(buffer),
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+};
+
+describe('announceTargetBranch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes a one-line notice with the verb, branch name and id (table output)', () => {
+    const { read, restore } = captureStderr();
+    announceTargetBranch({ output: 'table' }, ref, 'Planning against branch');
+    restore();
+
+    const out = read();
+    expect(out).toContain('Planning against branch');
+    expect(out).toContain('main');
+    expect(out).toContain('(br-snowy-frost-12345)');
+    // The notice is a single stderr line.
+    expect(out.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('notes when the project default branch was used as a fallback', () => {
+    const { read, restore } = captureStderr();
+    announceTargetBranch(
+      { output: 'table' },
+      { ...ref, usedDefault: true },
+      'Pulling env from branch',
+    );
+    restore();
+
+    expect(read()).toContain('project default');
+  });
+
+  it('stays silent for machine-readable output so piped stdout/stderr is clean', () => {
+    for (const output of ['json', 'yaml'] as const) {
+      const { read, restore } = captureStderr();
+      announceTargetBranch({ output }, ref, 'Inspecting branch');
+      restore();
+      expect(read()).toBe('');
+    }
+  });
+});

--- a/src/utils/branch_notice.ts
+++ b/src/utils/branch_notice.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+import { log } from '../log.js';
+import type { ResolvedBranchRef } from './enrichers.js';
+
+/**
+ * Print a one-line "this command is targeting <branch>" notice to **stderr** so
+ * the user can sanity-check they're acting on the branch they think they are —
+ * before a `status` / `plan` / `apply` / `env pull` does its work. This is the
+ * cheap guardrail that catches "I planned against the wrong branch" / "I pulled
+ * env from the wrong branch" before it bites.
+ *
+ * - Skipped for machine-readable output (`--output json|yaml`) so it never has
+ *   to be reasoned about by a script; it's stderr-only regardless, keeping
+ *   `--output table` stdout clean for piping too.
+ * - `verb` is the leading phrase, e.g. `'Planning against branch'` →
+ *   `→ Planning against branch main (br-…)`.
+ */
+export const announceTargetBranch = (
+  props: { output?: 'json' | 'yaml' | 'table' },
+  branch: ResolvedBranchRef,
+  verb: string,
+): void => {
+  if (props.output === 'json' || props.output === 'yaml') {
+    return;
+  }
+  const suffix = branch.usedDefault ? chalk.dim(' · project default') : '';
+  log.info(
+    '%s %s %s %s%s',
+    chalk.dim('→'),
+    verb,
+    chalk.cyan.bold(branch.branchName),
+    chalk.dim(`(${branch.branchId})`),
+    suffix,
+  );
+};

--- a/src/utils/enrichers.test.ts
+++ b/src/utils/enrichers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBranchRef } from './enrichers';
+import type { BranchScopeProps } from '../types';
+
+const BRANCHES = [
+  { id: 'br-main-branch-000001', name: 'main', default: true },
+  { id: 'br-feature-branch-000002', name: 'feature', default: false },
+];
+
+/** Minimal Api client stand-in: only `listProjectBranches` is exercised. */
+const apiClient = {
+  listProjectBranches: () => Promise.resolve({ data: { branches: BRANCHES } }),
+} as never;
+
+const props = (
+  branch: Partial<{ branch: string; id: string }>,
+): BranchScopeProps =>
+  ({
+    apiClient,
+    apiKey: '',
+    apiHost: '',
+    output: 'table',
+    contextFile: '',
+    projectId: 'test',
+    ...branch,
+  }) as BranchScopeProps;
+
+describe('resolveBranchRef', () => {
+  it('resolves a branch by name to its id, carrying the name back', async () => {
+    expect(await resolveBranchRef(props({ branch: 'feature' }))).toEqual({
+      branchId: 'br-feature-branch-000002',
+      branchName: 'feature',
+      usedDefault: false,
+    });
+  });
+
+  it('resolves a branch by id and looks up its friendly name', async () => {
+    expect(
+      await resolveBranchRef(props({ branch: 'br-feature-branch-000002' })),
+    ).toEqual({
+      branchId: 'br-feature-branch-000002',
+      branchName: 'feature',
+      usedDefault: false,
+    });
+  });
+
+  it('reads the branch from the `id` positional when no `branch` is set', async () => {
+    expect(await resolveBranchRef(props({ id: 'feature' }))).toEqual({
+      branchId: 'br-feature-branch-000002',
+      branchName: 'feature',
+      usedDefault: false,
+    });
+  });
+
+  it('trusts a br- id the listing does not return (no friendlier name)', async () => {
+    expect(
+      await resolveBranchRef(props({ branch: 'br-unknown-branch-999999' })),
+    ).toEqual({
+      branchId: 'br-unknown-branch-999999',
+      branchName: 'br-unknown-branch-999999',
+      usedDefault: false,
+    });
+  });
+
+  it('falls back to the project default branch when none is specified', async () => {
+    expect(await resolveBranchRef(props({}))).toEqual({
+      branchId: 'br-main-branch-000001',
+      branchName: 'main',
+      usedDefault: true,
+    });
+  });
+
+  it('throws a helpful error when a branch name does not resolve', async () => {
+    await expect(resolveBranchRef(props({ branch: 'nope' }))).rejects.toThrow(
+      /Branch nope not found.*Available branches: main, feature/s,
+    );
+  });
+});

--- a/src/utils/enrichers.ts
+++ b/src/utils/enrichers.ts
@@ -62,6 +62,75 @@ export const branchIdFromProps = async (props: BranchScopeProps) => {
   return (props as any).branchId;
 };
 
+/**
+ * The branch a command is about to act on, resolved to **both** its id and its
+ * human-readable name so callers can confirm the target to the user (see
+ * {@link announceTargetBranch}) before mutating it.
+ *
+ * Resolution mirrors {@link branchIdFromProps}: an explicit `branch`/`id`
+ * (name or `br-…` id) wins, otherwise the project's default branch is used. The
+ * difference is that this always carries the name back, so it lists the
+ * project's branches even for a `br-…` id (to look up the name). A `br-…` id the
+ * listing doesn't return is still trusted as an id (matching `branchIdResolve`),
+ * just with no friendlier name to show; a *name* that doesn't resolve is the
+ * same hard error as before.
+ */
+export type ResolvedBranchRef = {
+  branchId: string;
+  /** Friendly branch name when known, otherwise the id. */
+  branchName: string;
+  /** True when no branch was specified and the project's default was used. */
+  usedDefault: boolean;
+};
+
+export const resolveBranchRef = async (
+  props: BranchScopeProps,
+): Promise<ResolvedBranchRef> => {
+  const branch =
+    'branch' in props && typeof props.branch === 'string'
+      ? props.branch
+      : (props as any).id;
+
+  const { data } = await props.apiClient.listProjectBranches({
+    projectId: props.projectId,
+  });
+  const branches = data.branches;
+
+  if (branch) {
+    const ref = branch.toString();
+    const found = looksLikeBranchId(ref)
+      ? branches.find((b: Branch) => b.id === ref)
+      : branches.find((b: Branch) => b.name === ref);
+    if (found) {
+      return {
+        branchId: found.id,
+        branchName: found.name ?? found.id,
+        usedDefault: false,
+      };
+    }
+    // A `br-…` id absent from the listing is still usable as an id (trust it like
+    // branchIdResolve does); only an unresolved *name* is a genuine error.
+    if (looksLikeBranchId(ref)) {
+      return { branchId: ref, branchName: ref, usedDefault: false };
+    }
+    throw new Error(
+      `Branch ${ref} not found.\nAvailable branches: ${branches
+        .map((b: Branch) => b.name)
+        .join(', ')}`,
+    );
+  }
+
+  const defaultBranch = branches.find((b: Branch) => b.default);
+  if (!defaultBranch) {
+    throw new Error('No default branch found');
+  }
+  return {
+    branchId: defaultBranch.id,
+    branchName: defaultBranch.name ?? defaultBranch.id,
+    usedDefault: true,
+  };
+};
+
 export const resolveSingleDatabase = async (props: {
   apiClient: CommonProps['apiClient'];
   projectId: string;


### PR DESCRIPTION
## Summary

Adds a lightweight "which branch am I acting on?" guardrail to the branch-mutating / branch-reading commands, so it's easy to catch a wrong-branch operation *before* it happens.

- **`config status | plan | apply`** (and **`deploy`**, which aliases `apply`) print a one-line notice naming the branch they're about to inspect / plan against / apply to:
  - `→ Inspecting branch main (br-…)`
  - `→ Planning against branch main (br-…)`
  - `→ Applying to branch main (br-…)`
- **`env pull`** prints `→ Pulling env from branch main (br-…)` before it writes your `.env`.
- **`checkout`** prints `→ Currently on branch <name>` (read straight from `.neon`, no API call) *before* it switches, so the move is visible.

### Behaviour / DX notes
- The notice goes to **stderr** and is **skipped for `--output json|yaml`**, so piped/scripted stdout stays clean.
- When no branch is specified and the project default is used, the notice appends `· project default`.
- The **bundled** auto env-pull that `link` / `checkout` / `apply` run stays quiet — those already report the branch they pinned/applied to. Only an **explicit** `neonctl env pull` announces.

### Implementation
- New `resolveBranchRef` enricher resolves a branch to **both** its id and friendly name in a single `listProjectBranches` call (mirrors `branchIdFromProps`, but carries the name back for display; trusts an unlisted `br-…` id like `branchIdResolve` does).
- New `announceTargetBranch` UI helper renders the stderr notice (chalk, output-gated).

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint` (typecheck + eslint + prettier)
- [x] `pnpm test` — 2953 passed / 7 skipped
- [x] New unit tests: `resolveBranchRef` (by name / id / positional / unlisted-id / default / not-found) and `announceTargetBranch` (renders, default suffix, silent for json/yaml)
- [x] New `checkout` e2e test asserting the "Currently on branch" line precedes the checkout
- [x] Updated `config.apihost` / `env.apihost` mocks for the new resolver