### PR TITLE
fix(env): prune stale Neon-owned vars on env pull

### DIFF
--- a/src/commands/env.test.ts
+++ b/src/commands/env.test.ts
@@ -277,6 +277,39 @@ describe('env pull', () => {
     const content = readFileSync(join(cwd, '.env.preview'), 'utf8');
     expect(content).toMatch(/^DATABASE_URL=/m);
   });
+
+  it('prunes stale NEON_AUTH_* / NEON_DATA_API_* left from a prior project (Auth/Data API off)', async () => {
+    // A .env.local carried over from a project/branch that *had* Auth + the Data API
+    // enabled. The current branch (FakeNeonApi default) has neither, so a pull must drop the
+    // now-stale vars instead of leaving credentials for features that aren't enabled.
+    writeFileSync(
+      join(cwd, '.env.local'),
+      [
+        'APP_NAME=demo',
+        'DATABASE_URL=postgres://stale',
+        'NEON_AUTH_BASE_URL=https://stale.neonauth.example/db/auth',
+        'NEON_AUTH_JWKS_URL=https://stale.neonauth.example/db/auth/.well-known/jwks.json',
+        'NEON_DATA_API_URL=https://stale.apirest.example/db/rest/v1',
+        '',
+      ].join('\n'),
+    );
+
+    const result = await pull(baseProps(new FakeNeonApi(), cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    // The user's own line and the (refreshed) Postgres URLs survive…
+    expect(content).toContain('APP_NAME=demo');
+    expect(content).toMatch(/^DATABASE_URL=/m);
+    expect(content).not.toContain('postgres://stale');
+    // …but the stale Auth / Data API vars are gone.
+    expect(content).not.toContain('NEON_AUTH_BASE_URL');
+    expect(content).not.toContain('NEON_AUTH_JWKS_URL');
+    expect(content).not.toContain('NEON_DATA_API_URL');
+    expect(result.status).toBe('written');
+    if (result.status === 'written') {
+      expect(result.written).toContain('DATABASE_URL');
+    }
+  });
 });
 
 /**

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -82,6 +82,29 @@ const NEON_VAR_NAMES = Object.values(NEON_ENV_VAR_KEYS).flatMap((group) =>
 );
 
 /**
+ * The Neon env vars `env pull` *owns*, so it removes any that the branch no longer has when
+ * it reconciles the local `.env` (see {@link pull}). Scoped to the unambiguously Neon-named
+ * vars — the `NEON_*` aliases plus `DATABASE_URL[_UNPOOLED]` — so switching a working
+ * directory to a project/branch without Auth / the Data API drops the now-stale
+ * `NEON_AUTH_*` / `NEON_DATA_API_*` lines instead of leaving credentials for features that
+ * aren't enabled.
+ *
+ * Deliberately **excludes** the storage / AI Gateway vars Neon projects onto third-party SDK
+ * names (`AWS_*`, `OPENAI_*`): those collide with credentials a user may set by hand, so
+ * `env pull` only ever writes them, never prunes them. (Their Neon-branded siblings —
+ * `NEON_STORAGE_*` / `NEON_AI_GATEWAY_*` — are owned and pruned.)
+ */
+const NEON_OWNED_ENV_KEYS: readonly string[] = [
+  ...Object.values(NEON_ENV_VAR_KEYS.postgres),
+  ...Object.values(NEON_ENV_VAR_KEYS.auth),
+  ...Object.values(NEON_ENV_VAR_KEYS.dataApi),
+  NEON_ENV_VAR_KEYS.storage.regionNeon,
+  NEON_ENV_VAR_KEYS.storage.forcePathStyle,
+  NEON_ENV_VAR_KEYS.aiGateway.neonToken,
+  NEON_ENV_VAR_KEYS.aiGateway.neonBaseUrl,
+];
+
+/**
  * What an env pull actually did, so callers (notably `link --agent`) can report it precisely
  * instead of guessing. `written` lists the keys merged into `file`; `empty` means the branch
  * has no Neon vars to pull yet (no DATABASE_URL / Auth / Data API).
@@ -130,7 +153,12 @@ export const pull = async (
     return { status: 'empty' };
   }
 
-  const { written } = mergeEnvFile(targetPath, neonVars);
+  // Reconcile rather than blindly merge: write the branch's current Neon vars and prune any
+  // Neon-owned vars the branch no longer has (e.g. NEON_AUTH_* / NEON_DATA_API_* carried over
+  // from a previous project/branch). Non-Neon lines are always preserved.
+  const { written, removed } = mergeEnvFile(targetPath, neonVars, {
+    managedKeys: NEON_OWNED_ENV_KEYS,
+  });
   log.info(
     'Pulled %d Neon variable%s into %s: %s',
     written.length,
@@ -138,6 +166,14 @@ export const pull = async (
     targetPath,
     written.join(', '),
   );
+  if (removed.length > 0) {
+    log.info(
+      'Removed %d stale Neon variable%s not enabled on this branch: %s',
+      removed.length,
+      removed.length === 1 ? '' : 's',
+      removed.join(', '),
+    );
+  }
   return { status: 'written', written, file: targetPath };
 };
 

--- a/src/env_file.test.ts
+++ b/src/env_file.test.ts
@@ -86,6 +86,64 @@ describe('mergeEnvContent', () => {
     const second = mergeEnvContent(first, { B: '2' }).content;
     expect(second).toBe('A=1\nB=2\n');
   });
+
+  it('prunes managed keys absent from updates, keeping unmanaged lines', () => {
+    const original = [
+      '# app',
+      'APP_NAME=demo',
+      'DATABASE_URL=postgres://old',
+      'NEON_AUTH_BASE_URL=https://stale-auth',
+      'NEON_AUTH_JWKS_URL=https://stale-auth/jwks',
+      'NEON_DATA_API_URL=https://stale-data-api',
+      '',
+    ].join('\n');
+    const { content, written, removed } = mergeEnvContent(
+      original,
+      { DATABASE_URL: 'postgres://new' },
+      {
+        managedKeys: [
+          'DATABASE_URL',
+          'NEON_AUTH_BASE_URL',
+          'NEON_AUTH_JWKS_URL',
+          'NEON_DATA_API_URL',
+        ],
+      },
+    );
+    // The owned auth / data-api vars not in the pull are dropped; the user's own lines stay.
+    expect(content).toBe(
+      ['# app', 'APP_NAME=demo', 'DATABASE_URL=postgres://new'].join('\n') +
+        '\n',
+    );
+    expect(written).toEqual(['DATABASE_URL']);
+    expect(removed).toEqual([
+      'NEON_AUTH_BASE_URL',
+      'NEON_AUTH_JWKS_URL',
+      'NEON_DATA_API_URL',
+    ]);
+  });
+
+  it('never prunes a key outside managedKeys even when absent from updates', () => {
+    const original =
+      'OPENAI_API_KEY=user-own-key\nDATABASE_URL=postgres://old\n';
+    const { content, removed } = mergeEnvContent(
+      original,
+      { DATABASE_URL: 'postgres://new' },
+      // OPENAI_API_KEY is intentionally NOT owned (it collides with the user's own key).
+      { managedKeys: ['DATABASE_URL', 'NEON_AUTH_BASE_URL'] },
+    );
+    expect(content).toContain('OPENAI_API_KEY=user-own-key');
+    expect(removed).toEqual([]);
+  });
+
+  it('prunes managed keys even when updates is empty', () => {
+    const { content, removed } = mergeEnvContent(
+      'KEEP=1\nNEON_DATA_API_URL=https://stale\n',
+      {},
+      { managedKeys: ['NEON_DATA_API_URL'] },
+    );
+    expect(content).toBe('KEEP=1\n');
+    expect(removed).toEqual(['NEON_DATA_API_URL']);
+  });
 });
 
 describe('resolveEnvFilePath', () => {

--- a/src/env_file.ts
+++ b/src/env_file.ts
@@ -13,46 +13,83 @@ export const resolveEnvFilePath = (cwd: string, file?: string): string => {
 };
 
 /**
+ * Options for {@link mergeEnvFile} / {@link mergeEnvContent}.
+ */
+export type MergeEnvOptions = {
+  /**
+   * Keys the writer *owns*, so any that appear on disk but are absent from `updates` are
+   * removed (rather than preserved). Used by `env pull` to prune Neon-managed vars the
+   * branch no longer has — e.g. `NEON_AUTH_*` / `NEON_DATA_API_*` left behind after the
+   * working directory is pointed at a project/branch without those features. Keys outside
+   * this set are always preserved, so a user's own lines are never touched.
+   */
+  managedKeys?: Iterable<string>;
+};
+
+/**
  * Merge `updates` into the dotenv content at `path`, preserving every other line
  * (comments, blank lines, unrelated keys) and the file's existing order. Keys present in
  * both are updated in place; keys only in `updates` are appended. A non-existent file is
- * treated as empty. Returns the list of keys that were written (for reporting).
+ * treated as empty. When `managedKeys` is given, any owned key on disk that is absent from
+ * `updates` is removed. Returns the keys written and the (managed) keys removed.
  */
 export const mergeEnvFile = (
   path: string,
   updates: Record<string, string>,
-): { written: string[] } => {
+  options: MergeEnvOptions = {},
+): { written: string[]; removed: string[] } => {
   const original = existsSync(path) ? readFileSync(path, 'utf8') : '';
-  const { content, written } = mergeEnvContent(original, updates);
+  const { content, written, removed } = mergeEnvContent(
+    original,
+    updates,
+    options,
+  );
   writeFileSync(path, content);
-  return { written };
+  return { written, removed };
 };
 
 /**
  * Pure core of {@link mergeEnvFile}: takes the current file content and the updates, and
- * returns the new content plus which keys were written. Kept side-effect-free so it can be
- * unit-tested without touching the filesystem.
+ * returns the new content plus which keys were written / removed. Kept side-effect-free so
+ * it can be unit-tested without touching the filesystem.
  */
 export const mergeEnvContent = (
   original: string,
   updates: Record<string, string>,
-): { content: string; written: string[] } => {
+  options: MergeEnvOptions = {},
+): { content: string; written: string[]; removed: string[] } => {
   const keys = Object.keys(updates);
-  if (keys.length === 0) return { content: original, written: [] };
+
+  // Owned keys the current pull did not produce: stale Neon-managed vars to prune. Anything
+  // not in `managedKeys` is always kept, so a user's own lines are never removed.
+  const stale = new Set(
+    [...(options.managedKeys ?? [])].filter((key) => !(key in updates)),
+  );
+
+  if (keys.length === 0 && stale.size === 0) {
+    return { content: original, written: [], removed: [] };
+  }
 
   const remaining = new Set(keys);
+  const removed: string[] = [];
   const lines = original === '' ? [] : original.split('\n');
 
-  // Update keys in place where they already appear, so their position and any surrounding
-  // comments are preserved.
-  const updatedLines = lines.map((line) => {
+  // Walk the file: drop stale owned lines, update existing keys in place (so their position
+  // and any surrounding comments are preserved), and pass everything else through untouched.
+  const updatedLines: string[] = [];
+  for (const line of lines) {
     const key = parseKey(line);
+    if (key !== null && stale.has(key)) {
+      removed.push(key);
+      continue;
+    }
     if (key !== null && remaining.has(key)) {
       remaining.delete(key);
-      return formatLine(key, updates[key]);
+      updatedLines.push(formatLine(key, updates[key]));
+      continue;
     }
-    return line;
-  });
+    updatedLines.push(line);
+  }
 
   // Append keys that weren't already present, in the order they were given.
   const appended = keys
@@ -65,6 +102,7 @@ export const mergeEnvContent = (
     // A dotenv file ends with a trailing newline.
     content: content === '' ? '' : `${content}\n`,
     written: keys,
+    removed,
   };
 };
 


### PR DESCRIPTION
## Summary

`neonctl env pull` *merged* the branch's current Neon vars into the local `.env` but never *removed* Neon-managed vars the branch no longer has. Pointing a working directory at a project/branch **without** Neon Auth / the Data API left behind the previous project's `NEON_AUTH_BASE_URL`, `NEON_AUTH_JWKS_URL`, and `NEON_DATA_API_URL` lines — so the `.env` ended up holding credentials (pointing at a foreign endpoint) for features that aren't even enabled on the target branch.

This was reproducible by pulling a project with Auth + Data API enabled into a directory, then pulling a fresh project (default branch, neither feature enabled) into the same directory: the stale `NEON_AUTH_*` / `NEON_DATA_API_*` lines survived.

### Fix

`env pull` now **reconciles** instead of blindly merging:

- Writes the branch's current Neon vars (as before).
- Drops any **Neon-owned** var that the pull did not produce — the `NEON_*` aliases plus `DATABASE_URL[_UNPOOLED]`.
- Preserves every non-Neon line (comments, blank lines, the user's own keys).

The merge core (`mergeEnvContent` / `mergeEnvFile`) gained an optional `managedKeys` set; keys outside it are never touched.

The `AWS_*` / `OPENAI_*` names Neon shares with the AWS / OpenAI SDKs are intentionally **write-only** (never pruned), since they collide with credentials a user may set by hand. Their Neon-branded siblings (`NEON_STORAGE_*` / `NEON_AI_GATEWAY_*`) are owned and pruned.

When stale vars are removed, the pull reports them: `Removed N stale Neon variables not enabled on this branch: …`.

## Test plan

- [x] `mergeEnvContent` unit tests: prunes managed keys absent from updates, keeps unmanaged lines, never prunes keys outside `managedKeys` (e.g. a user's own `OPENAI_API_KEY`), and prunes even when `updates` is empty.
- [x] `env pull` regression test: a `.env.local` carrying `NEON_AUTH_*` / `NEON_DATA_API_*` from a prior project is reconciled against a branch with neither feature — the stale vars are dropped, the user's own lines and refreshed `DATABASE_URL` survive.
- [x] `pnpm typecheck`, eslint, prettier all clean.