### PR TITLE
fix(config): keep the changes table from overflowing on function URLs

### DIFF
--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -502,13 +502,12 @@ describe('config commands', () => {
     );
   });
 
-  it('keeps the changes table narrow: function details are summarized, never raw JSON with the invocation URL (regression)', async () => {
-    // Regression: the deployed-function change details carry a long `invocationUrl`.
-    // We used to JSON.stringify the whole details object into the changes table's
-    // "Details" column, which blew the ASCII table out to ~190 columns so its borders
-    // wrapped and misaligned in a normal terminal. The URL is already surfaced in the
-    // dedicated "Function URLs" table, so the changes table must show a compact summary
-    // (and never the raw JSON / URL).
+  it('keeps the changes table minimal and lists function URLs out of the table (regression)', async () => {
+    // Regression: a deployed function's change details carry a long `invocationUrl`. We used
+    // to JSON.stringify the whole details object into a "Details" table column, which blew the
+    // ASCII table out to ~190 columns so its borders wrapped and misaligned in a normal
+    // terminal. The changes table is now minimal (action/kind/identifier only) and the URLs
+    // are printed as a plain list below it, so nothing long ever lands in a table cell.
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();
 
@@ -525,28 +524,22 @@ describe('config commands', () => {
 
     await applyCmd({ ...baseProps(api, stream), output: 'table', config });
 
-    const out = read();
+    const out = stripAnsi(read());
     const invocationUrl = `https://${BRANCH_ID}.fake.neon.tech/functions/hello`;
 
-    // The compact summary is present in the changes table…
-    expect(out).toContain('runtime=nodejs24');
-    // …but never the raw JSON blob that caused the blow-up…
-    expect(out).not.toContain('{"slug"');
-    expect(out).not.toContain('"invocationUrl"');
-
-    // The URL lives only in the dedicated Function URLs table, not in the changes table.
+    // The changes table never carries a Details column or the raw details blob.
     const [appliedSection, functionSection = ''] = out.split('Function URLs');
     expect(appliedSection).toContain('Applied changes');
+    expect(appliedSection).not.toContain('Details');
+    expect(appliedSection).not.toContain('{"slug"');
     expect(appliedSection).not.toContain(invocationUrl);
-    expect(functionSection).toContain(invocationUrl);
+
+    // The URL is listed (not tabulated) below, as a copy-pasteable bullet.
+    expect(functionSection).toContain(`• hello: ${invocationUrl}`);
 
     // No rendered line is absurdly wide. Pre-fix the function detail row was ~190 cols;
     // a 120-col ceiling fails loudly if a long value ever leaks back into a table cell.
-    const widest = Math.max(
-      ...stripAnsi(out)
-        .split('\n')
-        .map((line) => line.length),
-    );
+    const widest = Math.max(...out.split('\n').map((line) => line.length));
     expect(widest).toBeLessThan(120);
   });
 

--- a/src/commands/config.test.ts
+++ b/src/commands/config.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import stripAnsi from 'strip-ansi';
 import type { NeonApi } from '@neondatabase/config-runtime';
 import type {
   CreateBucketInput,
@@ -499,6 +500,54 @@ describe('config commands', () => {
     expect(out).toContain(
       `https://${BRANCH_ID}.fake.neon.tech/functions/hello`,
     );
+  });
+
+  it('keeps the changes table narrow: function details are summarized, never raw JSON with the invocation URL (regression)', async () => {
+    // Regression: the deployed-function change details carry a long `invocationUrl`.
+    // We used to JSON.stringify the whole details object into the changes table's
+    // "Details" column, which blew the ASCII table out to ~190 columns so its borders
+    // wrapped and misaligned in a normal terminal. The URL is already surfaced in the
+    // dedicated "Function URLs" table, so the changes table must show a compact summary
+    // (and never the raw JSON / URL).
+    const api = new FakeNeonApi();
+    const { stream, read } = captureOut();
+
+    const source = join(cwd, 'hello.ts');
+    writeFileSync(
+      source,
+      "export default { fetch() { return new Response('ok'); } };\n",
+    );
+    const config = writeConfig(
+      `export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
+        source,
+      )} } } } };\n`,
+    );
+
+    await applyCmd({ ...baseProps(api, stream), output: 'table', config });
+
+    const out = read();
+    const invocationUrl = `https://${BRANCH_ID}.fake.neon.tech/functions/hello`;
+
+    // The compact summary is present in the changes table…
+    expect(out).toContain('runtime=nodejs24');
+    // …but never the raw JSON blob that caused the blow-up…
+    expect(out).not.toContain('{"slug"');
+    expect(out).not.toContain('"invocationUrl"');
+
+    // The URL lives only in the dedicated Function URLs table, not in the changes table.
+    const [appliedSection, functionSection = ''] = out.split('Function URLs');
+    expect(appliedSection).toContain('Applied changes');
+    expect(appliedSection).not.toContain(invocationUrl);
+    expect(functionSection).toContain(invocationUrl);
+
+    // No rendered line is absurdly wide. Pre-fix the function detail row was ~190 cols;
+    // a 120-col ceiling fails loudly if a long value ever leaks back into a table cell.
+    const widest = Math.max(
+      ...stripAnsi(out)
+        .split('\n')
+        .map((line) => line.length),
+    );
+    expect(widest).toBeLessThan(120);
   });
 
   it('reports the services a policy utilizes (Postgres always on) in the plan output', async () => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -353,7 +353,7 @@ const reportPushResult = (
       action: change.action,
       kind: change.kind,
       identifier: change.identifier,
-      details: change.details ? JSON.stringify(change.details) : '',
+      details: summarizeChangeDetails(change.details),
     }));
   const conflicts = result.conflicts.map((conflict: ConflictReport) => ({
     identifier: conflict.identifier,
@@ -420,6 +420,45 @@ const stringify = (value: unknown): string =>
     : typeof value === 'string'
       ? value
       : JSON.stringify(value);
+
+/**
+ * Longest individual detail value we inline into the changes table. Anything longer
+ * (notably a function's `invocationUrl`, which can run ~70+ chars) is elided so a single
+ * value can never widen the ASCII table past a terminal. The full value is still available
+ * via `--output json` and, for functions, in the dedicated "Function URLs" table.
+ */
+const MAX_DETAIL_VALUE = 40;
+
+/**
+ * Render an {@link AppliedChange}'s `details` as a compact, single-line, table-safe summary
+ * — never raw JSON. Earlier we `JSON.stringify`'d the whole object into the `Details` column,
+ * but a deployed function's details carry its `invocationUrl`, so the serialized blob blew the
+ * ASCII table out to ~190 columns and the borders no longer lined up in a normal terminal.
+ *
+ * The fix keeps the table narrow by:
+ *  - only inlining scalar fields (objects/arrays are never serialized into a cell),
+ *  - eliding long values (URLs, long paths) — they live in `--output json` / the Function
+ *    URLs table — rather than letting one value dictate the table width.
+ *
+ * Example: `{slug, source, runtime, deploymentId, invocationUrl}` becomes
+ * `slug=hello, source=./hello.ts, runtime=nodejs24, deploymentId=3` (the long URL dropped).
+ */
+const summarizeChangeDetails = (
+  details: Record<string, unknown> | undefined,
+): string => {
+  if (!details) return '';
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(details)) {
+    if (value === undefined || value === null) continue;
+    // Never inline nested JSON into a cell — that's exactly what blew up the table.
+    if (typeof value === 'object') continue;
+    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    // Drop values too long to fit (URLs, long paths). They remain in --output json.
+    if (rendered.length > MAX_DETAIL_VALUE) continue;
+    parts.push(`${key}=${rendered}`);
+  }
+  return parts.join(', ');
+};
 
 /**
  * Apply a `neon.ts` policy to a **freshly created** branch (used by `neonctl checkout`

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import yargs from 'yargs';
+import chalk from 'chalk';
 import { resolveConfig } from '@neondatabase/config';
 import {
   apply,
@@ -15,6 +16,7 @@ import {
 import { toNeonConfigView } from '../config_format.js';
 
 import { log } from '../log.js';
+import { isCi } from '../env.js';
 import { BranchScopeProps } from '../types.js';
 import { loadEnvFileIntoProcess } from '../env_file.js';
 import { fillSingleProject, resolveBranchRef } from '../utils/enrichers.js';
@@ -34,8 +36,12 @@ const neonctlBundler: FunctionBundler = async (fn) =>
   zipBundle(await bundleEntry(fn.source));
 
 const INSPECT_FIELDS = ['project', 'branch', 'config'] as const;
-const APPLIED_FIELDS = ['action', 'kind', 'identifier', 'details'] as const;
-const FUNCTION_FIELDS = ['slug', 'invocation_url'] as const;
+// Deliberately minimal: action/kind/identifier are short and fixed-ish, so the table can
+// never overflow. Per-change `details` (a function's long invocationUrl in particular) are
+// intentionally NOT a column — they used to be JSON-stringified into a cell and blew the
+// table past 190 cols. Function URLs are printed below as a plain list (see reportPushResult),
+// and the full details are still available via `--output json`.
+const APPLIED_FIELDS = ['action', 'kind', 'identifier'] as const;
 const CONFLICT_FIELDS = [
   'identifier',
   'field',
@@ -353,7 +359,6 @@ const reportPushResult = (
       action: change.action,
       kind: change.kind,
       identifier: change.identifier,
-      details: summarizeChangeDetails(change.details),
     }));
   const conflicts = result.conflicts.map((conflict: ConflictReport) => ({
     identifier: conflict.identifier,
@@ -363,9 +368,9 @@ const reportPushResult = (
     reason: conflict.reason,
   }));
 
-  // Deployed functions carry their invocation URL in the change details — pull them into a
-  // dedicated table so users can see where to call each function without digging through the
-  // raw details blob. Keyed by slug so a function never shows twice.
+  // Deployed functions carry their invocation URL in the change details — collect them so
+  // we can list where to call each function without digging through the raw details blob.
+  // Keyed by slug so a function never shows twice.
   const functionUrlBySlug = new Map<string, string>();
   for (const change of result.applied) {
     if (change.action === 'noop') continue;
@@ -375,10 +380,6 @@ const reportPushResult = (
       functionUrlBySlug.set(slug, invocationUrl);
     }
   }
-  const functions = [...functionUrlBySlug].map(([slug, invocation_url]) => ({
-    slug,
-    invocation_url,
-  }));
 
   const out = writer(props);
   const noChanges = changes.length === 0 && conflicts.length === 0;
@@ -388,17 +389,23 @@ const reportPushResult = (
       title: mode === 'plan' ? 'Planned changes' : 'Applied changes',
     });
   }
-  if (functions.length > 0) {
-    out.write(functions, {
-      fields: FUNCTION_FIELDS,
-      title: mode === 'plan' ? 'Function URLs (after apply)' : 'Function URLs',
-    });
-  }
   if (conflicts.length > 0) {
     out.write(conflicts, { fields: CONFLICT_FIELDS, title: 'Conflicts' });
   }
-  // Flush any tables, then append the summary so it reads directly below them.
+  // Flush any tables, then append the lists/summary so they read directly below them.
   out.end();
+
+  // Function URLs are a plain list rather than a table: an invocation URL can be 70+ chars,
+  // which makes any bordered table overflow and wrap awkwardly in a normal terminal. A list
+  // lets each URL reflow on its own line, and stays copy-pasteable.
+  if (functionUrlBySlug.size > 0) {
+    const heading =
+      mode === 'plan' ? 'Function URLs (after apply)' : 'Function URLs';
+    out.text(`\n${isCi() ? heading : chalk.bold(heading)}\n`);
+    for (const [slug, invocationUrl] of functionUrlBySlug) {
+      out.text(`  • ${slug}: ${invocationUrl}\n`);
+    }
+  }
 
   if (noChanges) {
     log.info(
@@ -420,45 +427,6 @@ const stringify = (value: unknown): string =>
     : typeof value === 'string'
       ? value
       : JSON.stringify(value);
-
-/**
- * Longest individual detail value we inline into the changes table. Anything longer
- * (notably a function's `invocationUrl`, which can run ~70+ chars) is elided so a single
- * value can never widen the ASCII table past a terminal. The full value is still available
- * via `--output json` and, for functions, in the dedicated "Function URLs" table.
- */
-const MAX_DETAIL_VALUE = 40;
-
-/**
- * Render an {@link AppliedChange}'s `details` as a compact, single-line, table-safe summary
- * — never raw JSON. Earlier we `JSON.stringify`'d the whole object into the `Details` column,
- * but a deployed function's details carry its `invocationUrl`, so the serialized blob blew the
- * ASCII table out to ~190 columns and the borders no longer lined up in a normal terminal.
- *
- * The fix keeps the table narrow by:
- *  - only inlining scalar fields (objects/arrays are never serialized into a cell),
- *  - eliding long values (URLs, long paths) — they live in `--output json` / the Function
- *    URLs table — rather than letting one value dictate the table width.
- *
- * Example: `{slug, source, runtime, deploymentId, invocationUrl}` becomes
- * `slug=hello, source=./hello.ts, runtime=nodejs24, deploymentId=3` (the long URL dropped).
- */
-const summarizeChangeDetails = (
-  details: Record<string, unknown> | undefined,
-): string => {
-  if (!details) return '';
-  const parts: string[] = [];
-  for (const [key, value] of Object.entries(details)) {
-    if (value === undefined || value === null) continue;
-    // Never inline nested JSON into a cell — that's exactly what blew up the table.
-    if (typeof value === 'object') continue;
-    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
-    // Drop values too long to fit (URLs, long paths). They remain in --output json.
-    if (rendered.length > MAX_DETAIL_VALUE) continue;
-    parts.push(`${key}=${rendered}`);
-  }
-  return parts.join(', ');
-};
 
 /**
  * Apply a `neon.ts` policy to a **freshly created** branch (used by `neonctl checkout`


### PR DESCRIPTION
## Summary

`config plan` / `config apply` render the planned/applied changes as an ASCII table. The `Details` column was filled by `JSON.stringify`-ing the whole `AppliedChange.details` object. A **deployed function**'s details carry a long `invocationUrl`, so the serialized blob blew the table out to ~190 columns — the borders then wrapped and misaligned in any normal-width terminal (worst case: re-applying an existing function, where every row carries a URL).

Rather than try to make a bordered ASCII table reflow like the web (no lightweight lib does this well — they wrap/truncate, which mangles a URL), this keeps the output minimal:

- **Drop the `Details` column entirely.** `action` / `kind` / `identifier` is all the changes table needs, and those are short, so the table can never overflow.
- **Print function URLs as a plain list, not a table.** A bullet per function lets each URL reflow on its own line and stay copy-pasteable.

Nothing is lost — the full per-change details are still available via `--output json`.

### Before / After

![Before vs after: the Details JSON with the function invocation URL blows the changes table to ~190 cols (borders wrap and misalign); the fix drops the Details column so the table is minimal and lists function URLs as bullets below it](https://raw.githubusercontent.com/neondatabase/neonctl/03bcfc3f13cd728a634286913391894ebe1e6f19/pr-566-config-table.png)

<details>
<summary>Same thing as text</summary>

**Before — table breaks (function `Details` JSON ≈ 190 cols)**

```
Applied changes
┌────────┬─────────┬──────────────────┬───────────── … ───────────────────────────────────────────────────────────────┐
│ Action │ Kind    │ Identifier       │ Details                                                                       … │
├────────┼─────────┼──────────────────┼───────────── … ───────────────────────────────────────────────────────────────┤
│ update │ service │ function:hello   │ {"slug":"hello","source":"./hello.ts","runtime":"nodejs24","deploymentId":3," … │
│ update │ service │ function:goodbye │ {"slug":"goodbye","source":"./goodbye.ts","runtime":"nodejs24","deploymentId": … │
└────────┴─────────┴──────────────────┴───────────── … ───────────────────────────────────────────────────────────────┘
```

**After — minimal table + URL list**

```
Applied changes
┌────────┬─────────┬──────────────────┐
│ Action │ Kind    │ Identifier       │
├────────┼─────────┼──────────────────┤
│ update │ service │ function:hello   │
├────────┼─────────┼──────────────────┤
│ update │ service │ function:goodbye │
└────────┴─────────┴──────────────────┘

Function URLs
  • hello: https://br-…-hello.compute.c-1.us-east-2.aws.neon.build/
  • goodbye: https://br-…-goodbye.compute.c-1.us-east-2.aws.neon.build/
```

</details>

## Changes

- `src/commands/config.ts`: drop `details` from `APPLIED_FIELDS` (and the `details` value from the row map); replace the Function URLs table with a plain bullet list rendered below the table.
- `src/commands/config.test.ts`: regression test asserting the changes table has no `Details` column / raw JSON / URL, that function URLs are listed as `• <slug>: <url>` below it, and that no rendered line exceeds 120 columns.

## Test plan

- [x] `pnpm typecheck` / `eslint` / `prettier --check` pass
- [x] `vitest run src/commands/config.test.ts` — 15 passing (incl. new regression test)
- [x] End-to-end against Neon staging in `demos/neon-preview`: created a fresh project, enabled auth + a public bucket + two functions, and ran `config plan` / `config apply` repeatedly (create + re-deploy of existing functions). Confirmed the changes table stays minimal and the function URLs list cleanly below it.

> [!NOTE]
> The before/after screenshot is hosted on the `assets/pr-566-screenshot` branch to keep this PR's diff clean; that branch can be deleted after merge.