### PR TITLE
chore: bump neon-init to 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",
@@ -71,7 +71,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.17.0",
+    "neon-init": "0.17.1",
     "open": "10.1.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.17.0
-        version: 0.17.0
+        specifier: 0.17.1
+        version: 0.17.1
       open:
         specifier: 10.1.0
         version: 10.1.0
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.17.0:
-    resolution: {integrity: sha512-yuN7gCLcVKlv96axzn4zR0X8w8a+Ib4NthMQR33LLApZFbYvjIVeygaG+2tG1mgtUNNOuNGAWy1F9+6QXM1I0A==}
+  neon-init@0.17.1:
+    resolution: {integrity: sha512-axY+oy4dFFlehM5uPm+vVWJkPRJsMsjc+s496gjJYfv0alHYOVP9wIlEkmbjb2L9GGZfO+FBFoJHE3n+IO8p5w==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3887,7 +3887,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5230,7 +5230,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)
@@ -6339,7 +6339,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.17.0:
+  neon-init@0.17.1:
     dependencies:
       '@clack/prompts': 0.10.1
       add-mcp: 1.8.0

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -53,26 +53,23 @@ describe('init', () => {
 
     expect(orchestrate).toHaveBeenCalledWith({
       agent: 'cursor',
-      skipNeonAuth: undefined,
       skipMigrations: undefined,
       preview: undefined,
     });
     expect(interactiveInit).not.toHaveBeenCalled();
   });
 
-  test('should pass skipNeonAuth and skipMigrations to orchestrate', async () => {
+  test('should pass skipMigrations to orchestrate', async () => {
     const { handler } = await import('./init.js');
     const { orchestrate } = await import('neon-init');
 
     await handler({
       agent: 'claude',
-      skipNeonAuth: true,
       skipMigrations: true,
     });
 
     expect(orchestrate).toHaveBeenCalledWith({
       agent: 'claude',
-      skipNeonAuth: true,
       skipMigrations: true,
       preview: undefined,
     });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,11 +27,6 @@ export const builder = (yargs: yargs.Argv) =>
       describe:
         'JSON object with a "step" field to route to a specific phase and phase-specific options.',
     })
-    .option('skip-neon-auth', {
-      type: 'boolean',
-      default: false,
-      describe: 'Skip the Neon Auth setup phase.',
-    })
     .option('skip-migrations', {
       type: 'boolean',
       default: false,
@@ -80,7 +75,6 @@ export const handler = async (argv: {
     if (isAgentMode) {
       const result = await orchestrate({
         agent,
-        skipNeonAuth: argv.skipNeonAuth,
         skipMigrations: argv.skipMigrations,
         preview: argv.preview,
       });


### PR DESCRIPTION
## Summary

Bumps `neon-init` from `0.17.0` to `0.17.1` and neonctl from `2.26.4` to `2.26.5`.

Picks up changes from https://github.com/neondatabase/neon-pkgs/pull/219:

- Skills management: base + preview skills, partial install detection, pre-install skills CLI, sandbox workarounds
- Setup flow: removed legacy round-trip paths, mode question hidden when nothing to customize
- Agent detection: `--agent` boolean flag, `--skip-neon-auth` removed, features-driven neon-auth
- Environment: `NEON_API_HOST`/`NEON_OAUTH_HOST` support, `NEON_VSX_GALLERY_URL` runtime support

## Dependencies

Depends on https://github.com/neondatabase/neon-pkgs/pull/219 being published first.

This pull request and its description were written by Isaac.