### PR TITLE
chore: bump neon-init to 0.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.26.5",
+  "version": "2.26.6",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",
@@ -71,7 +71,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.17.1",
+    "neon-init": "0.17.2",
     "open": "10.1.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.17.1
-        version: 0.17.1
+        specifier: 0.17.2
+        version: 0.17.2
       open:
         specifier: 10.1.0
         version: 10.1.0
@@ -2781,8 +2781,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.17.1:
-    resolution: {integrity: sha512-axY+oy4dFFlehM5uPm+vVWJkPRJsMsjc+s496gjJYfv0alHYOVP9wIlEkmbjb2L9GGZfO+FBFoJHE3n+IO8p5w==}
+  neon-init@0.17.2:
+    resolution: {integrity: sha512-BZXrosObgMzxGLxK1bdVnt0kADjYIn0qsZt7tAU6Sg2ZwLYWftfKkzNxWQ1hT6nk7oy5rz8YH+tuq6yOFQ6t0w==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3887,7 +3887,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5230,7 +5230,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)
@@ -6339,7 +6339,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.17.1:
+  neon-init@0.17.2:
     dependencies:
       '@clack/prompts': 0.10.1
       add-mcp: 1.8.0

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -22,10 +22,11 @@ vi.mock('neon-init', () => ({
 
 describe('init', () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.resetModules();
   });
 
-  test('should call interactiveInit when --agent is omitted', async () => {
+  test('should call interactiveInit when no --agent flag', async () => {
     const { handler } = await import('./init.js');
     const { interactiveInit, orchestrate } = await import('neon-init');
 
@@ -35,21 +36,24 @@ describe('init', () => {
     expect(orchestrate).not.toHaveBeenCalled();
   });
 
-  test('should fall through to interactiveInit when --agent is empty and detectAgent returns null', async () => {
+  test('should fall through to interactiveInit when --agent is false and detectAgent returns null', async () => {
     const { handler } = await import('./init.js');
     const { interactiveInit, orchestrate } = await import('neon-init');
 
-    await handler({ agent: '' });
+    await handler({ agent: false });
 
     expect(interactiveInit).toHaveBeenCalledTimes(1);
     expect(orchestrate).not.toHaveBeenCalled();
   });
 
-  test('should call orchestrate with agent "cursor"', async () => {
+  test('should call orchestrate when --agent is true', async () => {
     const { handler } = await import('./init.js');
-    const { interactiveInit, orchestrate } = await import('neon-init');
+    const { interactiveInit, orchestrate, detectAgent } = await import(
+      'neon-init'
+    );
+    (detectAgent as ReturnType<typeof vi.fn>).mockReturnValue('cursor');
 
-    await handler({ agent: 'cursor' });
+    await handler({ agent: true });
 
     expect(orchestrate).toHaveBeenCalledWith({
       agent: 'cursor',
@@ -61,10 +65,11 @@ describe('init', () => {
 
   test('should pass skipMigrations to orchestrate', async () => {
     const { handler } = await import('./init.js');
-    const { orchestrate } = await import('neon-init');
+    const { orchestrate, detectAgent } = await import('neon-init');
+    (detectAgent as ReturnType<typeof vi.fn>).mockReturnValue('claude');
 
     await handler({
-      agent: 'claude',
+      agent: true,
       skipMigrations: true,
     });
 
@@ -82,5 +87,19 @@ describe('init', () => {
     await handler({ preview: true });
 
     expect(interactiveInit).toHaveBeenCalledWith({ preview: true });
+  });
+
+  test('should pass preview to orchestrate in agent mode', async () => {
+    const { handler } = await import('./init.js');
+    const { orchestrate, detectAgent } = await import('neon-init');
+    (detectAgent as ReturnType<typeof vi.fn>).mockReturnValue('cursor');
+
+    await handler({ agent: true, preview: true });
+
+    expect(orchestrate).toHaveBeenCalledWith({
+      agent: 'cursor',
+      skipMigrations: undefined,
+      preview: true,
+    });
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -19,8 +19,9 @@ export const builder = (yargs: yargs.Argv) =>
     })
     .option('agent', {
       alias: 'a',
-      type: 'string',
-      describe: 'Agent to configure (cursor, copilot, claude, etc.).',
+      type: 'boolean',
+      default: false,
+      describe: 'Enable agent/JSON mode (agent type is auto-detected).',
     })
     .option('data', {
       type: 'string',
@@ -41,19 +42,18 @@ export const builder = (yargs: yargs.Argv) =>
     .strict(false);
 
 export const handler = async (argv: {
-  agent?: string;
+  agent?: boolean;
   data?: string;
-  skipNeonAuth?: boolean;
   skipMigrations?: boolean;
   preview?: boolean;
 }) => {
   try {
-    // Auto-detect agent from environment if --agent not explicitly provided.
-    // For IDE-based detection (Cursor, VS Code, Windsurf), require non-TTY stdin
-    // to distinguish "agent spawned this" from "human typed this in terminal".
+    // Auto-detect agent from environment. When --agent is explicitly passed,
+    // always detect (the user asked for agent mode). Otherwise, require
+    // non-TTY stdin to distinguish agent from human in terminal.
     const agent =
-      argv.agent || (!process.stdin.isTTY ? detectAgent() : null) || undefined;
-    const isAgentMode = agent !== undefined;
+      (argv.agent || !process.stdin.isTTY ? detectAgent() : null) || undefined;
+    const isAgentMode = argv.agent || agent !== undefined;
 
     // --data with a "step" field routes to the appropriate phase
     if (argv.data && isAgentMode) {


### PR DESCRIPTION
## Summary

Bumps `neon-init` to `0.17.2` and `neonctl` to `2.26.6`.

Picks up: when skills install fails in sandboxed environments, the response now includes the exact shell commands so the agent can run them directly.

## Dependencies

Depends on https://github.com/neondatabase/neon-pkgs/pull/220 being published first. Lockfile update needed after publish.

This pull request and its description were written by Isaac.