### PR TITLE
feat(git): sync Neon branch to git branch + neon.ts lifecycle hooks (Preview)

### DIFF
--- a/src/commands/__snapshots__/set_context.test.ts.snap
+++ b/src/commands/__snapshots__/set_context.test.ts.snap
@@ -17,6 +17,8 @@ exports[`set_context > deprecation > warns (to stderr) and still performs the ra
 }"
 `;
 
+exports[`set_context > non-destructive to git workflow state > preserves an existing git block 1`] = `""`;
+
 exports[`set_context > should set the context to organization > create projects selecting organization from the context 1`] = `
 "project:
   id: new-project-789012

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -20,6 +20,14 @@ import {
   createBranchFromPolicyOnCheckout,
 } from './config.js';
 import { handler as linkHandler } from './link.js';
+import { GIT_HOOK_ENV_FLAG, readGitContext } from '../utils/git.js';
+import {
+  buildHookBranch,
+  loadHooks,
+  resolveHookEnv,
+  runCheckoutAfterHook,
+  runCheckoutBeforeHook,
+} from '../utils/hooks.js';
 
 type CheckoutProps = CommonProps & {
   projectId?: string;
@@ -90,6 +98,32 @@ export const handler = async (props: CheckoutProps) => {
   // nothing resolves, fall back to an interactive `neonctl link`.
   const projectId = await resolveProjectId(props);
 
+  // Lifecycle hooks (Preview): read git facts + load the neon.ts `hooks` block once. The
+  // `checkout.before` hook may rewrite the branch name (e.g. map a git branch to a Neon
+  // slug) before we resolve it; it runs before resolution because the name isn't pinned yet.
+  const cwd = process.cwd();
+  const git = readGitContext(cwd, {
+    triggeredByGitHook: process.env[GIT_HOOK_ENV_FLAG] === '1',
+  });
+  const hooks = await loadHooks(cwd);
+  if (props.id) {
+    const renamed = await runCheckoutBeforeHook({
+      hooks,
+      inputName: props.id,
+      git,
+      cwd,
+    });
+    if (renamed && renamed !== props.id) {
+      log.info(
+        '%s checkout.before hook mapped %s → %s',
+        chalk.dim('→'),
+        chalk.cyan(props.id),
+        chalk.cyan.bold(renamed),
+      );
+      props.id = renamed;
+    }
+  }
+
   const { branchId, branchName, created, policyApplied } =
     await resolveBranchId(props, projectId);
 
@@ -136,6 +170,28 @@ export const handler = async (props: CheckoutProps) => {
     branch: branchId,
     envPull: props.envPull,
   });
+
+  // `checkout.after` hook (Preview): runs once the branch is pinned and env is resolved.
+  // Env is resolved in-memory here even under `--no-env-pull`, so a migration hook always
+  // has a connection string. A hook failure degrades to a warning (the checkout stands).
+  if (hooks?.checkout?.after) {
+    const env = await resolveHookEnv({
+      cwd,
+      projectId,
+      branchId,
+      ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+      ...(props.apiHost ? { apiHost: props.apiHost } : {}),
+    });
+    if (env) {
+      const branch = await buildHookBranch({
+        apiClient: props.apiClient,
+        projectId,
+        branchId,
+        created,
+      });
+      await runCheckoutAfterHook({ hooks, branch, env, git, cwd });
+    }
+  }
 };
 
 /**

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -25,6 +25,13 @@ import { bundleEntry } from '../utils/esbuild.js';
 import { zipBundle } from '../utils/zip.js';
 import { writer } from '../writer.js';
 import { autoPullEnvAfterPin } from './env.js';
+import { GIT_HOOK_ENV_FLAG, readGitContext } from '../utils/git.js';
+import {
+  buildHookBranch,
+  resolveHookEnv,
+  runDeployAfterHook,
+  runDeployBeforeHook,
+} from '../utils/hooks.js';
 
 /**
  * Bundle a function with neonctl's OWN bundler (the shared esbuild helper) so the
@@ -276,6 +283,24 @@ export const applyCmd = async (props: ConfigProps): Promise<void> => {
   const branch = await resolveBranchRef(props);
   announceTargetBranch(props, branch, 'Applying to branch');
   const branchId = branch.branchId;
+
+  // Lifecycle hooks (Preview): the `deploy` phase brackets the apply. `before` can validate
+  // or abort (a throw propagates); `after` observes the resolved env + PushResult.
+  const cwd = props.cwd ?? process.cwd();
+  const hooks = config.hooks;
+  const git = readGitContext(cwd, {
+    triggeredByGitHook: process.env[GIT_HOOK_ENV_FLAG] === '1',
+  });
+  if (hooks?.deploy?.before) {
+    const hookBranch = await buildHookBranch({
+      apiClient: props.apiClient,
+      projectId: props.projectId,
+      branchId,
+      created: false,
+    });
+    await runDeployBeforeHook({ hooks, branch: hookBranch, git, cwd });
+  }
+
   const result = await apply(config, {
     projectId: props.projectId,
     branchId,
@@ -293,6 +318,35 @@ export const applyCmd = async (props: ConfigProps): Promise<void> => {
   // usable for local dev. `--no-env-pull` opts out; a pull failure degrades to a warning
   // (the apply already succeeded). See autoPullEnvAfterPin.
   await autoPullEnvAfterPin({ ...props, envPull: props.envPull !== false });
+
+  // `deploy.after` hook (Preview): runs after a successful apply. Env is resolved in-memory
+  // regardless of `--env-pull`; a hook failure degrades to a warning (the apply stands).
+  if (hooks?.deploy?.after) {
+    const env = await resolveHookEnv({
+      cwd,
+      projectId: props.projectId,
+      branchId,
+      ...(props.apiKey ? { apiKey: props.apiKey } : {}),
+      ...(props.apiHost ? { apiHost: props.apiHost } : {}),
+      ...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+    });
+    if (env) {
+      const hookBranch = await buildHookBranch({
+        apiClient: props.apiClient,
+        projectId: props.projectId,
+        branchId,
+        created: false,
+      });
+      await runDeployAfterHook({
+        hooks,
+        branch: hookBranch,
+        env,
+        result,
+        git,
+        cwd,
+      });
+    }
+  }
 };
 
 type ReportMode = 'plan' | 'apply';

--- a/src/commands/git.test.ts
+++ b/src/commands/git.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import { partitionBranchesToPrune } from './git.js';
+
+describe('partitionBranchesToPrune', () => {
+  const branches = [
+    { id: 'br-main', name: 'main', default: true },
+    { id: 'br-prod', name: 'production', protected: true },
+    { id: 'br-x', name: 'preview/x' },
+    { id: 'br-y', name: 'preview/y' },
+    { id: 'br-live', name: 'preview/live' }, // mapped from a still-present git branch
+  ];
+
+  test('deletes only orphaned, non-default, non-protected branches', () => {
+    const orphans = new Set(['main', 'production', 'preview/x', 'preview/y']);
+    const { toDelete, skipped } = partitionBranchesToPrune(branches, orphans);
+
+    expect(toDelete.map((b) => b.name).sort()).toEqual([
+      'preview/x',
+      'preview/y',
+    ]);
+    expect(skipped).toEqual([
+      { name: 'main', reason: 'default branch' },
+      { name: 'production', reason: 'protected' },
+    ]);
+  });
+
+  test('never touches a branch that is not orphaned', () => {
+    const { toDelete } = partitionBranchesToPrune(
+      branches,
+      new Set(['preview/x']),
+    );
+    expect(toDelete.map((b) => b.name)).toEqual(['preview/x']);
+    // `preview/live` is not in the orphan set → kept.
+    expect(toDelete.some((b) => b.name === 'preview/live')).toBe(false);
+  });
+
+  test('returns nothing to delete when there are no orphans', () => {
+    const { toDelete, skipped } = partitionBranchesToPrune(branches, new Set());
+    expect(toDelete).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+});

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -1,0 +1,223 @@
+import yargs from 'yargs';
+import chalk from 'chalk';
+
+import {
+  contextBranch,
+  gitBranchMapping,
+  readContextFile,
+  setGitBranchMapping,
+  setGitFollow,
+} from '../context.js';
+import { log } from '../log.js';
+import { CommonProps } from '../types.js';
+import {
+  currentGitBranch,
+  gitRepoRoot,
+  installPostCheckoutHook,
+  isGitRepo,
+  isManagedHook,
+  postCheckoutHookPath,
+  readGitContext,
+  removePostCheckoutHook,
+} from '../utils/git.js';
+import { handler as checkoutHandler } from './checkout.js';
+
+type GitProps = CommonProps & {
+  projectId?: string;
+  orgId?: string;
+  envPull?: boolean;
+  quiet?: boolean;
+};
+
+export const command = 'git';
+export const describe =
+  'Sync the checked-out Neon branch to your git branch (Preview)';
+export const aliases: string[] = [];
+
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 git <sub-command> [options]')
+    .command(
+      'install',
+      'Install a git post-checkout hook that syncs the Neon branch on `git checkout`',
+      (yargs) => yargs,
+      (args) => {
+        install(args as unknown as GitProps);
+      },
+    )
+    .command(
+      'uninstall',
+      'Remove the git post-checkout hook installed by `git install`',
+      (yargs) => yargs,
+      (args) => {
+        uninstall(args as unknown as GitProps);
+      },
+    )
+    .command(
+      'sync',
+      'Check out the Neon branch mapped to the current git branch (run by the hook)',
+      (yargs) =>
+        yargs.options({
+          'env-pull': {
+            describe:
+              "Pull the branch's Neon env vars into a local .env after sync. On by default.",
+            type: 'boolean',
+            default: true,
+          },
+          quiet: {
+            describe: 'Reduce output (used by the git hook).',
+            type: 'boolean',
+            default: false,
+          },
+        }),
+      (args) => sync(args as unknown as GitProps),
+    )
+    .command(
+      'status',
+      'Show the git context, hook state, and current git → Neon mapping',
+      (yargs) => yargs,
+      (args) => {
+        status(args as unknown as GitProps);
+      },
+    )
+    .demandCommand(1);
+
+export const handler = (args: yargs.Argv) => args;
+
+const requireRepoRoot = (): string | undefined => {
+  const cwd = process.cwd();
+  if (!isGitRepo(cwd)) {
+    log.error(
+      'Not inside a git repository. Run `neonctl git` from a git work tree.',
+    );
+    return undefined;
+  }
+  return gitRepoRoot(cwd);
+};
+
+export const install = (props: GitProps): void => {
+  const repoRoot = requireRepoRoot();
+  if (!repoRoot) return;
+
+  const result = installPostCheckoutHook(repoRoot);
+  if (result.status === 'conflict') {
+    log.error(
+      'A non-neonctl `post-checkout` hook already exists at %s.\n' +
+        'Remove or rename it first, then re-run `neonctl git install`.',
+      result.hookPath,
+    );
+    return;
+  }
+  setGitFollow(props.contextFile, true);
+  log.info(
+    'Git → Neon sync %s. `git checkout <branch>` will now check out the mapped Neon branch.\n' +
+      'Hook: %s',
+    result.status === 'installed' ? 'installed' : 'updated',
+    postCheckoutHookPath(repoRoot),
+  );
+};
+
+export const uninstall = (props: GitProps): void => {
+  const repoRoot = requireRepoRoot();
+  if (!repoRoot) return;
+
+  const result = removePostCheckoutHook(repoRoot);
+  setGitFollow(props.contextFile, false);
+  switch (result) {
+    case 'removed':
+      log.info(
+        'Removed the neonctl git post-checkout hook. Git → Neon sync is off.',
+      );
+      break;
+    case 'foreign':
+      log.warning(
+        'Left the existing `post-checkout` hook in place (not managed by neonctl). ' +
+          'Git → Neon sync flag cleared.',
+      );
+      break;
+    case 'absent':
+      log.info(
+        'No neonctl git hook was installed. Git → Neon sync flag cleared.',
+      );
+      break;
+  }
+};
+
+/**
+ * Check out the Neon branch that corresponds to the current git branch. Invoked by the
+ * installed `post-checkout` hook (with `NEON_GIT_HOOK=1`) and runnable by hand. Resolves the
+ * Neon branch name via the persisted map (sticky), delegates to `neonctl checkout` (whose
+ * `checkout.before` hook may further map the name and whose `checkout.after` hook runs
+ * migrations, etc.), then records the resulting git → Neon mapping so it stays stable.
+ */
+export const sync = async (props: GitProps): Promise<void> => {
+  const cwd = process.cwd();
+  if (!isGitRepo(cwd)) {
+    log.error('Not inside a git repository.');
+    return;
+  }
+  const gitBranch = currentGitBranch(cwd);
+  if (!gitBranch) {
+    log.info('Detached HEAD — no git branch to sync. Skipping.');
+    return;
+  }
+
+  const context = readContextFile(props.contextFile);
+  // A previously-resolved mapping wins (sticky); otherwise pass the git branch through and
+  // let the policy's `checkout.before` hook (or the default derivation) name the Neon branch.
+  const inputName = gitBranchMapping(context, gitBranch) ?? gitBranch;
+
+  await checkoutHandler({
+    ...props,
+    id: inputName,
+    envPull: props.envPull ?? true,
+  });
+
+  // Persist the mapping from the branch actually pinned, so subsequent checkouts of this git
+  // branch resolve to the same Neon branch without re-deriving.
+  const resolved = contextBranch(readContextFile(props.contextFile));
+  if (resolved) {
+    setGitBranchMapping(props.contextFile, gitBranch, resolved);
+  }
+};
+
+export const status = (props: GitProps): void => {
+  const cwd = process.cwd();
+  const git = readGitContext(cwd);
+  if (!git.available) {
+    log.info('Not inside a git repository.');
+    return;
+  }
+
+  const repoRoot = git.repoRoot ?? cwd;
+  const hookPath = postCheckoutHookPath(repoRoot);
+  const installed = isManagedHook(hookPath);
+  const context = readContextFile(props.contextFile);
+  const mapping = context.git?.map ?? {};
+  const currentBranch = git.branch;
+  const mappedNeon = currentBranch
+    ? gitBranchMapping(context, currentBranch)
+    : undefined;
+
+  log.info('Git branch:        %s', chalk.cyan(currentBranch ?? '(detached)'));
+  log.info('Hook installed:    %s', installed ? chalk.green('yes') : 'no');
+  log.info(
+    'Follow on checkout: %s',
+    context.git?.follow ? chalk.green('yes') : 'no',
+  );
+  if (currentBranch) {
+    log.info(
+      'Maps to Neon:      %s',
+      mappedNeon
+        ? chalk.cyan(mappedNeon)
+        : chalk.dim('(unmapped — will derive on next sync)'),
+    );
+  }
+  const entries = Object.entries(mapping);
+  if (entries.length > 0) {
+    log.info('Known mappings:');
+    for (const [g, n] of entries) {
+      log.info('  %s → %s', g, n);
+    }
+  }
+};

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -1,5 +1,6 @@
 import yargs from 'yargs';
 import chalk from 'chalk';
+import prompts from 'prompts';
 
 import {
   contextBranch,
@@ -8,11 +9,15 @@ import {
   setGitBranchMapping,
   setGitFollow,
 } from '../context.js';
+import { isCi } from '../env.js';
 import { log } from '../log.js';
 import { CommonProps } from '../types.js';
 import {
   currentGitBranch,
+  GIT_HOOK_ENV_FLAG,
+  gitPull,
   gitRepoRoot,
+  hasUpstream,
   installPostCheckoutHook,
   isGitRepo,
   isManagedHook,
@@ -27,6 +32,8 @@ type GitProps = CommonProps & {
   orgId?: string;
   envPull?: boolean;
   quiet?: boolean;
+  /** Tri-state: `--pull` (true), `--no-pull` (false), or unset (prompt in a manual TTY). */
+  pull?: boolean;
 };
 
 export const command = 'git';
@@ -63,6 +70,13 @@ export const builder = (argv: yargs.Argv) =>
               "Pull the branch's Neon env vars into a local .env after sync. On by default.",
             type: 'boolean',
             default: true,
+          },
+          pull: {
+            describe:
+              'Run `git pull --ff-only` before syncing so local files (incl. migration ' +
+              'files) match the branch before any checkout.after migration runs. Without ' +
+              'the flag, prompts when run manually in a TTY and skips in the hook / CI.',
+            type: 'boolean',
           },
           quiet: {
             describe: 'Reduce output (used by the git hook).',
@@ -162,6 +176,27 @@ export const sync = async (props: GitProps): Promise<void> => {
     return;
   }
 
+  // Optionally fast-forward local files (incl. committed migration files) before checkout, so
+  // a shared branch that is ahead of your local tree doesn't leave code↔schema skewed when the
+  // `checkout.after` migration runs. Opt-in (network + can diverge); see resolveShouldPull.
+  if (await resolveShouldPull(props, cwd, gitBranch)) {
+    const outcome = gitPull(cwd);
+    switch (outcome.status) {
+      case 'pulled':
+        log.info('%s git pull --ff-only (%s)', chalk.dim('→'), gitBranch);
+        break;
+      case 'no-upstream':
+        log.info('No upstream for %s — skipping git pull.', gitBranch);
+        break;
+      case 'failed':
+        log.warning(
+          'git pull --ff-only failed (continuing with sync): %s',
+          outcome.detail,
+        );
+        break;
+    }
+  }
+
   const context = readContextFile(props.contextFile);
   // A previously-resolved mapping wins (sticky); otherwise pass the git branch through and
   // let the policy's `checkout.before` hook (or the default derivation) name the Neon branch.
@@ -179,6 +214,31 @@ export const sync = async (props: GitProps): Promise<void> => {
   if (resolved) {
     setGitBranchMapping(props.contextFile, gitBranch, resolved);
   }
+};
+
+/**
+ * Decide whether `git sync` should `git pull` first. Mirrors the rest of the CLI's
+ * auto-vs-interactive philosophy (cf. `checkout` / `link`): an explicit flag always wins;
+ * otherwise we only *prompt* in a real manual TTY, and never auto-pull in the post-checkout
+ * hook or CI (no network surprises in automation). Skips when there's nothing upstream.
+ */
+const resolveShouldPull = async (
+  props: GitProps,
+  cwd: string,
+  gitBranch: string,
+): Promise<boolean> => {
+  if (props.pull === true) return true;
+  if (props.pull === false) return false;
+  if (!hasUpstream(cwd)) return false;
+  const triggeredByGitHook = process.env[GIT_HOOK_ENV_FLAG] === '1';
+  if (triggeredByGitHook || isCi() || !process.stdout.isTTY) return false;
+  const { pull } = await prompts({
+    type: 'confirm',
+    name: 'pull',
+    message: `Pull latest for "${gitBranch}" (git pull --ff-only) before syncing?`,
+    initial: false,
+  });
+  return Boolean(pull);
 };
 
 export const status = (props: GitProps): void => {

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -6,8 +6,10 @@ import { toNeonBranchName } from '@neondatabase/config';
 
 import {
   contextBranch,
+  gitBranchMap,
   gitBranchMapping,
   readContextFile,
+  setGitBranchMap,
   setGitBranchMapping,
   setGitFollow,
 } from '../context.js';
@@ -23,6 +25,7 @@ import {
   installPostCheckoutHook,
   isGitRepo,
   isManagedHook,
+  localGitBranches,
   postCheckoutHookPath,
   readGitContext,
   removePostCheckoutHook,
@@ -36,6 +39,10 @@ type GitProps = CommonProps & {
   quiet?: boolean;
   /** Tri-state: `--pull` (true), `--no-pull` (false), or unset (prompt in a manual TTY). */
   pull?: boolean;
+  /** `git cleanup`: also delete the orphaned Neon branches (never default/protected). */
+  pruneNeonBranches?: boolean;
+  /** `git cleanup`: skip the deletion confirmation prompt. */
+  yes?: boolean;
 };
 
 export const command = 'git';
@@ -95,6 +102,26 @@ export const builder = (argv: yargs.Argv) =>
       (args) => {
         status(args as unknown as GitProps);
       },
+    )
+    .command(
+      'cleanup',
+      'Prune git → Neon mappings whose local git branch is gone; optionally delete the orphaned Neon branches',
+      (yargs) =>
+        yargs.options({
+          'prune-neon-branches': {
+            describe:
+              'Also delete the orphaned Neon branches (never the default or a protected branch).',
+            type: 'boolean',
+            default: false,
+          },
+          yes: {
+            describe:
+              'Skip the confirmation prompt before deleting Neon branches.',
+            type: 'boolean',
+            default: false,
+          },
+        }),
+      (args) => cleanup(args as unknown as GitProps),
     )
     .demandCommand(1);
 
@@ -288,4 +315,152 @@ export const status = (props: GitProps): void => {
       log.info('  %s → %s', g, n);
     }
   }
+};
+
+/** A Neon branch as far as pruning cares (the live list returns more). */
+type PrunableBranch = {
+  id: string;
+  name: string;
+  default?: boolean;
+  protected?: boolean;
+};
+
+/**
+ * Split the orphaned Neon branches (those mapped from now-deleted git branches) into the ones
+ * safe to delete and the ones to skip. Default and protected branches are **never** deleted.
+ * Pure (no I/O) so it's unit-testable.
+ */
+export const partitionBranchesToPrune = <B extends PrunableBranch>(
+  branches: B[],
+  orphanNeonNames: ReadonlySet<string>,
+): { toDelete: B[]; skipped: { name: string; reason: string }[] } => {
+  const toDelete: B[] = [];
+  const skipped: { name: string; reason: string }[] = [];
+  for (const branch of branches) {
+    if (!orphanNeonNames.has(branch.name)) continue;
+    if (branch.default) {
+      skipped.push({ name: branch.name, reason: 'default branch' });
+    } else if (branch.protected) {
+      skipped.push({ name: branch.name, reason: 'protected' });
+    } else {
+      toDelete.push(branch);
+    }
+  }
+  return { toDelete, skipped };
+};
+
+/**
+ * Prune the git → Neon workflow state. By default this only cleans `.neon`: mapping entries
+ * whose git branch no longer exists locally are dropped. With `--prune-neon-branches` it also
+ * deletes the orphaned Neon branches — never the default branch and never a protected one.
+ */
+export const cleanup = async (props: GitProps): Promise<void> => {
+  const cwd = process.cwd();
+  if (!isGitRepo(cwd)) {
+    log.error('Not inside a git repository.');
+    return;
+  }
+
+  const context = readContextFile(props.contextFile);
+  const map = gitBranchMap(context);
+  const entries = Object.entries(map);
+  if (entries.length === 0) {
+    log.info('No git → Neon mappings to clean up.');
+    return;
+  }
+
+  const local = new Set(localGitBranches(cwd));
+  const stale = entries.filter(([gitBranch]) => !local.has(gitBranch));
+  if (stale.length === 0) {
+    log.info(
+      'All %d mapping(s) still have a local git branch — nothing to prune.',
+      entries.length,
+    );
+    return;
+  }
+
+  // 1) Always prune the stale mappings from .neon (non-destructive to Neon).
+  const kept = Object.fromEntries(
+    entries.filter(([gitBranch]) => local.has(gitBranch)),
+  );
+  setGitBranchMap(props.contextFile, kept);
+  log.info('Pruned %d stale mapping(s) from .neon:', stale.length);
+  for (const [gitBranch, neonBranch] of stale) {
+    log.info('  %s → %s', gitBranch, neonBranch);
+  }
+
+  // 2) Optionally delete the orphaned Neon branches.
+  if (!props.pruneNeonBranches) {
+    log.info(
+      'Re-run with --prune-neon-branches to also delete the orphaned Neon branch(es).',
+    );
+    return;
+  }
+
+  if (!props.projectId) {
+    log.error(
+      'Cannot delete Neon branches: no project in context. Run `neonctl link` first.',
+    );
+    return;
+  }
+
+  const orphanNeonNames = new Set(stale.map(([, neonBranch]) => neonBranch));
+  const branches = (
+    await props.apiClient.listProjectBranches({ projectId: props.projectId })
+  ).data.branches;
+  const { toDelete, skipped } = partitionBranchesToPrune(
+    branches,
+    orphanNeonNames,
+  );
+
+  for (const { name, reason } of skipped) {
+    log.warning(
+      'Keeping Neon branch %s (%s) — never auto-deleted.',
+      name,
+      reason,
+    );
+  }
+
+  if (toDelete.length === 0) {
+    log.info('No orphaned Neon branches to delete.');
+    return;
+  }
+
+  if (!(await confirmPrune(props, toDelete))) {
+    log.info('Aborted — no Neon branches were deleted.');
+    return;
+  }
+
+  for (const branch of toDelete) {
+    await props.apiClient.deleteProjectBranch(props.projectId, branch.id);
+    log.info('Deleted Neon branch %s (%s).', branch.name, branch.id);
+  }
+};
+
+/**
+ * Confirm deleting the orphaned Neon branches. Deletion is destructive, so an explicit
+ * `--yes` wins; otherwise prompt in an interactive terminal, and refuse (with a warning) in
+ * CI / non-interactive contexts rather than deleting without consent.
+ */
+const confirmPrune = async (
+  props: GitProps,
+  toDelete: PrunableBranch[],
+): Promise<boolean> => {
+  if (props.yes) return true;
+  if (isCi() || !process.stdout.isTTY) {
+    log.warning(
+      'Refusing to delete %d Neon branch(es) non-interactively. Re-run with --yes to confirm.',
+      toDelete.length,
+    );
+    return false;
+  }
+  const { ok } = await prompts({
+    type: 'confirm',
+    name: 'ok',
+    message: `Delete ${toDelete.length} orphaned Neon branch(es): ${toDelete
+      .map((branch) => branch.name)
+      .join(', ')}?`,
+    initial: false,
+  });
+  return Boolean(ok);
 };

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -2,6 +2,8 @@ import yargs from 'yargs';
 import chalk from 'chalk';
 import prompts from 'prompts';
 
+import { toNeonBranchName } from '@neondatabase/config';
+
 import {
   contextBranch,
   gitBranchMapping,
@@ -198,9 +200,15 @@ export const sync = async (props: GitProps): Promise<void> => {
   }
 
   const context = readContextFile(props.contextFile);
-  // A previously-resolved mapping wins (sticky); otherwise pass the git branch through and
-  // let the policy's `checkout.before` hook (or the default derivation) name the Neon branch.
-  const inputName = gitBranchMapping(context, gitBranch) ?? gitBranch;
+  // Resolve the Neon branch name to check out:
+  //   1. a previously-recorded mapping wins (sticky — no duplicate branches), else
+  //   2. a Neon-safe name derived from the git branch via `toNeonBranchName`.
+  // (2) means a brand-new branch is always valid by default — no `checkout.before` hook
+  // required. A `checkout.before` hook can still override: it receives this name as
+  // `inputName` *and* the raw git branch on `git.branch`, so it can re-derive with custom
+  // options (e.g. a `preview/` prefix) and stay stable.
+  const inputName =
+    gitBranchMapping(context, gitBranch) ?? toNeonBranchName(gitBranch);
 
   await checkoutHandler({
     ...props,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,6 +23,7 @@ import * as deploy from './deploy.js';
 import * as env from './env.js';
 import * as bucket from './bucket.js';
 import * as bootstrap from './bootstrap.js';
+import * as git from './git.js';
 
 export default [
   auth,
@@ -50,4 +51,5 @@ export default [
   env,
   bucket,
   bootstrap,
+  git,
 ];

--- a/src/commands/set_context.test.ts
+++ b/src/commands/set_context.test.ts
@@ -222,4 +222,34 @@ describe('set_context', () => {
       expect(readFile(CONTEXT_FILE)).toMatchSnapshot();
     });
   });
+
+  describe('non-destructive to git workflow state', () => {
+    // set-context still does a raw write of project/org/branch, but must NOT wipe the
+    // git → Neon mapping a user (or `neonctl git`) built up. This is the backward-compatible
+    // guarantee that lets `set-context` coexist with the git-sync workflow.
+    test('preserves an existing git block', async ({ testCliCommand }) => {
+      const file = join(tmpdir(), `neon_git_preserve_${Date.now()}`);
+      writeFileSync(
+        file,
+        JSON.stringify({
+          projectId: 'old',
+          git: { follow: true, map: { main: 'main' } },
+        }),
+      );
+      try {
+        await testCliCommand([
+          'set-context',
+          '--project-id',
+          'test',
+          '--context-file',
+          file,
+        ]);
+        const ctx = JSON.parse(readFileSync(file, 'utf-8'));
+        expect(ctx.projectId).toBe('test');
+        expect(ctx.git).toEqual({ follow: true, map: { main: 'main' } });
+      } finally {
+        rmSync(file, { force: true });
+      }
+    });
+  });
 });

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -13,6 +13,10 @@ import {
   applyContext,
   currentContextFile,
   ensureGitignored,
+  gitBranchMapping,
+  readContextFile,
+  setGitBranchMapping,
+  setGitFollow,
 } from './context.js';
 
 describe('currentContextFile', () => {
@@ -155,5 +159,75 @@ describe('applyContext', () => {
     expect(readFileSync(join(workspace, '.gitignore'), 'utf-8')).toBe(
       'node_modules\n',
     );
+  });
+
+  test('preserves an existing git mapping when a write omits `git`', () => {
+    const file = join(workspace, '.neon');
+    applyContext(file, {
+      projectId: 'proj-y',
+      branch: 'main',
+      git: { follow: true, map: { main: 'main' } },
+    });
+    // A later write (e.g. set-context / checkout) carrying no `git` must not wipe it.
+    applyContext(file, { projectId: 'proj-z', branch: 'feature' });
+    expect(readContextFile(file)).toEqual({
+      projectId: 'proj-z',
+      branch: 'feature',
+      git: { follow: true, map: { main: 'main' } },
+    });
+  });
+
+  test('replaces the git block when a write provides an explicit `git`', () => {
+    const file = join(workspace, '.neon');
+    applyContext(file, { projectId: 'p', git: { map: { main: 'main' } } });
+    applyContext(file, {
+      projectId: 'p',
+      git: { map: { dev: 'preview/dev' } },
+    });
+    expect(readContextFile(file).git).toEqual({ map: { dev: 'preview/dev' } });
+  });
+});
+
+describe('git mapping helpers', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-gitmap-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('setGitBranchMapping merges entries and preserves the rest of the context', () => {
+    const file = join(workspace, '.neon');
+    applyContext(file, { projectId: 'p', orgId: 'o', branch: 'main' });
+    setGitBranchMapping(file, 'feature/billing-ui', 'preview/feature-billing');
+    setGitBranchMapping(file, 'main', 'main');
+
+    const ctx = readContextFile(file);
+    expect(ctx.projectId).toBe('p');
+    expect(ctx.orgId).toBe('o');
+    expect(gitBranchMapping(ctx, 'feature/billing-ui')).toBe(
+      'preview/feature-billing',
+    );
+    expect(gitBranchMapping(ctx, 'main')).toBe('main');
+  });
+
+  test('gitBranchMapping returns undefined for an unmapped branch', () => {
+    expect(gitBranchMapping({}, 'whatever')).toBeUndefined();
+  });
+
+  test('setGitFollow toggles follow without dropping the map', () => {
+    const file = join(workspace, '.neon');
+    setGitBranchMapping(file, 'main', 'main');
+    setGitFollow(file, true);
+    expect(readContextFile(file).git).toEqual({
+      follow: true,
+      map: { main: 'main' },
+    });
+    setGitFollow(file, false);
+    expect(readContextFile(file).git?.follow).toBe(false);
+    expect(readContextFile(file).git?.map).toEqual({ main: 'main' });
   });
 });

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -13,8 +13,10 @@ import {
   applyContext,
   currentContextFile,
   ensureGitignored,
+  gitBranchMap,
   gitBranchMapping,
   readContextFile,
+  setGitBranchMap,
   setGitBranchMapping,
   setGitFollow,
 } from './context.js';
@@ -216,6 +218,24 @@ describe('git mapping helpers', () => {
 
   test('gitBranchMapping returns undefined for an unmapped branch', () => {
     expect(gitBranchMapping({}, 'whatever')).toBeUndefined();
+  });
+
+  test('gitBranchMap returns a copy of the map; setGitBranchMap replaces it (preserving follow)', () => {
+    const file = join(workspace, '.neon');
+    applyContext(file, {
+      projectId: 'p',
+      git: { follow: true, map: { main: 'main', 'feature/x': 'preview/x' } },
+    });
+    expect(gitBranchMap(readContextFile(file))).toEqual({
+      main: 'main',
+      'feature/x': 'preview/x',
+    });
+
+    // Prune `feature/x` (its git branch is gone) — keep only `main`.
+    setGitBranchMap(file, { main: 'main' });
+    const ctx = readContextFile(file);
+    expect(ctx.git).toEqual({ follow: true, map: { main: 'main' } });
+    expect(ctx.projectId).toBe('p');
   });
 
   test('setGitFollow toggles follow without dropping the map', () => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,6 +5,19 @@ import yargs from 'yargs';
 
 import { log } from './log.js';
 
+/**
+ * Git → Neon mapping persisted in `.neon` so `git checkout` can drive `neonctl checkout`.
+ * The keys are git branch names; the **values are real Neon branch names** (valid slugs, the
+ * same form stored in {@link Context.branch}). The map is built up as branches are resolved,
+ * so a git branch always resolves to the same Neon branch on subsequent checkouts.
+ */
+export type GitContextConfig = {
+  /** When true, the installed git `post-checkout` hook drives `neonctl git sync`. */
+  follow?: boolean;
+  /** git branch name -> Neon branch name (a valid Neon slug). */
+  map?: Record<string, string>;
+};
+
 export type Context = {
   orgId?: string;
   projectId?: string;
@@ -20,6 +33,13 @@ export type Context = {
    * dropped the next time the context is written.
    */
   branchId?: string;
+  /**
+   * Git → Neon workflow state (the branch mapping and `follow` flag). Preserved across
+   * writes by {@link applyContext} unless a caller explicitly provides a new `git` block,
+   * so project/org/branch updates (e.g. the deprecated `set-context`, or a plain `checkout`)
+   * never wipe the mapping.
+   */
+  git?: GitContextConfig;
 };
 
 /**
@@ -110,9 +130,13 @@ export const updateContextFile = (file: string, context: Context) => {
 
 /**
  * Shared primitive used by `link`, the deprecated `set-context`, and `checkout`
- * to persist context. Mirrors the destructive write semantics of
- * `updateContextFile` — any field not present in `context` is dropped from the
- * file.
+ * to persist context. The project/org/branch trio keeps its destructive write
+ * semantics — any of those not present in `context` is dropped from the file, so
+ * existing scripts behave unchanged — but the {@link Context.git} block is
+ * **preserved** when the caller doesn't provide one. That makes a plain
+ * `set-context` / `checkout` non-destructive to the git → Neon mapping: you can
+ * re-pin project/org/branch without wiping the branch map a user (or
+ * `neonctl git sync`) built up. Pass an explicit `git` to replace it.
  *
  * `.gitignore` scaffolding only happens when the context file is being
  * *created* (it didn't exist before this write). On updates to an existing
@@ -122,10 +146,50 @@ export const updateContextFile = (file: string, context: Context) => {
  */
 export const applyContext = (file: string, context: Context) => {
   const isNewFile = !existsSync(file);
-  updateContextFile(file, context);
+  // Preserve the git mapping unless the caller explicitly replaces it. This is what makes
+  // `set-context` / `checkout` non-destructive to the git → Neon workflow state.
+  const existing = isNewFile ? {} : readContextFile(file);
+  const merged: Context =
+    context.git === undefined && existing.git !== undefined
+      ? { ...context, git: existing.git }
+      : context;
+  updateContextFile(file, merged);
   if (isNewFile) {
     ensureGitignored(file);
   }
+};
+
+/** Look up the Neon branch a git branch maps to in the persisted `.neon` context. */
+export const gitBranchMapping = (
+  context: Context,
+  gitBranch: string,
+): string | undefined => context.git?.map?.[gitBranch];
+
+/**
+ * Record a git branch -> Neon branch mapping in `.neon`, merging into any existing map and
+ * preserving the rest of the context. Passes an explicit `git` so {@link applyContext}
+ * replaces (rather than just preserves) the block with the new entry folded in.
+ */
+export const setGitBranchMapping = (
+  file: string,
+  gitBranch: string,
+  neonBranch: string,
+): void => {
+  const context = readContextFile(file);
+  const git: GitContextConfig = {
+    ...context.git,
+    map: { ...context.git?.map, [gitBranch]: neonBranch },
+  };
+  applyContext(file, { ...context, git });
+};
+
+/** Set the `git.follow` flag (whether the post-checkout hook drives `neonctl git sync`). */
+export const setGitFollow = (file: string, follow: boolean): void => {
+  const context = readContextFile(file);
+  applyContext(file, {
+    ...context,
+    git: { ...context.git, follow },
+  });
 };
 
 /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -165,6 +165,20 @@ export const gitBranchMapping = (
   gitBranch: string,
 ): string | undefined => context.git?.map?.[gitBranch];
 
+/** The full git → Neon mapping from the context (a copy; empty when unset). */
+export const gitBranchMap = (context: Context): Record<string, string> => ({
+  ...context.git?.map,
+});
+
+/** Replace the git → Neon mapping in `.neon`, preserving `git.follow` and the rest. */
+export const setGitBranchMap = (
+  file: string,
+  map: Record<string, string>,
+): void => {
+  const context = readContextFile(file);
+  applyContext(file, { ...context, git: { ...context.git, map } });
+};
+
 /**
  * Record a git branch -> Neon branch mapping in `.neon`, merging into any existing map and
  * preserving the rest of the context. Passes an explicit `git` so {@link applyContext}

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  currentGitBranch,
+  installPostCheckoutHook,
+  isGitRepo,
+  isManagedHook,
+  postCheckoutHookPath,
+  readGitContext,
+  removePostCheckoutHook,
+} from './git.js';
+
+const run = (args: string[], cwd: string) =>
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+
+const initRepo = (dir: string) => {
+  run(['init', '-b', 'main'], dir);
+  run(['config', 'user.email', 'test@example.com'], dir);
+  run(['config', 'user.name', 'Test'], dir);
+  // Pin a repo-local hooks dir so the suite is hermetic even when the machine has a global
+  // `core.hooksPath` (e.g. a managed githooks directory) that would otherwise be targeted.
+  run(['config', 'core.hooksPath', '.git/hooks'], dir);
+  writeFileSync(join(dir, 'README.md'), '# test\n');
+  run(['add', '.'], dir);
+  run(['commit', '-m', 'init'], dir);
+};
+
+describe('git facts', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'neonctl-git-'));
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('reports available:false outside a git repo', () => {
+    const ctx = readGitContext(repo);
+    expect(ctx.available).toBe(false);
+    expect(ctx.branch).toBeUndefined();
+    expect(ctx.triggeredByGitHook).toBe(false);
+  });
+
+  test('reads the current branch, sha, and clean/dirty state', () => {
+    initRepo(repo);
+    expect(isGitRepo(repo)).toBe(true);
+    expect(currentGitBranch(repo)).toBe('main');
+
+    const clean = readGitContext(repo);
+    expect(clean.available).toBe(true);
+    expect(clean.branch).toBe('main');
+    expect(clean.sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(clean.shortSha).toBeDefined();
+    expect(clean.isDirty).toBe(false);
+    expect(clean.isDetached).toBe(false);
+
+    writeFileSync(join(repo, 'new.txt'), 'x');
+    expect(readGitContext(repo).isDirty).toBe(true);
+  });
+
+  test('threads the triggeredByGitHook flag through', () => {
+    initRepo(repo);
+    expect(
+      readGitContext(repo, { triggeredByGitHook: true }).triggeredByGitHook,
+    ).toBe(true);
+  });
+
+  test('detects detached HEAD as isDetached with no branch', () => {
+    initRepo(repo);
+    const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repo,
+      encoding: 'utf-8',
+    }).trim();
+    run(['checkout', sha], repo);
+    const ctx = readGitContext(repo);
+    expect(ctx.isDetached).toBe(true);
+    expect(ctx.branch).toBeUndefined();
+  });
+});
+
+describe('post-checkout hook management', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'neonctl-hook-'));
+    initRepo(repo);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('installs a managed hook, then refreshes it (idempotent)', () => {
+    const first = installPostCheckoutHook(repo);
+    expect(first.status).toBe('installed');
+    const hookPath = postCheckoutHookPath(repo);
+    expect(existsSync(hookPath)).toBe(true);
+    expect(isManagedHook(hookPath)).toBe(true);
+    expect(readFileSync(hookPath, 'utf-8')).toContain('neonctl git sync');
+
+    const second = installPostCheckoutHook(repo);
+    expect(second.status).toBe('updated');
+  });
+
+  test('refuses to clobber a foreign hook', () => {
+    const hookPath = postCheckoutHookPath(repo);
+    writeFileSync(hookPath, '#!/bin/sh\necho not ours\n');
+    const result = installPostCheckoutHook(repo);
+    expect(result.status).toBe('conflict');
+    // Foreign content untouched.
+    expect(readFileSync(hookPath, 'utf-8')).toContain('not ours');
+  });
+
+  test('removes a managed hook but leaves a foreign one', () => {
+    installPostCheckoutHook(repo);
+    expect(removePostCheckoutHook(repo)).toBe('removed');
+    expect(removePostCheckoutHook(repo)).toBe('absent');
+
+    const hookPath = postCheckoutHookPath(repo);
+    writeFileSync(hookPath, '#!/bin/sh\necho not ours\n');
+    expect(removePostCheckoutHook(repo)).toBe('foreign');
+    expect(existsSync(hookPath)).toBe(true);
+  });
+});

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -12,6 +12,8 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {
   currentGitBranch,
+  gitPull,
+  hasUpstream,
   installPostCheckoutHook,
   isGitRepo,
   isManagedHook,
@@ -87,6 +89,34 @@ describe('git facts', () => {
     const ctx = readGitContext(repo);
     expect(ctx.isDetached).toBe(true);
     expect(ctx.branch).toBeUndefined();
+  });
+
+  test('gitPull no-ops with no upstream configured', () => {
+    initRepo(repo);
+    expect(hasUpstream(repo)).toBe(false);
+    expect(gitPull(repo)).toEqual({ status: 'no-upstream' });
+  });
+
+  test('gitPull fast-forwards from a configured upstream', () => {
+    // Set up an "upstream" (a bare-ish clone) so the current branch has @{u} to pull.
+    const upstream = mkdtempSync(join(tmpdir(), 'neonctl-upstream-'));
+    initRepo(upstream);
+    run(['clone', upstream, repo + '-clone'], tmpdir());
+    const clone = repo + '-clone';
+    run(['config', 'user.email', 'test@example.com'], clone);
+    run(['config', 'user.name', 'Test'], clone);
+    try {
+      expect(hasUpstream(clone)).toBe(true);
+      // Advance the upstream, then pull it into the clone.
+      writeFileSync(join(upstream, 'feature.txt'), 'new\n');
+      run(['add', '.'], upstream);
+      run(['commit', '-m', 'advance'], upstream);
+      expect(gitPull(clone)).toEqual({ status: 'pulled' });
+      expect(existsSync(join(clone, 'feature.txt'))).toBe(true);
+    } finally {
+      rmSync(upstream, { recursive: true, force: true });
+      rmSync(clone, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -17,6 +17,7 @@ import {
   installPostCheckoutHook,
   isGitRepo,
   isManagedHook,
+  localGitBranches,
   postCheckoutHookPath,
   readGitContext,
   removePostCheckoutHook,
@@ -89,6 +90,18 @@ describe('git facts', () => {
     const ctx = readGitContext(repo);
     expect(ctx.isDetached).toBe(true);
     expect(ctx.branch).toBeUndefined();
+  });
+
+  test('localGitBranches lists local branches (empty outside a repo)', () => {
+    expect(localGitBranches(repo)).toEqual([]); // not initialized yet
+    initRepo(repo);
+    run(['branch', 'feature/x'], repo);
+    run(['branch', 'preview/y'], repo);
+    expect(localGitBranches(repo).sort()).toEqual([
+      'feature/x',
+      'main',
+      'preview/y',
+    ]);
   });
 
   test('gitPull no-ops with no upstream configured', () => {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,170 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+
+import type { GitContext } from '@neondatabase/config';
+
+import { log } from '../log.js';
+
+/**
+ * Env var the installed `post-checkout` hook sets before invoking `neonctl git sync`, so the
+ * CLI can tell a hook-triggered run from a manual `neonctl checkout` / `deploy`. Surfaced on
+ * {@link GitContext.triggeredByGitHook} so a `checkout.before` hook can decide whether to
+ * follow `git.branch` or honor the explicit `inputName`.
+ */
+export const GIT_HOOK_ENV_FLAG = 'NEON_GIT_HOOK';
+
+/** Sentinel marking the `post-checkout` hook as neonctl-managed (safe to update/remove). */
+const HOOK_SENTINEL =
+  '# neonctl:git-sync (managed — edit `neonctl git` instead)';
+
+const POST_CHECKOUT_HOOK = `#!/usr/bin/env sh
+${HOOK_SENTINEL}
+# Syncs the Neon branch to the checked-out git branch. Runs only on branch switches
+# ($3 == 1), never blocks the checkout, and no-ops when neonctl isn't on PATH.
+[ "$3" = "1" ] || exit 0
+command -v neonctl >/dev/null 2>&1 || exit 0
+${GIT_HOOK_ENV_FLAG}=1 neonctl git sync --quiet || true
+`;
+
+/** Run a git command, returning trimmed stdout, or `undefined` on any failure. */
+const git = (args: string[], cwd: string): string | undefined => {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+};
+
+/** Whether `cwd` is inside a git work tree. */
+export const isGitRepo = (cwd: string): boolean =>
+  git(['rev-parse', '--is-inside-work-tree'], cwd) === 'true';
+
+/** Absolute path to the repository root (`git rev-parse --show-toplevel`), if any. */
+export const gitRepoRoot = (cwd: string): string | undefined =>
+  git(['rev-parse', '--show-toplevel'], cwd);
+
+/** The current branch name, or `undefined` in detached-HEAD state / outside a repo. */
+export const currentGitBranch = (cwd: string): string | undefined => {
+  const branch = git(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd);
+  return branch && branch.length > 0 ? branch : undefined;
+};
+
+/**
+ * Read the read-only git facts the hooks receive. Never throws: outside a repo (or with git
+ * uninstalled) it returns `{ available: false, … }` with the optional fields absent.
+ *
+ * @param cwd directory to inspect.
+ * @param options.triggeredByGitHook whether this invocation came from the post-checkout hook.
+ */
+export const readGitContext = (
+  cwd: string,
+  options: { triggeredByGitHook?: boolean } = {},
+): GitContext => {
+  const triggeredByGitHook = options.triggeredByGitHook ?? false;
+  if (!isGitRepo(cwd)) {
+    return {
+      available: false,
+      isDetached: false,
+      isDirty: false,
+      triggeredByGitHook,
+    };
+  }
+
+  const branch = currentGitBranch(cwd);
+  const sha = git(['rev-parse', 'HEAD'], cwd);
+  const shortSha = git(['rev-parse', '--short', 'HEAD'], cwd);
+  const status = git(['status', '--porcelain'], cwd);
+  // `origin/HEAD` -> e.g. "origin/main"; strip the remote prefix for the bare default branch.
+  const remoteHead = git(['rev-parse', '--abbrev-ref', 'origin/HEAD'], cwd);
+  const defaultBranch = remoteHead?.startsWith('origin/')
+    ? remoteHead.slice('origin/'.length)
+    : undefined;
+  const remoteUrl = git(['remote', 'get-url', 'origin'], cwd);
+  const repoRoot = gitRepoRoot(cwd);
+
+  return {
+    available: true,
+    isDetached: branch === undefined,
+    isDirty: status !== undefined && status.length > 0,
+    triggeredByGitHook,
+    ...(branch ? { branch } : {}),
+    ...(sha ? { sha } : {}),
+    ...(shortSha ? { shortSha } : {}),
+    ...(defaultBranch ? { defaultBranch } : {}),
+    ...(remoteUrl ? { remoteUrl } : {}),
+    ...(repoRoot ? { repoRoot } : {}),
+  };
+};
+
+/**
+ * Path to the `post-checkout` hook for a repo. Uses `git rev-parse --git-path hooks` so it
+ * honors whatever git itself would use — `.git/hooks`, a `core.hooksPath` override (relative
+ * or absolute), worktrees, etc. — instead of re-deriving the rules by hand.
+ */
+export const postCheckoutHookPath = (repoRoot: string): string => {
+  const hooksDir = git(['rev-parse', '--git-path', 'hooks'], repoRoot);
+  const dir = hooksDir
+    ? isAbsolute(hooksDir)
+      ? hooksDir
+      : resolve(repoRoot, hooksDir)
+    : resolve(repoRoot, '.git', 'hooks');
+  return resolve(dir, 'post-checkout');
+};
+
+/** Whether a `post-checkout` hook exists and is neonctl-managed (carries our sentinel). */
+export const isManagedHook = (hookPath: string): boolean => {
+  if (!existsSync(hookPath)) return false;
+  try {
+    return readFileSync(hookPath, 'utf-8').includes(HOOK_SENTINEL);
+  } catch {
+    return false;
+  }
+};
+
+export type InstallHookResult =
+  | { status: 'installed' }
+  | { status: 'updated' }
+  | { status: 'conflict'; hookPath: string };
+
+/**
+ * Install (or refresh) the neonctl-managed `post-checkout` hook. Refuses to clobber a
+ * pre-existing hook we don't own, returning `{ status: 'conflict' }` so the caller can warn
+ * instead of silently overwriting the user's script.
+ */
+export const installPostCheckoutHook = (
+  repoRoot: string,
+): InstallHookResult => {
+  const hookPath = postCheckoutHookPath(repoRoot);
+  const existed = existsSync(hookPath);
+  if (existed && !isManagedHook(hookPath)) {
+    return { status: 'conflict', hookPath };
+  }
+  mkdirSync(dirname(hookPath), { recursive: true });
+  writeFileSync(hookPath, POST_CHECKOUT_HOOK);
+  chmodSync(hookPath, 0o755);
+  return { status: existed ? 'updated' : 'installed' };
+};
+
+export type RemoveHookResult = 'removed' | 'absent' | 'foreign';
+
+/** Remove the managed `post-checkout` hook. Leaves a foreign (user-authored) hook untouched. */
+export const removePostCheckoutHook = (repoRoot: string): RemoveHookResult => {
+  const hookPath = postCheckoutHookPath(repoRoot);
+  if (!existsSync(hookPath)) return 'absent';
+  if (!isManagedHook(hookPath)) return 'foreign';
+  rmSync(hookPath);
+  log.debug('Removed managed post-checkout hook at %s', hookPath);
+  return 'removed';
+};

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -61,6 +61,55 @@ export const currentGitBranch = (cwd: string): string | undefined => {
   return branch && branch.length > 0 ? branch : undefined;
 };
 
+/** Whether the current branch has a configured upstream (`@{u}`) to pull from. */
+export const hasUpstream = (cwd: string): boolean =>
+  git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], cwd) !==
+  undefined;
+
+export type GitPullOutcome =
+  | { status: 'pulled' }
+  | { status: 'no-upstream' }
+  | { status: 'failed'; detail: string };
+
+/**
+ * Fast-forward the current branch from its upstream (`git pull --ff-only`). Used by
+ * `git sync` to bring local files — crucially, committed migration files — up to date with a
+ * shared branch *before* a `checkout.after` migration runs, so a branch that is ahead of your
+ * local tree doesn't leave code↔schema skewed.
+ *
+ * `--ff-only` is deliberate: it never creates a merge commit or leaves conflict markers in
+ * your tree. If the branch has diverged it fails cleanly (reported, non-fatal) instead of
+ * mutating the working tree mid-sync. No-ops (returns `no-upstream`) when there's nothing to
+ * pull from.
+ */
+export const gitPull = (cwd: string): GitPullOutcome => {
+  if (!hasUpstream(cwd)) return { status: 'no-upstream' };
+  try {
+    execFileSync('git', ['pull', '--ff-only'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 'pulled' };
+  } catch (err) {
+    // `git pull` failures (e.g. a diverged branch that can't fast-forward) carry the reason
+    // on `stderr` (a string, since we set `encoding`). Narrow without casting.
+    let detail: string;
+    if (
+      err !== null &&
+      typeof err === 'object' &&
+      'stderr' in err &&
+      typeof err.stderr === 'string' &&
+      err.stderr.trim().length > 0
+    ) {
+      detail = err.stderr.trim();
+    } else {
+      detail = err instanceof Error ? err.message : 'unknown error';
+    }
+    return { status: 'failed', detail };
+  }
+};
+
 /**
  * Read the read-only git facts the hooks receive. Never throws: outside a repo (or with git
  * uninstalled) it returns `{ available: false, … }` with the optional fields absent.

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -61,6 +61,19 @@ export const currentGitBranch = (cwd: string): string | undefined => {
   return branch && branch.length > 0 ? branch : undefined;
 };
 
+/** All local branch names (`refs/heads`). Empty outside a repo or with no branches. */
+export const localGitBranches = (cwd: string): string[] => {
+  const out = git(
+    ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
+    cwd,
+  );
+  if (!out) return [];
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+};
+
 /** Whether the current branch has a configured upstream (`@{u}`) to pull from. */
 export const hasUpstream = (cwd: string): boolean =>
   git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], cwd) !==

--- a/src/utils/hooks.test.ts
+++ b/src/utils/hooks.test.ts
@@ -20,4 +20,47 @@ describe('buildHookEnv', () => {
     expect(env.postgres.databaseUrlUnpooled).toBe('');
     expect(env.branch).toBeUndefined();
   });
+
+  test('a bare policy yields only postgres (+ branch) — no service namespaces', () => {
+    const env = buildHookEnv({
+      DATABASE_URL: 'postgres://pooled/neondb',
+      DATABASE_URL_UNPOOLED: 'postgres://direct/neondb',
+    });
+    expect(env.auth).toBeUndefined();
+    expect(env.dataApi).toBeUndefined();
+    expect(env.storage).toBeUndefined();
+    expect(env.aiGateway).toBeUndefined();
+  });
+
+  test('populates every namespace whose vars are present (sound NeonEnv at runtime)', () => {
+    const env = buildHookEnv({
+      DATABASE_URL: 'postgres://pooled/neondb',
+      DATABASE_URL_UNPOOLED: 'postgres://direct/neondb',
+      NEON_AUTH_BASE_URL: 'https://auth.neon',
+      NEON_AUTH_JWKS_URL: 'https://auth.neon/jwks',
+      NEON_DATA_API_URL: 'https://dataapi.neon',
+      AWS_ACCESS_KEY_ID: 'nak_live_x',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      AWS_ENDPOINT_URL_S3: 'https://s3.neon',
+      AWS_REGION: 'us-east-2',
+      OPENAI_API_KEY: 'sk-neon',
+      OPENAI_BASE_URL: 'https://ai.neon/openai/v1',
+    });
+    expect(env.auth).toEqual({
+      baseUrl: 'https://auth.neon',
+      jwksUrl: 'https://auth.neon/jwks',
+    });
+    expect(env.dataApi).toEqual({ url: 'https://dataapi.neon' });
+    expect(env.storage).toEqual({
+      accessKeyId: 'nak_live_x',
+      secretAccessKey: 'secret',
+      endpoint: 'https://s3.neon',
+      region: 'us-east-2',
+      forcePathStyle: true,
+    });
+    expect(env.aiGateway).toEqual({
+      apiKey: 'sk-neon',
+      baseUrl: 'https://ai.neon/openai/v1',
+    });
+  });
 });

--- a/src/utils/hooks.test.ts
+++ b/src/utils/hooks.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildHookEnv } from './hooks.js';
+
+describe('buildHookEnv', () => {
+  test('maps the flat Neon vars into the structured postgres shape', () => {
+    const env = buildHookEnv({
+      DATABASE_URL: 'postgres://pooled/neondb',
+      DATABASE_URL_UNPOOLED: 'postgres://direct/neondb',
+      NEON_BRANCH: 'preview/feature-billing',
+    });
+    expect(env.postgres.databaseUrl).toBe('postgres://pooled/neondb');
+    expect(env.postgres.databaseUrlUnpooled).toBe('postgres://direct/neondb');
+    expect(env.branch).toEqual({ name: 'preview/feature-billing' });
+  });
+
+  test('omits branch when NEON_BRANCH is absent and defaults missing URLs to empty', () => {
+    const env = buildHookEnv({});
+    expect(env.postgres.databaseUrl).toBe('');
+    expect(env.postgres.databaseUrlUnpooled).toBe('');
+    expect(env.branch).toBeUndefined();
+  });
+});

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -2,16 +2,39 @@ import { Api } from '@neondatabase/api-client';
 import type {
   GitContext,
   HookBranch,
-  HookEnv,
   Hooks,
   NeonApi,
+  NeonAiGatewayEnv,
+  NeonAuthEnv,
+  NeonDataApiEnv,
+  NeonEnv,
+  NeonStorageEnv,
   PushResult,
 } from '@neondatabase/config';
 import { loadConfigFromFile, runHook } from '@neondatabase/config-runtime';
-import { NEON_ENV_VAR_KEYS } from '@neondatabase/env';
 
 import { resolveNeonEnvVars } from '../dev/env.js';
 import { log } from '../log.js';
+
+/**
+ * OS-level env-var names a resolved Neon env can carry. Spelled out as literals (rather than
+ * reaching into `@neondatabase/env`'s `NEON_ENV_VAR_KEYS`) so this stays robust across env
+ * package versions — these names are a stable public contract.
+ */
+const ENV_VARS = {
+  databaseUrl: 'DATABASE_URL',
+  databaseUrlUnpooled: 'DATABASE_URL_UNPOOLED',
+  branch: 'NEON_BRANCH',
+  authBaseUrl: 'NEON_AUTH_BASE_URL',
+  authJwksUrl: 'NEON_AUTH_JWKS_URL',
+  dataApiUrl: 'NEON_DATA_API_URL',
+  awsAccessKeyId: 'AWS_ACCESS_KEY_ID',
+  awsSecretAccessKey: 'AWS_SECRET_ACCESS_KEY',
+  awsEndpoint: 'AWS_ENDPOINT_URL_S3',
+  awsRegion: 'AWS_REGION',
+  openaiApiKey: 'OPENAI_API_KEY',
+  openaiBaseUrl: 'OPENAI_BASE_URL',
+} as const;
 
 /**
  * Load the `hooks` block from the nearest `neon.ts`, or `undefined` when there is no policy
@@ -82,7 +105,7 @@ export const runDeployBeforeHook = async (args: {
 export const runCheckoutAfterHook = async (args: {
   hooks: Hooks | undefined;
   branch: HookBranch;
-  env: HookEnv;
+  env: NeonEnv;
   git: GitContext;
   cwd: string;
 }): Promise<void> => {
@@ -101,7 +124,7 @@ export const runCheckoutAfterHook = async (args: {
 export const runDeployAfterHook = async (args: {
   hooks: Hooks | undefined;
   branch: HookBranch;
-  env: HookEnv;
+  env: NeonEnv;
   result: PushResult;
   git: GitContext;
   cwd: string;
@@ -152,7 +175,7 @@ export const resolveHookEnv = async (args: {
   apiKey?: string;
   apiHost?: string;
   api?: NeonApi;
-}): Promise<HookEnv | undefined> => {
+}): Promise<NeonEnv | undefined> => {
   try {
     const vars = await resolveNeonEnvVars({
       cwd: args.cwd,
@@ -171,32 +194,91 @@ export const resolveHookEnv = async (args: {
   }
 };
 
-/** OS-level var carrying the branch name. Literal (not via NEON_ENV_VAR_KEYS) so this stays
- * compatible across `@neondatabase/env` versions that predate the `branch` key group. */
-const NEON_BRANCH_VAR = 'NEON_BRANCH';
+/**
+ * A resolved Neon env with **all** optional namespaces spelled out. A structural superset of
+ * the bare {@link NeonEnv} (so it's assignable wherever `NeonEnv<C>` is expected) that also
+ * lets us read/populate the policy-dependent namespaces without casting. neonctl resolves a
+ * general env (it doesn't have the literal policy type), populated to match whatever the
+ * policy enabled — which is exactly the `NeonEnv<typeof config>` the hook author's `env` is.
+ */
+export type ResolvedHookEnv = NeonEnv & {
+  auth?: NeonAuthEnv;
+  dataApi?: NeonDataApiEnv;
+  storage?: NeonStorageEnv;
+  aiGateway?: NeonAiGatewayEnv;
+};
 
-/** Map the flat resolved Neon vars into the structured {@link HookEnv}. */
-export const buildHookEnv = (vars: Record<string, string>): HookEnv => {
-  const keys = NEON_ENV_VAR_KEYS;
-  const env: HookEnv = {
+/**
+ * Map the flat resolved Neon vars into a structured {@link ResolvedHookEnv}. Populates
+ * **every** namespace whose vars are present (auth / dataApi / storage / aiGateway), not just
+ * postgres — so the runtime value matches the `NeonEnv<typeof config>` a hook author's `env`
+ * is typed as. `resolveNeonEnvVars` only emits a namespace's vars when the policy enables it,
+ * so the presence here lines up with the policy's static toggles.
+ */
+export const buildHookEnv = (vars: Record<string, string>): ResolvedHookEnv => {
+  const env: ResolvedHookEnv = {
     postgres: {
-      databaseUrl: vars[keys.postgres.databaseUrl] ?? '',
-      databaseUrlUnpooled: vars[keys.postgres.databaseUrlUnpooled] ?? '',
+      databaseUrl: vars[ENV_VARS.databaseUrl] ?? '',
+      databaseUrlUnpooled: vars[ENV_VARS.databaseUrlUnpooled] ?? '',
     },
   };
-  const branchName = vars[NEON_BRANCH_VAR];
+
+  const branchName = vars[ENV_VARS.branch];
   if (branchName) env.branch = { name: branchName };
+
+  const authBaseUrl = vars[ENV_VARS.authBaseUrl];
+  const authJwksUrl = vars[ENV_VARS.authJwksUrl];
+  if (authBaseUrl && authJwksUrl) {
+    env.auth = { baseUrl: authBaseUrl, jwksUrl: authJwksUrl };
+  }
+
+  const dataApiUrl = vars[ENV_VARS.dataApiUrl];
+  if (dataApiUrl) env.dataApi = { url: dataApiUrl };
+
+  const accessKeyId = vars[ENV_VARS.awsAccessKeyId];
+  const secretAccessKey = vars[ENV_VARS.awsSecretAccessKey];
+  if (accessKeyId && secretAccessKey) {
+    env.storage = {
+      accessKeyId,
+      secretAccessKey,
+      endpoint: vars[ENV_VARS.awsEndpoint] ?? '',
+      region: vars[ENV_VARS.awsRegion] ?? '',
+      // Neon's object storage always uses path-style addressing today.
+      forcePathStyle: true,
+    };
+  }
+
+  const aiApiKey = vars[ENV_VARS.openaiApiKey];
+  const aiBaseUrl = vars[ENV_VARS.openaiBaseUrl];
+  if (aiApiKey && aiBaseUrl) {
+    env.aiGateway = { apiKey: aiApiKey, baseUrl: aiBaseUrl };
+  }
+
   return env;
 };
 
-/** Re-derive the OS-level env vars from a {@link HookEnv} for injection into shell hooks. */
-const hookEnvToProcessEnv = (env: HookEnv): Record<string, string> => {
-  const keys = NEON_ENV_VAR_KEYS;
+/** Re-derive the OS-level env vars from a {@link ResolvedHookEnv} for shell-hook injection. */
+const hookEnvToProcessEnv = (env: ResolvedHookEnv): Record<string, string> => {
   const out: Record<string, string> = {
-    [keys.postgres.databaseUrl]: env.postgres.databaseUrl,
-    [keys.postgres.databaseUrlUnpooled]: env.postgres.databaseUrlUnpooled,
+    [ENV_VARS.databaseUrl]: env.postgres.databaseUrl,
+    [ENV_VARS.databaseUrlUnpooled]: env.postgres.databaseUrlUnpooled,
   };
-  if (env.branch?.name) out[NEON_BRANCH_VAR] = env.branch.name;
+  if (env.branch?.name) out[ENV_VARS.branch] = env.branch.name;
+  if (env.auth) {
+    out[ENV_VARS.authBaseUrl] = env.auth.baseUrl;
+    out[ENV_VARS.authJwksUrl] = env.auth.jwksUrl;
+  }
+  if (env.dataApi) out[ENV_VARS.dataApiUrl] = env.dataApi.url;
+  if (env.storage) {
+    out[ENV_VARS.awsAccessKeyId] = env.storage.accessKeyId;
+    out[ENV_VARS.awsSecretAccessKey] = env.storage.secretAccessKey;
+    out[ENV_VARS.awsEndpoint] = env.storage.endpoint;
+    out[ENV_VARS.awsRegion] = env.storage.region;
+  }
+  if (env.aiGateway) {
+    out[ENV_VARS.openaiApiKey] = env.aiGateway.apiKey;
+    out[ENV_VARS.openaiBaseUrl] = env.aiGateway.baseUrl;
+  }
   return out;
 };
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,228 @@
+import { Api } from '@neondatabase/api-client';
+import type {
+  GitContext,
+  HookBranch,
+  HookEnv,
+  Hooks,
+  NeonApi,
+  PushResult,
+} from '@neondatabase/config';
+import { loadConfigFromFile, runHook } from '@neondatabase/config-runtime';
+import { NEON_ENV_VAR_KEYS } from '@neondatabase/env';
+
+import { resolveNeonEnvVars } from '../dev/env.js';
+import { log } from '../log.js';
+
+/**
+ * Load the `hooks` block from the nearest `neon.ts`, or `undefined` when there is no policy
+ * on disk (so every command degrades to a no-op without a `neon.ts`). Other load errors —
+ * a genuinely broken policy — propagate so the user sees them.
+ */
+export const loadHooks = async (cwd: string): Promise<Hooks | undefined> => {
+  try {
+    const { config } = await loadConfigFromFile({ cwd });
+    return config.hooks;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/Could not find a Neon config file/i.test(message)) return undefined;
+    throw err;
+  }
+};
+
+/** Stream hook (shell) output through the CLI logger. */
+const onOutput = (chunk: string) => {
+  const text = chunk.replace(/\n$/, '');
+  if (text.length > 0) log.info('%s', text);
+};
+
+/**
+ * Run the `checkout.before` hook (if any). Returns the rewritten branch name when the hook
+ * (function form) returns `{ name }`, else `undefined`. Throws propagate to abort the
+ * checkout — that's the documented `before`-hook contract.
+ */
+export const runCheckoutBeforeHook = async (args: {
+  hooks: Hooks | undefined;
+  inputName: string;
+  git: GitContext;
+  cwd: string;
+}): Promise<string | undefined> => {
+  const hook = args.hooks?.checkout?.before;
+  if (!hook) return undefined;
+  const result = await runHook(
+    hook,
+    { inputName: args.inputName, git: args.git },
+    { cwd: args.cwd, onOutput },
+  );
+  return result?.name;
+};
+
+/** Run the `deploy.before` hook (if any). Throws propagate to abort the deploy. */
+export const runDeployBeforeHook = async (args: {
+  hooks: Hooks | undefined;
+  branch: HookBranch;
+  git: GitContext;
+  cwd: string;
+}): Promise<void> => {
+  const hook = args.hooks?.deploy?.before;
+  if (!hook) return;
+  await runHook(
+    hook,
+    { branch: args.branch, git: args.git },
+    {
+      cwd: args.cwd,
+      onOutput,
+    },
+  );
+};
+
+/**
+ * Run the `checkout.after` hook (if any). Failures degrade to a warning — the branch is
+ * already checked out, so an `after` failure must not unwind the pin.
+ */
+export const runCheckoutAfterHook = async (args: {
+  hooks: Hooks | undefined;
+  branch: HookBranch;
+  env: HookEnv;
+  git: GitContext;
+  cwd: string;
+}): Promise<void> => {
+  const hook = args.hooks?.checkout?.after;
+  if (!hook) return;
+  await runAfter('checkout.after', () =>
+    runHook(
+      hook,
+      { branch: args.branch, env: args.env, git: args.git },
+      { cwd: args.cwd, env: hookEnvToProcessEnv(args.env), onOutput },
+    ),
+  );
+};
+
+/** Run the `deploy.after` hook (if any). Failures degrade to a warning (apply already ran). */
+export const runDeployAfterHook = async (args: {
+  hooks: Hooks | undefined;
+  branch: HookBranch;
+  env: HookEnv;
+  result: PushResult;
+  git: GitContext;
+  cwd: string;
+}): Promise<void> => {
+  const hook = args.hooks?.deploy?.after;
+  if (!hook) return;
+  await runAfter('deploy.after', () =>
+    runHook(
+      hook,
+      {
+        branch: args.branch,
+        env: args.env,
+        result: args.result,
+        git: args.git,
+      },
+      { cwd: args.cwd, env: hookEnvToProcessEnv(args.env), onOutput },
+    ),
+  );
+};
+
+const runAfter = async (
+  label: string,
+  run: () => Promise<unknown>,
+): Promise<void> => {
+  try {
+    await run();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warning(
+      'The `%s` hook failed: %s\nThe branch change already succeeded; re-run the hook ' +
+        'manually if needed.',
+      label,
+      message,
+    );
+  }
+};
+
+/**
+ * Fetch the branch's resolved Neon env (DATABASE_URL, …) for an `after` hook, shaped into
+ * {@link HookEnv}. Resolved in-memory regardless of `--env-pull`, so a migration hook always
+ * has a connection string even when no `.env` is written. Returns `undefined` on failure so
+ * the caller can skip the hook with a warning rather than crash.
+ */
+export const resolveHookEnv = async (args: {
+  cwd: string;
+  projectId: string;
+  branchId: string;
+  apiKey?: string;
+  apiHost?: string;
+  api?: NeonApi;
+}): Promise<HookEnv | undefined> => {
+  try {
+    const vars = await resolveNeonEnvVars({
+      cwd: args.cwd,
+      projectId: args.projectId,
+      branchId: args.branchId,
+      env: { ...process.env },
+      ...(args.apiKey ? { apiKey: args.apiKey } : {}),
+      ...(args.apiHost ? { apiHost: args.apiHost } : {}),
+      ...(args.api ? { api: args.api } : {}),
+    });
+    return buildHookEnv(vars);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warning('Could not resolve env for the after hook: %s', message);
+    return undefined;
+  }
+};
+
+/** OS-level var carrying the branch name. Literal (not via NEON_ENV_VAR_KEYS) so this stays
+ * compatible across `@neondatabase/env` versions that predate the `branch` key group. */
+const NEON_BRANCH_VAR = 'NEON_BRANCH';
+
+/** Map the flat resolved Neon vars into the structured {@link HookEnv}. */
+export const buildHookEnv = (vars: Record<string, string>): HookEnv => {
+  const keys = NEON_ENV_VAR_KEYS;
+  const env: HookEnv = {
+    postgres: {
+      databaseUrl: vars[keys.postgres.databaseUrl] ?? '',
+      databaseUrlUnpooled: vars[keys.postgres.databaseUrlUnpooled] ?? '',
+    },
+  };
+  const branchName = vars[NEON_BRANCH_VAR];
+  if (branchName) env.branch = { name: branchName };
+  return env;
+};
+
+/** Re-derive the OS-level env vars from a {@link HookEnv} for injection into shell hooks. */
+const hookEnvToProcessEnv = (env: HookEnv): Record<string, string> => {
+  const keys = NEON_ENV_VAR_KEYS;
+  const out: Record<string, string> = {
+    [keys.postgres.databaseUrl]: env.postgres.databaseUrl,
+    [keys.postgres.databaseUrlUnpooled]: env.postgres.databaseUrlUnpooled,
+  };
+  if (env.branch?.name) out[NEON_BRANCH_VAR] = env.branch.name;
+  return out;
+};
+
+/**
+ * Build a {@link HookBranch} from the live branch metadata. `created` is supplied by the
+ * caller (only the checkout/deploy flow knows whether this op created the branch).
+ */
+export const buildHookBranch = async (args: {
+  apiClient: Api<unknown>;
+  projectId: string;
+  branchId: string;
+  created: boolean;
+}): Promise<HookBranch> => {
+  const { data } = await args.apiClient.getProjectBranch(
+    args.projectId,
+    args.branchId,
+  );
+  const branch = data.branch;
+  return {
+    projectId: args.projectId,
+    id: branch.id,
+    name: branch.name,
+    created: args.created,
+    isDefault: branch.default ?? false,
+    isProtected: branch.protected ?? false,
+    ...(branch.parent_id ? { parentId: branch.parent_id } : {}),
+    ...(branch.expires_at ? { expiresAt: branch.expires_at } : {}),
+  };
+};


### PR DESCRIPTION
> **Draft.** Part of a 3-PR series adding `neon.ts` lifecycle hooks and a git → Neon branch workflow. Consumes the hooks contract from **neondatabase/neon-pkgs#221** (locally linked via `pnpm link` until that publishes; bump the `@neondatabase/config*` deps then).

# Overview

## Background: `neon.ts` and `branch()`

`neon.ts` is a config-as-code file for a Neon project (think `vite.config.ts`, but for your database branches). It default-exports a policy built with `defineConfig({ … })` from `@neondatabase/config`, describing a branch's desired state:

- **Static service toggles** — `auth`, `dataApi`, and a `preview` block (functions, buckets, AI Gateway) declare *what exists* on a branch.
- **`branch(target) => ({ … })`** — an existing, **pure** closure for *per-branch tuning* (`protected`, `ttl`, `parent`, compute settings). It returns the desired settings for a given branch and is evaluated whenever the policy is read (`plan` / `status` / `apply`), so by contract it has no side effects.

```ts
// neon.ts as it exists today
export default defineConfig({
  auth: true,
  branch: (branch) => ({ protected: branch.name === "main" }),
});
```

The `neonctl` CLI reads this policy to create and configure branches — e.g. `neonctl checkout <branch>` (pin/create a branch) and `neonctl deploy` (apply the policy).

## What this PR adds

1. **Lifecycle hooks** — an *imperative* companion to `branch()`. Where `branch()` declares *what a branch should look like*, hooks *do things* — run migrations, seed data, send a notification — at the real `checkout` / `deploy` moments. Hooks never run during `plan` / `status`, so the declarative layer stays side-effect free.
2. **A git → Neon workflow** — `git checkout <branch>` checks out the matching Neon branch and runs those hooks. Git is the source of truth and Neon follows it (one directional: `neonctl checkout` only updates local state, never runs git).

The end result: switch git branches normally, and your local `.env` points at an isolated Neon branch that matches your code — already created and migrated.

# Spec

## New CLI commands: `neonctl git …`

This PR adds one new top-level command, `neonctl git`, with five sub-commands:

| Command | What it does |
| --- | --- |
| `neonctl git install` | Writes a managed `post-checkout` git hook (into the repo's effective hooks directory, resolved via `git rev-parse --git-path hooks`, so a custom/global `core.hooksPath` is honored) and records `git.follow` in `.neon`. Run once per clone. Refuses to overwrite a pre-existing hook it doesn't own. |
| `neonctl git uninstall` | Removes the managed hook and clears `git.follow`. Leaves a foreign hook untouched. |
| `neonctl git sync` | Checks out the Neon branch for the current git branch, then records the git → Neon mapping. Invoked automatically by the `post-checkout` hook; also runnable by hand. Can optionally `git pull --ff-only` first (`--pull`). |
| `neonctl git status` | Prints the current git facts, whether the hook is installed, and the git → Neon mapping. Read-only. |
| `neonctl git cleanup` | Prunes `.neon` mappings whose local git branch no longer exists. With `--prune-neon-branches`, also deletes the orphaned Neon branches — **never** the default branch and **never** a protected one. Branch deletion is destructive, so it confirms in an interactive terminal (or `--yes`) and refuses non-interactively. |

## How a branch switch flows

Install the hook once; from then on, plain `git` drives everything (you never run `neonctl git sync` by hand — the hook does):

```
# One-time setup
neonctl git install                       # installs the post-checkout hook (once per clone)

# From then on, just use git as normal:
git checkout -b feature/billing
  └─ [automatic] post-checkout hook → `NEON_GIT_HOOK=1 neonctl git sync --quiet`
       ├─ (opt-in) git pull --ff-only          # bring local code + migration files up to date
       ├─ resolve Neon branch name = git.map[feature/billing] ?? toNeonBranchName("feature/billing")
       ├─ neonctl checkout <neon-branch>          # creates it from the neon.ts policy if absent
       │    ├─ checkout.before({ inputName, git })  → (optional) override the name / abort
       │    └─ checkout.after({ branch, env, git }) → e.g. migrate(env.postgres.databaseUrlUnpooled)
       └─ record the git → Neon mapping in .neon
  → .env now points at an isolated, migrated branch matching your code branch
```

## Lifecycle hooks

A policy may declare a `hooks` block, keyed by the CLI command it brackets. Each phase has a `before` and an `after`:

- `checkout.before({ inputName, git })` — runs before the branch is resolved. May **rename** the branch (return `{ name }`) or **abort** (throw / a shell hook exiting non-zero).
- `checkout.after({ branch, env, git })` — runs after the branch is checked out and its env is resolved. `branch.created` tells you whether this checkout created the branch or selected an existing one.
- `deploy.before({ branch, git })` / `deploy.after({ branch, env, result, git })` — bracket `neonctl deploy` (apply the policy). `result` is what the apply changed.

A hook is either a function `(ctx) => …` or a shell command (a string, or an array run in sequence). `before` hooks influence/abort; `after` hooks observe (a failure is reported as a warning — the branch change already happened). The connection env (`env`) is resolved in memory and passed in even when `--no-env-pull` is set, so a migration hook always has a connection string.

`env` is the resolved Neon environment for the branch, typed precisely to the policy: `env.postgres.databaseUrl` / `databaseUrlUnpooled` are always present, and `env.auth` / `env.dataApi` / `env.storage` / `env.aiGateway` appear when the policy enables those services.

### Example `neon.ts`

A complete policy that migrates with Drizzle. `checkout.before` is **optional** — `neonctl git sync` already derives a valid Neon branch name by default, so you only add `before` to customize it:

```ts
import { defineConfig, toNeonBranchName } from "@neondatabase/config/v1";
import type { CheckoutBeforeContext, HookBranch } from "@neondatabase/config/v1";
import postgres from "postgres";
import { drizzle } from "drizzle-orm/postgres-js";
import { migrate } from "drizzle-orm/postgres-js/migrator";

const MIGRATIONS_DIR = "./drizzle";

/** Apply committed migrations against a branch's direct (unpooled) connection. */
async function runMigrations(databaseUrl: string): Promise<void> {
  const sql = postgres(databaseUrl, { max: 1 });
  try {
    await migrate(drizzle(sql), { migrationsFolder: MIGRATIONS_DIR });
  } finally {
    await sql.end();
  }
}

/** Only auto-migrate a branch you own — never a shared/protected one (e.g. main). */
function shouldMigrateOnCheckout(branch: HookBranch): boolean {
  if (branch.isProtected || branch.isDefault) {
    return false;
  }
  return branch.created;
}

/** Optional: customize the Neon branch name derived from the git branch. */
function neonBranchNameFor({ inputName, git }: CheckoutBeforeContext): string {
  // Manual `neonctl checkout <name>` (not the git hook): honor the name as typed.
  if (!git.triggeredByGitHook || !git.branch) {
    return inputName;
  }
  // Keep the trunk as-is; turn every other git branch into a preview branch.
  if (git.branch === "main" || git.branch === "master") {
    return "main";
  }
  return toNeonBranchName(git.branch, { prefix: "preview/" });
}

export default defineConfig({
  auth: true,
  branch: (branch) => ({ protected: branch.name === "main" }),

  hooks: {
    checkout: {
      before: (ctx) => ({ name: neonBranchNameFor(ctx) }),
      after: async ({ branch, env }) => {
        if (!shouldMigrateOnCheckout(branch)) {
          console.log(`Skipping migrations for ${branch.name}.`);
          return;
        }
        console.log(`Applying migrations to ${branch.name}…`);
        await runMigrations(env.postgres.databaseUrlUnpooled);
      },
    },

    deploy: {
      // Explicit deploy (e.g. CI deploying a PR branch) → always migrate.
      after: async ({ env }) => {
        await runMigrations(env.postgres.databaseUrlUnpooled);
      },
    },
  },
});
```

### The `git` context

Every hook receives a read-only `git` object describing the surrounding repository — hooks can *read* git but never drive it. Fields: `available`, `branch`, `sha`, `shortSha`, `isDetached`, `isDirty`, `defaultBranch`, `remoteUrl`, `repoRoot`, and `triggeredByGitHook` (true when the run came from the installed `post-checkout` hook vs. a manual command). There is intentionally no `git.checkout()` — git stays the source of truth.

`git` is populated whether you run `neonctl checkout` directly or it's invoked by the hook:

| What you run | Who calls `neonctl checkout` | `inputName` | `git.branch` | `git.triggeredByGitHook` |
| --- | --- | --- | --- | --- |
| `neonctl checkout dev-1` (repo on `feature/x`) | you, directly | `"dev-1"` | `"feature/x"` | `false` |
| `neonctl checkout dev-1` (not a git repo) | you, directly | `"dev-1"` | `undefined` (`available: false`) | `false` |
| `git checkout feature/x` | the `post-checkout` hook → `neonctl git sync` | `toNeonBranchName("feature/x")` → `"feature/x"` | `"feature/x"` | `true` |

Walking the last row: after `neonctl git install`, running `git checkout feature/x` fires the `post-checkout` hook, which runs `neonctl git sync`. `git sync` reads the current git branch and derives a Neon-safe name with `toNeonBranchName("feature/x")`, passing it to `neonctl checkout` as `inputName`. Here it's unchanged — `toNeonBranchName` preserves `/` (Neon branch names allow it) and the name is already lowercase, so `"feature/x"` stays `"feature/x"` (it would become `"feature-x"` only with `preserveSlashes: false`, or for a name that needs sanitizing like `Feature/X`). A `checkout.before` hook can override it (it also gets the raw branch on `git.branch`). The resolved name is saved to `.neon` `git.map` and reused next time, so the same git branch always maps to the same Neon branch.

## Naming convention: git branch → Neon branch

`neonctl git sync` resolves the Neon branch name as:

```ts
const inputName = gitBranchMapping(context, gitBranch) ?? toNeonBranchName(gitBranch);
// `checkout.before` (if present) may then override it; the result is saved back to git.map
```

Precedence (first match wins) — valid by default, fully overridable:

1. **Recorded mapping** — `.neon` `git.map[gitBranch]`, saved after each sync, so a git branch always resolves to the same Neon branch (no duplicates).
2. **Default derivation** — `toNeonBranchName(gitBranch)` from `@neondatabase/config` when there's no mapping yet, so a brand-new branch is always a valid Neon name with no hook required. (Lowercases, reduces each path segment to `[a-z0-9-]`, preserves `/` hierarchy — pass `preserveSlashes: false` for a flat token — and falls back to `branch`.)
3. **`checkout.before` hook (optional)** — overrides the above for custom conventions, e.g. `toNeonBranchName(git.branch, { prefix: "preview/" })`.

## When commands prompt vs. run automatically

The CLI follows one rule, consistent with `neonctl link` / `checkout` / `bootstrap`: an explicit flag always wins; otherwise prompt only in an interactive terminal, and in CI / non-interactive contexts use a safe default or error (never block on a prompt).

| Command / step | Interactive terminal | Hook / CI / non-TTY |
| --- | --- | --- |
| `neonctl link` | prompts to pick project/branch | needs flags, else errors |
| `neonctl checkout <missing-name>` | prompts "create it?" (Y/n) | errors (never auto-creates) |
| `neonctl bootstrap` | guided prompts | flag-driven |
| `neonctl git install` | refuses to overwrite a foreign hook (errors) | same |
| `neonctl git sync` → env pull | on by default; `--no-env-pull` to skip | same |
| `neonctl git sync` → git pull | prompts (default N) | skipped unless `--pull` |
| `neonctl git sync` → detached HEAD | skips (nothing to map) | skips |
| `neonctl git cleanup --prune-neon-branches` | confirms deletion (default N) | refuses unless `--yes` |

## The `git pull` step

`neonctl git sync` can fast-forward local files before checkout with `git pull --ff-only` (`--pull` / `--no-pull`, else a prompt in an interactive terminal). This keeps your **committed migration files** in step with the branch: if you check out a Neon branch that is ahead of your local tree, your local migration files may be behind what's already applied — `migrate` then has nothing to do (safe) but your code and schema can diverge, with no down-migration to reconcile them. Pulling first brings the migration files up to date before `checkout.after` runs.

`--ff-only` never creates a merge commit or leaves conflict markers — on a diverged branch it fails cleanly (reported, non-fatal) and the sync continues. It's opt-in (it hits the network) and is never run automatically from the hook or CI.

## Cleaning up stale branches

Over time the `git.map` accumulates entries for git branches you've since deleted locally. `neonctl git cleanup` reconciles it against your local git branches:

- **Default** — drops mapping entries whose git branch no longer exists locally (touches only `.neon`; nothing on Neon).
- **`--prune-neon-branches`** — additionally deletes the orphaned Neon branches (the ones those stale entries pointed at). The default branch and any protected branch are **never** deleted (they're reported as skipped). Because deleting branches is destructive, it confirms in an interactive terminal (or `--yes`) and refuses to delete non-interactively.

## `.neon` mapping and `set-context`

- `.neon` gains a `git` block: `{ follow, map }`, where `map` values are real Neon branch names (the same form as the existing `branch` field).
- The deprecated `neonctl set-context` (and a plain `checkout`) **preserve** the `git` block: writing `.neon` without an explicit `git` keeps the existing mapping, so re-pinning project/org/branch never wipes it. The raw project/org/branch write behavior is otherwise unchanged.

## Migration edge cases

Auto-applying migrations is unsafe in some situations, so hooks expose the signals to guard on rather than migrating unconditionally: protected/default branches (`branch.isProtected` / `isDefault`); selecting a pre-existing shared branch (`!branch.created`, mitigated by `git sync --pull`); detached HEAD or an older commit; a dirty tree with ungenerated migrations (`git.isDirty`); concurrent runners (use a Postgres advisory lock); using the pooled URL for DDL (prefer `databaseUrlUnpooled`); and a cold start on a freshly-created branch (retry the first connect). A ready-made, guarded Drizzle `migrateHook` that bakes in this policy is planned for PR3.

# What this PR implements

- **`.neon` context** (`src/context.ts`): the `git` block (`{ follow, map }`, real Neon slugs as values); a git-preserving `applyContext`; `gitBranchMapping` / `gitBranchMap` / `setGitBranchMapping` / `setGitBranchMap` / `setGitFollow` helpers.
- **git utilities** (`src/utils/git.ts`): read-only git facts (`readGitContext` → `GitContext`); managed `post-checkout` hook install/remove (sentinel-guarded, honoring `core.hooksPath`); `git pull --ff-only` (`hasUpstream` / `gitPull`); `localGitBranches`.
- **hook plumbing** (`src/utils/hooks.ts`): build the `git` / branch / env contexts and run the checkout/deploy `before`+`after` hooks via the runtime runner. `env` is resolved in memory (even under `--no-env-pull`) and populated for every namespace the policy enables, so it matches the typed `NeonEnv<typeof config>`.
- **`neonctl git`** (`src/commands/git.ts`): `install` / `uninstall` / `sync` / `status` / `cleanup`, with `sync` deriving the default Neon-safe name + the opt-in `--pull` step, and `cleanup` pruning stale mappings + (with `--prune-neon-branches`) deleting orphaned Neon branches via the pure `partitionBranchesToPrune` (default/protected never deleted).
- **checkout / deploy**: invoke the hooks at the existing seams (rename before resolution; migrate-style work after env is available).
- **Tests** (real temp git repos + temp `.neon` files, no mocks): git facts + detached HEAD; managed-hook install/refresh/conflict/remove; `gitPull` no-upstream and fast-forward; `.neon` git preservation + mapping helpers; `set-context` preserving an existing `git` block; the env mapping (postgres-only by default, all namespaces when present).

# Existing machinery this builds on

- **`neonctl checkout`** — branch resolution (name/id), `.neon` pin, interactive "create it?" prompt, bundled env pull. The checkout hooks slot into its existing seams.
- **`neonctl deploy` (`config apply`)** — load policy → resolve branch → apply → env pull. The deploy hooks bracket this unchanged flow.
- **Policy-driven branch create on checkout**, the env resolver (`resolveNeonEnvVars`), and the `.neon` context (`projectId` / `orgId` / `branch`, `applyContext`, `enrichFromContext`) — all reused; `set-context` is extended (git preservation), not replaced.

# Test plan

- [x] `context.test.ts`: `applyContext` preserves vs. replaces `git`; mapping helpers.
- [x] `set_context.test.ts`: an existing `git` block survives a `set-context` write.
- [x] `utils/git.test.ts` (real temp git repos): facts, dirty/clean, detached HEAD; hook install/refresh/conflict/remove (hermetic against a global `core.hooksPath`); `gitPull` no-upstream + fast-forward; `localGitBranches`.
- [x] `commands/git.test.ts`: `partitionBranchesToPrune` deletes only orphaned, non-default, non-protected branches.
- [x] `utils/hooks.test.ts`: env mapping — postgres-only for a bare policy, all namespaces when present.
- [x] Touched files pass; `tsc` / eslint / prettier clean. (The full suite has pre-existing parallel mock-server flakiness unrelated to this change.)
- [ ] End-to-end git → checkout → migrate loop — lands with PR3 (`@neondatabase/config-runtime/drizzle`) against a real Neon branch.

# Follow-ups

- Bump `@neondatabase/config*` to the published hooks release and remove the `pnpm link` stand-in.
- PR3: `@neondatabase/config-runtime/drizzle` (`runMigrations`, `getPendingMigrations`, `isUpToDate`, `migrateHook`) with real-Postgres end-to-end tests.
- Optionally let `neonctl git install --pull` bake the pull step into the generated hook for users who want auto-pull on every checkout.
