### PR TITLE
fix(env): drop removed NEON_STORAGE_FORCE_PATH_STYLE from owned env keys

### DIFF
--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -99,7 +99,6 @@ const NEON_OWNED_ENV_KEYS: readonly string[] = [
   ...Object.values(NEON_ENV_VAR_KEYS.auth),
   ...Object.values(NEON_ENV_VAR_KEYS.dataApi),
   NEON_ENV_VAR_KEYS.storage.regionNeon,
-  NEON_ENV_VAR_KEYS.storage.forcePathStyle,
   NEON_ENV_VAR_KEYS.aiGateway.neonToken,
   NEON_ENV_VAR_KEYS.aiGateway.neonBaseUrl,
 ];


### PR DESCRIPTION
## Summary

Follows neondatabase/neon-pkgs#225, which removes the always-`true` `NEON_STORAGE_FORCE_PATH_STYLE` var from `@neondatabase/env`.

`env pull` keeps a list of "Neon-owned" keys it prunes when stale. With the var gone from `NEON_ENV_VAR_KEYS.storage`, the reference `NEON_ENV_VAR_KEYS.storage.forcePathStyle` no longer exists, so it's dropped from that list.

## Changes

- Remove `NEON_ENV_VAR_KEYS.storage.forcePathStyle` from `NEON_OWNED_ENV_KEYS` in `src/commands/env.ts`.

## Test plan

- [x] `pnpm typecheck`
- [x] `vitest run src/commands/env.test.ts` (8/8)

## Note

Depends on neondatabase/neon-pkgs#225 — merge/release that first (this won't compile against the current published `@neondatabase/env`, which still exports the key).