### PR TITLE
fix(env): drop removed NEON_STORAGE_REGION from owned env keys

### DIFF
--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -98,7 +98,6 @@ const NEON_OWNED_ENV_KEYS: readonly string[] = [
   ...Object.values(NEON_ENV_VAR_KEYS.postgres),
   ...Object.values(NEON_ENV_VAR_KEYS.auth),
   ...Object.values(NEON_ENV_VAR_KEYS.dataApi),
-  NEON_ENV_VAR_KEYS.storage.regionNeon,
   NEON_ENV_VAR_KEYS.storage.forcePathStyle,
   NEON_ENV_VAR_KEYS.aiGateway.neonToken,
   NEON_ENV_VAR_KEYS.aiGateway.neonBaseUrl,


### PR DESCRIPTION
## Summary

Follows neondatabase/neon-pkgs#226, which removes the redundant `NEON_STORAGE_REGION` alias from `@neondatabase/env`.

With the var gone from `NEON_ENV_VAR_KEYS.storage`, the reference `NEON_ENV_VAR_KEYS.storage.regionNeon` no longer exists, so it's dropped from the `env pull` owned-key prune list.

## Changes

- Remove `NEON_ENV_VAR_KEYS.storage.regionNeon` from `NEON_OWNED_ENV_KEYS` in `src/commands/env.ts`.

## Test plan

- [x] `pnpm typecheck`
- [x] `vitest run src/commands/env.test.ts` (8/8)

## Note

Depends on neondatabase/neon-pkgs#226 — merge/release that first (won't compile against the current published `@neondatabase/env`, which still exports the key).