### PR TITLE
refactor: replace axios with native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,6 @@
     "@neondatabase/config-runtime": "0.8.0",
     "@neondatabase/env": "0.6.0",
     "@segment/analytics-node": "1.3.0",
-    "axios": "1.7.2",
-    "axios-debug-log": "1.0.0",
     "chalk": "5.3.0",
     "chokidar": "5.0.0",
     "cli-table": "0.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,6 @@ importers:
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
-      axios:
-        specifier: 1.7.2
-        version: 1.7.2
-      axios-debug-log:
-        specifier: 1.0.0
-        version: 1.0.0(axios@1.7.2)
       chalk:
         specifier: 5.3.0
         version: 5.3.0
@@ -1161,9 +1155,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/debug@4.1.13':
-    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
-
   '@types/diff@5.2.1':
     resolution: {integrity: sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==}
 
@@ -1199,9 +1190,6 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@18.19.41':
     resolution: {integrity: sha512-LX84pRJ+evD2e2nrgYCHObGWkiQJ1mL+meAgbvnwk/US6vmMY7S2ygBTGV2Jw91s9vUsLSXeDEkUHZIJGLrhsg==}
@@ -1435,16 +1423,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios-debug-log@1.0.0:
-    resolution: {integrity: sha512-ZjMaEBEij9w+Vbk2Uc3XflchTT7j9rZdYD/snN+XQ5FRDq1QjZNhh0Izb3KSyarU5vTkiCvJyg1xDiQBHZZB9w==}
-    peerDependencies:
-      axios: '>=1.0.0'
-
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
-  axios@1.7.2:
-    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -3040,9 +3020,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -3887,7 +3864,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4547,10 +4524,6 @@ snapshots:
     dependencies:
       '@types/node': 18.19.41
 
-  '@types/debug@4.1.13':
-    dependencies:
-      '@types/ms': 2.1.0
-
   '@types/diff@5.2.1': {}
 
   '@types/docker-modem@3.0.6':
@@ -4596,8 +4569,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/minimist@1.2.5': {}
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@18.19.41':
     dependencies:
@@ -4918,14 +4889,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-debug-log@1.0.0(axios@1.7.2):
-    dependencies:
-      '@types/debug': 4.1.13
-      axios: 1.7.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -4935,14 +4898,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  axios@1.7.2:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   b4a@1.8.1: {}
 
@@ -5230,7 +5185,7 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@18.19.41)(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.8.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.8.3)
@@ -6609,8 +6564,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { Analytics, TrackParams } from '@segment/analytics-node';
-import { isAxiosError } from 'axios';
 
+import { apiErrorRequestId, isApiError } from './utils/http.js';
 import { CREDENTIALS_FILE } from './config.js';
 import { getGithubEnvVars, isCi } from './env.js';
 import { ErrorCode } from './errors.js';
@@ -120,8 +120,8 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
   if (!client) {
     return;
   }
-  const axiosError = isAxiosError(err) ? err : undefined;
-  const requestId = axiosError?.response?.headers['x-neon-ret-request-id'];
+  const apiError = isApiError(err) ? err : undefined;
+  const requestId = apiError ? apiErrorRequestId(apiError) : undefined;
   if (requestId) {
     log.debug('Failed request ID: %s', requestId);
   }
@@ -132,7 +132,7 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
       message: err.message,
       stack: err.stack,
       errCode,
-      statusCode: axiosError?.response?.status,
+      statusCode: apiError?.response?.status,
       requestId: requestId,
     },
   });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { createApiClient } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
 
+import { isApiError } from './utils/http.js';
 import { log } from './log.js';
 import pkg from './pkg.js';
 
@@ -29,7 +29,7 @@ export const retryOnLock = async <T>(fn: () => Promise<T>): Promise<T> => {
       return await fn();
     } catch (err) {
       errOut = err;
-      if (isAxiosError(err) && err.response?.status === 423) {
+      if (isApiError(err) && err.response?.status === 423) {
         attempt++;
         log.info(
           `Resource is locked. Waiting ${RETRY_DELAY}ms before retrying...`,

--- a/src/commands/auth.test.ts
+++ b/src/commands/auth.test.ts
@@ -1,5 +1,4 @@
 import { Api } from '@neondatabase/api-client';
-import axios from 'axios';
 
 import {
   existsSync,
@@ -18,7 +17,7 @@ import { test } from '../test_utils/fixtures';
 import { startOauthServer } from '../test_utils/oauth_server';
 import { authFlow, ensureAuth, deleteCredentials } from './auth';
 
-vi.mock('open', () => ({ default: vi.fn((url: string) => axios.get(url)) }));
+vi.mock('open', () => ({ default: vi.fn((url: string) => fetch(url)) }));
 vi.mock('../pkg.ts', () => ({ default: { version: '0.0.0' } }));
 
 describe('auth', () => {

--- a/src/commands/bucket.ts
+++ b/src/commands/bucket.ts
@@ -3,9 +3,9 @@ import { stat, unlink } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import yargs from 'yargs';
-import axios, { isAxiosError } from 'axios';
 
 import { retryOnLock } from '../api.js';
+import { httpFetch, isApiError, streamToWeb } from '../utils/http.js';
 import { BranchScopeProps } from '../types.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { log } from '../log.js';
@@ -295,7 +295,7 @@ const deleteBucket = async (
       }),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(
         `Bucket "${props.name}" not found on branch ${branchId}.`,
       );
@@ -452,7 +452,7 @@ const objectNotFoundMessage = (
   bucket: string,
   branchId: string,
 ): string => {
-  if (isAxiosError(err)) {
+  if (isApiError(err)) {
     const serverMessage = serverErrorMessage(err.response?.data);
     if (serverMessage !== undefined) {
       return serverMessage;
@@ -479,7 +479,7 @@ const getObject = async (
       objectKey: key,
     });
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       // The download response is a stream, so a 404 body arrives as a stream
       // too; drain and parse it to recover the server's message (which
       // distinguishes a missing bucket from a missing object).
@@ -558,7 +558,7 @@ const putObject = async (
       contentType: props.contentType,
     }));
   } catch (err: unknown) {
-    if (isAxiosError(err)) {
+    if (isApiError(err)) {
       const status = err.response?.status;
       if (status === 404) {
         throw new Error(objectNotFoundMessage(err, key, bucket, branchId));
@@ -580,30 +580,32 @@ const putObject = async (
 
   // Stream the file straight into the PUT body; never buffer the whole file.
   // The presigned URL targets the branch S3 data-plane endpoint directly, so
-  // this PUT goes through a plain axios call rather than the console api-client.
+  // this PUT goes through a plain `fetch` rather than the console api-client.
   //
   // `presign.headers` carries the signature-relevant headers (e.g. host,
   // content-type); the server does not sign Content-Length, so we set it
   // ourselves from the stat'd size to keep the upload streamed, not chunked.
-  // `maxRedirects: 0` ensures we never resend the file bytes and signed headers
-  // to a different host if the data-plane endpoint were to answer with a
-  // redirect.
+  // `redirect: 'error'` ensures we never resend the file bytes and signed
+  // headers to a different host if the data-plane endpoint were to answer with a
+  // redirect. The file stream is adapted to a web stream so it can be a `fetch`
+  // body; `duplex: 'half'` is required by the runtime when streaming a request.
   try {
-    await axios.put(presign.url, createReadStream(props.file), {
+    await httpFetch(presign.url, {
+      method: 'PUT',
       headers: {
         ...presign.headers,
-        'Content-Length': fileSize,
+        'Content-Length': String(fileSize),
       },
-      maxBodyLength: Infinity,
-      maxContentLength: Infinity,
-      maxRedirects: 0,
+      body: streamToWeb(createReadStream(props.file)),
+      duplex: 'half',
+      redirect: 'error',
     });
   } catch (err: unknown) {
     // The upload targets the S3 data plane, whose error bodies are XML rather
     // than the JSON `{ message }` the console returns, so surface the status
-    // (and axios message) rather than leaking a raw error. Never include the
+    // (and the error message) rather than leaking a raw error. Never include the
     // presigned URL, which carries the signature.
-    if (isAxiosError(err)) {
+    if (isApiError(err)) {
       const status = err.response?.status;
       throw new Error(
         `Failed to upload "${props.file}" to "${key}" in bucket "${bucket}" on branch ${branchId}${
@@ -664,7 +666,7 @@ const deleteObject = async (
       }),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(objectNotFoundMessage(err, rest, bucket, branchId));
     }
     throw err;

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -1,5 +1,4 @@
 import { Branch } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import yargs from 'yargs';
@@ -14,6 +13,7 @@ import {
 } from '../utils/branch_picker.js';
 import { fillSingleProject } from '../utils/enrichers.js';
 import { looksLikeBranchId } from '../utils/formats.js';
+import { isApiError } from '../utils/http.js';
 import { autoPullEnvAfterPin } from './env.js';
 import {
   applyPolicyOnCreate,
@@ -296,7 +296,7 @@ const resolveOrgId = async (
     const { data } = await props.apiClient.getProject(projectId);
     return data.project.org_id ?? undefined;
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 401) {
+    if (isApiError(err) && err.response?.status === 401) {
       throw err;
     }
     log.debug(
@@ -390,7 +390,7 @@ const tryAutoDetectProject = async (
     // `fillSingleProject` throws on "No projects found" / "Multiple projects
     // found" — both mean we can't pick a project automatically. Network/auth
     // errors are real and should surface to the user.
-    if (isAxiosError(err)) {
+    if (isApiError(err)) {
       throw err;
     }
     log.debug(

--- a/src/commands/data_api.ts
+++ b/src/commands/data_api.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs';
-import { isAxiosError } from 'axios';
 
 import { retryOnLock } from '../api.js';
+import { isApiError } from '../utils/http.js';
 import { BranchScopeProps } from '../types.js';
 import {
   branchIdFromProps,
@@ -305,7 +305,7 @@ const update = async (
       );
       current = data.settings ?? undefined;
     } catch (err: unknown) {
-      if (isAxiosError(err) && err.response?.status === 404) {
+      if (isApiError(err) && err.response?.status === 404) {
         throw new Error(
           `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
         );
@@ -333,7 +333,7 @@ const update = async (
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
       );
@@ -361,7 +361,7 @@ const refreshSchema = async (props: DataApiProps): Promise<void> => {
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
       );
@@ -390,7 +390,7 @@ const deleteDataApi = async (props: DataApiProps): Promise<void> => {
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}.`,
       );

--- a/src/commands/functions.ts
+++ b/src/commands/functions.ts
@@ -2,9 +2,9 @@ import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import yargs from 'yargs';
-import { isAxiosError } from 'axios';
 
 import { retryOnLock } from '../api.js';
+import { isApiError } from '../utils/http.js';
 import { log } from '../log.js';
 import { BranchScopeProps } from '../types.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
@@ -239,7 +239,7 @@ const emitDeployResult = (
 // A poll error worth retrying: a network error (no HTTP response), a 5xx, or a
 // 404 from eventual consistency. Anything else (e.g. 401/403) is surfaced.
 const isTransient = (err: unknown): boolean =>
-  isAxiosError(err) &&
+  isApiError(err) &&
   (err.response === undefined ||
     err.response.status === 404 ||
     err.response.status >= 500);
@@ -306,7 +306,7 @@ const deploy = async (props: DeployProps) => {
     );
     before = fn.current_deployment?.id;
   } catch (err: unknown) {
-    if (!(isAxiosError(err) && err.response?.status === 404)) throw err;
+    if (!(isApiError(err) && err.response?.status === 404)) throw err;
   }
 
   await retryOnLock(() =>
@@ -467,7 +467,7 @@ const deleteFn = async (props: BranchScopeProps & { slug: string }) => {
       deleteFunction(props.apiClient, props.projectId, branchId, props.slug),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       throw new Error(
         `Function "${props.slug}" not found on branch ${branchId}.`,
       );

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -5,7 +5,6 @@ import {
   ProjectListItem,
   RegionResponse,
 } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
 import prompts, { InitialReturnValue } from 'prompts';
 import yargs from 'yargs';
 
@@ -24,6 +23,7 @@ import {
   createBranch,
   pickBranchInteractively,
 } from '../utils/branch_picker.js';
+import { apiErrorMessage, isApiError } from '../utils/http.js';
 import { autoPullEnvAfterPin, renderAgentPullNote } from './env.js';
 import { REGIONS } from './projects.js';
 
@@ -386,7 +386,7 @@ class LinkInputError extends Error {
 }
 
 const httpStatus = (err: unknown): number | undefined =>
-  isAxiosError(err) ? err.response?.status : undefined;
+  isApiError(err) ? err.response?.status : undefined;
 
 /**
  * Fetch a project, turning the common failure modes into clear, actionable
@@ -1053,15 +1053,8 @@ const emitAgent = (response: AgentResponse) => {
 const ORG_KEY_LIMITED_FRAGMENT = 'not allowed for organization API keys';
 
 const isOrgKeyLimitedError = (err: unknown): boolean => {
-  if (!isAxiosError(err)) return false;
-  const data = err.response?.data;
-  if (data === undefined || data === null || typeof data !== 'object') {
-    return false;
-  }
-  const message = (data as { message?: unknown }).message;
-  return (
-    typeof message === 'string' && message.includes(ORG_KEY_LIMITED_FRAGMENT)
-  );
+  if (!isApiError(err)) return false;
+  return apiErrorMessage(err)?.includes(ORG_KEY_LIMITED_FRAGMENT) ?? false;
 };
 
 const fetchOrganizations = async (
@@ -1156,17 +1149,9 @@ const toAgentError = (
   if (err instanceof LinkInputError) {
     return { status: 'error', code: err.agentCode, message: err.message };
   }
-  if (isAxiosError(err)) {
+  if (isApiError(err)) {
     const status = err.response?.status;
-    const data = err.response?.data;
-    const apiMessage =
-      typeof data === 'object' && data !== null
-        ? (data as { message?: unknown }).message
-        : undefined;
-    const message =
-      typeof apiMessage === 'string' && apiMessage.length > 0
-        ? apiMessage
-        : err.message;
+    const message = apiErrorMessage(err) ?? err.message;
     let code = 'API_ERROR';
     if (status === 401 || status === 403) {
       code = 'AUTH_ERROR';
@@ -1255,7 +1240,7 @@ const fetchRegions = async (props: CommonProps): Promise<RegionResponse[]> => {
       return data.regions;
     }
   } catch (err) {
-    if (isAxiosError(err)) {
+    if (isApiError(err)) {
       log.debug(
         'getActiveRegions failed (%s), falling back to the static region list.',
         err.response?.status ?? err.code ?? err.message,

--- a/src/commands/neon_auth.ts
+++ b/src/commands/neon_auth.ts
@@ -6,10 +6,10 @@ import {
   NeonAuthOauthProviderType,
   NeonAuthEmailVerificationMethod,
 } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
 import chalk from 'chalk';
 import yargs from 'yargs';
 import { retryOnLock } from '../api.js';
+import { apiErrorBodyCode, isApiError } from '../utils/http.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 import { writer } from '../writer.js';
@@ -671,7 +671,7 @@ const enable = async (props: AuthBranchProps & { databaseName?: string }) => {
       }),
     ));
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 409) {
+    if (isApiError(err) && err.response?.status === 409) {
       alreadyEnabled = true;
       ({ data } = await props.apiClient.getNeonAuth(props.projectId, branchId));
     } else {
@@ -715,7 +715,7 @@ const status = async (props: AuthBranchProps) => {
   try {
     ({ data } = await props.apiClient.getNeonAuth(props.projectId, branchId));
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       printMessage('Neon Auth is not configured for this branch');
       return;
     }
@@ -798,9 +798,8 @@ const oauthProviderAdd = async (
     ));
   } catch (err) {
     if (
-      isAxiosError(err) &&
-      (err.response?.data as { code?: string } | undefined)?.code ===
-        'INVALID_SHARED_OAUTH_PROVIDER'
+      isApiError(err) &&
+      apiErrorBodyCode(err) === 'INVALID_SHARED_OAUTH_PROVIDER'
     ) {
       throw new Error(
         `The "${props.providerId}" provider requires your own OAuth app credentials.\n` +
@@ -847,9 +846,8 @@ const oauthProviderUpdate = async (
     ));
   } catch (err) {
     if (
-      isAxiosError(err) &&
-      (err.response?.data as { code?: string } | undefined)?.code ===
-        'INVALID_SHARED_OAUTH_PROVIDER'
+      isApiError(err) &&
+      apiErrorBodyCode(err) === 'INVALID_SHARED_OAUTH_PROVIDER'
     ) {
       throw new Error(
         `The "${props.providerId}" provider requires your own OAuth app credentials.\n` +

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -16,7 +16,7 @@ import { writer } from '../writer.js';
 import { psql } from '../utils/psql.js';
 import { updateContextFile } from '../context.js';
 import { getComputeUnits } from '../utils/compute_units.js';
-import { isAxiosError } from 'axios';
+import { apiErrorMessage, isApiError } from '../utils/http.js';
 import prompts, { InitialReturnValue } from 'prompts';
 import { isCi } from '../env.js';
 
@@ -431,11 +431,11 @@ const handleMissingOrgId = async (
   }
 };
 
-const isOrgIdError = (err: any) => {
+const isOrgIdError = (err: unknown) => {
   return (
-    isAxiosError(err) &&
+    isApiError(err) &&
     err.response?.status == 400 &&
-    err.response?.data?.message?.includes('org_id is required')
+    apiErrorMessage(err)?.includes('org_id is required')
   );
 };
 

--- a/src/commands/schema_diff.ts
+++ b/src/commands/schema_diff.ts
@@ -9,7 +9,7 @@ import {
   PointInTime,
   PointInTimeBranchId,
 } from '../utils/point_in_time.js';
-import { isAxiosError } from 'axios';
+import { apiErrorMessage, isApiError } from '../utils/http.js';
 import { sendError } from '../analytics.js';
 import { log } from '../log.js';
 
@@ -124,11 +124,10 @@ const fetchSchema = async (
     });
     return response.data.sql ?? '';
   } catch (error) {
-    if (isAxiosError(error)) {
-      const data = error.response?.data;
+    if (isApiError(error)) {
       sendError(error, 'API_ERROR');
       throw new Error(
-        data.message ??
+        apiErrorMessage(error) ??
           `Error while fetching schema for branch ${pointInTime.branchId}`,
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,6 @@
 import { basename } from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import axiosDebug from 'axios-debug-log';
-axiosDebug({
-  request(debug, config) {
-    debug(`${config.method?.toUpperCase()} ${config.url}`);
-  },
-  response(debug, response) {
-    debug(`${response.status} ${response.statusText}`);
-  },
-  error(debug, error) {
-    debug(error);
-  },
-});
 import { Api } from '@neondatabase/api-client';
 
 import { ensureAuth, deleteCredentials } from './commands/auth.js';
@@ -30,7 +18,7 @@ import {
   sendError,
   trackEvent,
 } from './analytics.js';
-import { isAxiosError } from 'axios';
+import { apiErrorMessage, isApiError } from './utils/http.js';
 import { matchErrorCode } from './errors.js';
 import { showHelp } from './help.js';
 import { currentContextFile, enrichFromContext } from './context.js';
@@ -189,7 +177,7 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
     log.debug('Stack: %s', err.stack);
   }
 
-  if (isAxiosError(err)) {
+  if (isApiError(err)) {
     if (err.code === 'ECONNABORTED') {
       log.error('Request timed out');
       sendError(err, 'REQUEST_TIMEOUT');
@@ -208,8 +196,9 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
         return false;
       }
     } else {
-      if (err.response?.data?.message) {
-        log.error(err.response?.data?.message);
+      const serverMessage = apiErrorMessage(err);
+      if (serverMessage) {
+        log.error(serverMessage);
       }
       log.debug(
         'status: %d %s | path: %s',

--- a/src/storage_api.ts
+++ b/src/storage_api.ts
@@ -16,10 +16,10 @@ import { type Api } from '@neondatabase/api-client';
 
 export type ApiClient = Api<unknown>;
 
-// The api-client bundles its own axios version, whose `AxiosResponse` type is
-// not assignable to the one neonctl depends on directly. Callers only ever read
-// `.data` (and, for the download helper, `.headers`), so we expose that minimal
-// shape and let the helpers return the client's native promise unchanged.
+// The api-client returns its own (axios-based) response type. neonctl no longer
+// depends on axios directly, and callers only ever read `.data` (and, for the
+// download helper, `.headers`), so we expose that minimal shape and let the
+// helpers return the client's native promise unchanged.
 type ApiResponse<T> = { data: T };
 type ApiResponseWithHeaders<T> = {
   data: T;
@@ -339,9 +339,10 @@ export const deleteProjectBranchBucketObjectsByPrefix = (
  *
  * Returns the URL, the headers that must accompany the PUT for the signature to
  * verify, and the expiry. The actual upload (a `PUT` to the returned `url` with
- * the returned `headers` and the file stream) is performed by the caller, NOT
- * through this api-client, since it targets the branch S3 data-plane endpoint
- * rather than the console API. No SigV4 or credential handling happens here.
+ * the returned `headers` and the file stream) is performed by the caller via a
+ * direct `fetch`, NOT through this api-client, since it targets the branch S3
+ * data-plane endpoint rather than the console API. No SigV4 or credential
+ * handling happens here.
  *
  * The object key may contain `/`; it is percent-encoded into a single path
  * segment so nested keys are routed to the `{object_key}` parameter.

--- a/src/utils/bootstrap.ts
+++ b/src/utils/bootstrap.ts
@@ -1,8 +1,8 @@
-import axios, { isAxiosError } from 'axios';
 import { gunzipSync } from 'fflate';
 import YAML from 'yaml';
 
 import { log } from '../log.js';
+import { httpFetch, isApiError } from './http.js';
 
 /**
  * A scaffold template that lives in a subdirectory of a public GitHub repo we
@@ -218,12 +218,11 @@ export const parseManifest = (text: string): BootstrapTemplate[] => {
 export const fetchTemplates = async (): Promise<BootstrapTemplate[]> => {
   for (const url of manifestUrls()) {
     try {
-      const res = await axios.get<string>(url, {
-        responseType: 'text',
+      const res = await httpFetch(url, {
         headers: downloadHeaders(),
-        timeout: 10_000,
+        timeoutMs: 10_000,
       });
-      const templates = parseManifest(res.data);
+      const templates = parseManifest(await res.text());
       if (templates.length > 0) {
         return templates;
       }
@@ -444,7 +443,7 @@ const tarballUrl = (template: BootstrapTemplate): string => {
 };
 
 const friendlyGithubError = (err: unknown, url: string): Error => {
-  if (isAxiosError(err)) {
+  if (isApiError(err)) {
     const status = err.response?.status;
     if (status === 404) {
       return new Error(
@@ -473,12 +472,11 @@ export const downloadTemplate = async (
 
   let gzipped: Buffer;
   try {
-    const res = await axios.get<ArrayBuffer>(url, {
-      responseType: 'arraybuffer',
+    const res = await httpFetch(url, {
       headers: downloadHeaders(),
-      timeout: 30_000,
+      timeoutMs: 30_000,
     });
-    gzipped = Buffer.from(res.data);
+    gzipped = Buffer.from(await res.arrayBuffer());
   } catch (err) {
     throw friendlyGithubError(err, url);
   }

--- a/src/utils/enrichers.ts
+++ b/src/utils/enrichers.ts
@@ -1,7 +1,8 @@
 import { BranchScopeProps, CommonProps, OrgScopeProps } from '../types.js';
 import { looksLikeBranchId } from './formats.js';
 import { Branch, Database } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+
+import { apiErrorMessage, isApiError } from './http.js';
 
 export const branchIdResolve = async ({
   branch,
@@ -200,9 +201,9 @@ export const fillSingleProject = async (
   } catch (error) {
     // If the API error is about missing org_id, provide a user-friendly message
     if (
-      isAxiosError(error) &&
+      isApiError(error) &&
       error.response?.status === 400 &&
-      error.response?.data?.message?.includes('org_id is required')
+      apiErrorMessage(error)?.includes('org_id is required')
     ) {
       throw new Error(
         'Multiple projects found, please provide one with the --project-id option',

--- a/src/utils/http.test.ts
+++ b/src/utils/http.test.ts
@@ -1,0 +1,299 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { type AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  apiErrorBodyCode,
+  apiErrorMessage,
+  apiErrorRequestId,
+  HttpError,
+  httpFetch,
+  isApiError,
+  streamToWeb,
+} from './http.js';
+
+// ---------------------------------------------------------------------------
+// isApiError: the axios-free replacement for axios' `isAxiosError`. It must
+// detect both our own HttpError and the api-client's axios errors (recognised
+// structurally via the `isAxiosError` marker), and nothing else.
+// ---------------------------------------------------------------------------
+describe('isApiError', () => {
+  it('detects HttpError', () => {
+    expect(isApiError(new HttpError('boom'))).toBe(true);
+  });
+
+  it('detects an axios-shaped error via its isAxiosError marker', () => {
+    // This is exactly what `@neondatabase/api-client` throws: a plain Error
+    // carrying `isAxiosError === true` (from its own bundled axios copy).
+    const axiosLike = Object.assign(new Error('Request failed'), {
+      isAxiosError: true,
+      response: { status: 404 },
+    });
+    expect(isApiError(axiosLike)).toBe(true);
+  });
+
+  it('rejects a plain Error and non-error values', () => {
+    expect(isApiError(new Error('plain'))).toBe(false);
+    expect(isApiError({ isAxiosError: false })).toBe(false);
+    expect(isApiError({})).toBe(false);
+    expect(isApiError(null)).toBe(false);
+    expect(isApiError(undefined)).toBe(false);
+    expect(isApiError('Request failed with status code 500')).toBe(false);
+    expect(isApiError(500)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accessors: pull values out of the (untyped) error body / headers safely,
+// without leaking `any` to call sites.
+// ---------------------------------------------------------------------------
+describe('error accessors', () => {
+  const withBody = (data: unknown, headers: Record<string, unknown> = {}) =>
+    new HttpError('Request failed with status code 400', {
+      response: { status: 400, statusText: 'Bad Request', data, headers },
+    });
+
+  it('reads a non-empty server message', () => {
+    expect(apiErrorMessage(withBody({ message: 'org_id is required' }))).toBe(
+      'org_id is required',
+    );
+  });
+
+  it('ignores empty, non-string, or absent messages', () => {
+    expect(apiErrorMessage(withBody({ message: '' }))).toBeUndefined();
+    expect(apiErrorMessage(withBody({ message: 42 }))).toBeUndefined();
+    expect(apiErrorMessage(withBody({}))).toBeUndefined();
+    expect(apiErrorMessage(withBody('a plain string body'))).toBeUndefined();
+    expect(apiErrorMessage(withBody(undefined))).toBeUndefined();
+    expect(apiErrorMessage(new HttpError('no response'))).toBeUndefined();
+  });
+
+  it('reads a server error code', () => {
+    expect(
+      apiErrorBodyCode(withBody({ code: 'INVALID_SHARED_OAUTH_PROVIDER' })),
+    ).toBe('INVALID_SHARED_OAUTH_PROVIDER');
+    expect(apiErrorBodyCode(withBody({ code: 7 }))).toBeUndefined();
+    expect(apiErrorBodyCode(withBody({}))).toBeUndefined();
+  });
+
+  it('reads the Neon request id header', () => {
+    expect(
+      apiErrorRequestId(
+        withBody({}, { 'x-neon-ret-request-id': 'req-abc-123' }),
+      ),
+    ).toBe('req-abc-123');
+    expect(apiErrorRequestId(withBody({}, {}))).toBeUndefined();
+    expect(apiErrorRequestId(new HttpError('no response'))).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamToWeb: a Node Readable adapted to a web ReadableStream usable as a
+// fetch body, without buffering the whole source.
+// ---------------------------------------------------------------------------
+describe('streamToWeb', () => {
+  it('streams Buffer chunks through unchanged', async () => {
+    const web = streamToWeb(
+      Readable.from([Buffer.from('hello '), Buffer.from('world')]),
+    );
+    expect(await new Response(web).text()).toBe('hello world');
+  });
+
+  it('encodes string chunks as UTF-8', async () => {
+    const web = streamToWeb(Readable.from(['über', '-', 'café']));
+    expect(await new Response(web).text()).toBe('über-café');
+  });
+
+  it('propagates source errors to the consumer', async () => {
+    const failing = new Readable({
+      read() {
+        this.destroy(new Error('disk gone'));
+      },
+    });
+    await expect(new Response(streamToWeb(failing)).text()).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// httpFetch: a real local server stands in for the remote host so the whole
+// request/response/error path runs end to end with no mocking.
+// ---------------------------------------------------------------------------
+describe('httpFetch', () => {
+  let server: Server;
+  let handler: (req: IncomingMessage, res: ServerResponse) => void;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    handler = (_req, res) => res.end('ok');
+    server = createServer((req, res) => {
+      handler(req, res);
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    baseUrl = `http://localhost:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      }),
+    );
+  });
+
+  it('returns the Response for a 2xx and reads the body as text', async () => {
+    handler = (_req, res) => {
+      res.statusCode = 200;
+      res.end('the body');
+    };
+    const res = await httpFetch(`${baseUrl}/ok`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('the body');
+  });
+
+  it('reads a binary body via arrayBuffer', async () => {
+    handler = (_req, res) => {
+      res.statusCode = 200;
+      res.end(Buffer.from([1, 2, 3, 4]));
+    };
+    const res = await httpFetch(`${baseUrl}/bin`);
+    expect([...new Uint8Array(await res.arrayBuffer())]).toEqual([1, 2, 3, 4]);
+  });
+
+  it('forwards request method and headers', async () => {
+    let seen: { method?: string; auth?: string } = {};
+    handler = (req, res) => {
+      seen = { method: req.method, auth: req.headers.authorization };
+      res.end('ok');
+    };
+    await httpFetch(`${baseUrl}/x`, {
+      method: 'GET',
+      headers: { Authorization: 'Bearer t0ken' },
+    });
+    expect(seen.method).toBe('GET');
+    expect(seen.auth).toBe('Bearer t0ken');
+  });
+
+  it('throws an HttpError carrying status, message and parsed JSON body on non-2xx', async () => {
+    handler = (_req, res) => {
+      res.statusCode = 404;
+      res.setHeader('content-type', 'application/json');
+      res.setHeader('x-neon-ret-request-id', 'req-xyz');
+      res.end(JSON.stringify({ message: 'Not Found' }));
+    };
+    const err = await httpFetch(`${baseUrl}/missing`).catch((e: unknown) => e);
+    expect(isApiError(err)).toBe(true);
+    if (!(err instanceof HttpError)) {
+      throw new Error('expected HttpError');
+    }
+    // Message mirrors axios so interpolated user-facing strings are unchanged.
+    expect(err.message).toBe('Request failed with status code 404');
+    expect(err.response?.status).toBe(404);
+    expect(apiErrorMessage(err)).toBe('Not Found');
+    expect(apiErrorRequestId(err)).toBe('req-xyz');
+  });
+
+  it('keeps a non-JSON error body as a raw string', async () => {
+    handler = (_req, res) => {
+      res.statusCode = 403;
+      res.setHeader('content-type', 'text/plain');
+      res.end('Forbidden');
+    };
+    const err = await httpFetch(`${baseUrl}/forbidden`).catch(
+      (e: unknown) => e,
+    );
+    if (!(err instanceof HttpError)) {
+      throw new Error('expected HttpError');
+    }
+    expect(err.response?.status).toBe(403);
+    expect(err.response?.data).toBe('Forbidden');
+    // No JSON message to surface.
+    expect(apiErrorMessage(err)).toBeUndefined();
+  });
+
+  it('times out with an ECONNABORTED code, mirroring axios', async () => {
+    handler = (_req, res) => {
+      // Respond well after the deadline; clean up if the client aborts first.
+      const timer = setTimeout(() => {
+        if (!res.writableEnded) {
+          res.end('late');
+        }
+      }, 1000);
+      res.on('close', () => {
+        clearTimeout(timer);
+      });
+    };
+    const err = await httpFetch(`${baseUrl}/slow`, { timeoutMs: 50 }).catch(
+      (e: unknown) => e,
+    );
+    if (!(err instanceof HttpError)) {
+      throw new Error('expected HttpError');
+    }
+    expect(err.code).toBe('ECONNABORTED');
+    expect(err.message).toContain('timeout of 50ms');
+  });
+
+  it('does not follow redirects (redirect: error) so request bodies are never resent', async () => {
+    handler = (_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', '/elsewhere');
+      res.end();
+    };
+    const err = await httpFetch(`${baseUrl}/redirect`, {
+      redirect: 'error',
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    // A redirect refusal is a transport failure, not an API error with a status.
+    expect(isApiError(err)).toBe(false);
+  });
+
+  it('streams a request body with a manual Content-Length (not chunked)', async () => {
+    let captured: {
+      body?: string;
+      contentLength?: string;
+      transferEncoding?: string;
+      contentType?: string;
+    } = {};
+    handler = (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(Buffer.from(c)));
+      req.on('end', () => {
+        captured = {
+          body: Buffer.concat(chunks).toString('utf8'),
+          contentLength: req.headers['content-length'],
+          transferEncoding: req.headers['transfer-encoding'],
+          contentType: req.headers['content-type'],
+        };
+        res.statusCode = 200;
+        res.end();
+      });
+    };
+
+    const payload = 'streamed upload body';
+    await httpFetch(`${baseUrl}/upload`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/plain',
+        'Content-Length': String(Buffer.byteLength(payload)),
+      },
+      body: streamToWeb(Readable.from([Buffer.from(payload)])),
+      duplex: 'half',
+    });
+
+    expect(captured.body).toBe(payload);
+    expect(captured.contentType).toBe('text/plain');
+    expect(captured.contentLength).toBe(String(Buffer.byteLength(payload)));
+    // The explicit Content-Length must win: the upload is sent framed, not
+    // chunked (the object-storage data plane requires a length).
+    expect(captured.transferEncoding).toBeUndefined();
+  });
+});

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,292 @@
+// HTTP + API error handling for neonctl, free of any direct axios dependency.
+//
+// neonctl no longer depends on axios. Two concerns used to rely on it, and both
+// are handled here:
+//
+//  1. Error detection. The generated Neon API client
+//     (`@neondatabase/api-client`) still uses axios under the hood and rejects
+//     with `AxiosError` instances on non-2xx responses. Rather than import axios
+//     just for `isAxiosError`, this module detects those errors structurally via
+//     the `isAxiosError` marker the client sets, and exposes a small, stable,
+//     axios-free surface (`ApiError` + accessors) that the rest of the CLI uses.
+//
+//  2. Direct requests. The handful of calls neonctl makes itself (GitHub
+//     template downloads, the presigned object-storage upload) go through
+//     {@link httpFetch}, a thin wrapper over the global `fetch` that mirrors the
+//     parts of axios those call sites depended on: it throws on non-2xx (like
+//     axios' default `validateStatus`) with the parsed body attached, supports a
+//     request timeout (surfaced with axios' `ECONNABORTED` code), and logs
+//     request/response lines under DEBUG (replacing axios-debug-log, which only
+//     ever instrumented these direct calls). Errors thrown here are
+//     {@link HttpError}, which implements the same `ApiError` surface, so callers
+//     branch on `.response?.status` uniformly regardless of origin.
+//
+// If the api-client ever drops axios, this file is the only place that needs to
+// change.
+
+import { type Readable } from 'node:stream';
+
+import { log } from '../log.js';
+
+/** The response portion of a normalized API/HTTP error. */
+export type ApiErrorResponse = {
+  /** HTTP status code (always present when a response was received). */
+  status: number;
+  /** HTTP status text (may be empty). */
+  statusText: string;
+  /** Parsed response body (JSON object/array, raw string, or a stream). */
+  data?: unknown;
+  /** Lower-cased response headers. */
+  headers: Record<string, unknown>;
+};
+
+/**
+ * A normalized HTTP/API error: the axios-free shape neonctl relies on. Both the
+ * api-client's `AxiosError` (detected structurally) and {@link HttpError} (our
+ * own `fetch` failures) satisfy this type, so call sites handle them the same
+ * way.
+ */
+export type ApiError = Error & {
+  /** Transport-level error code, e.g. `ECONNABORTED` for a timeout. */
+  code?: string;
+  response?: ApiErrorResponse;
+  request?: { path?: string };
+};
+
+/**
+ * Error thrown by {@link httpFetch} for a non-2xx response or a timeout. The
+ * message mirrors axios (`Request failed with status code <n>`) so user-facing
+ * messages that interpolate it are unchanged after the migration.
+ */
+export class HttpError extends Error implements ApiError {
+  readonly code?: string;
+  readonly response?: ApiErrorResponse;
+  readonly request?: { path?: string };
+
+  constructor(
+    message: string,
+    init: {
+      code?: string;
+      response?: ApiErrorResponse;
+      request?: { path?: string };
+    } = {},
+  ) {
+    super(message);
+    this.name = 'HttpError';
+    this.code = init.code;
+    this.response = init.response;
+    this.request = init.request;
+  }
+}
+
+// axios marks every error it throws with `isAxiosError === true`. The check is
+// instance-agnostic (it's a plain property), which is exactly why neonctl's old
+// `isAxiosError` could detect errors from the api-client's bundled axios copy —
+// and why this structural check is a faithful, dependency-free replacement.
+const hasAxiosErrorMarker = (err: object): boolean =>
+  'isAxiosError' in err && err.isAxiosError === true;
+
+/**
+ * Type guard for a normalized API/HTTP error. True for {@link HttpError} and for
+ * any error carrying axios' `isAxiosError` marker (i.e. thrown by the
+ * api-client). The drop-in replacement for axios' `isAxiosError`.
+ */
+export const isApiError = (err: unknown): err is ApiError => {
+  if (err instanceof HttpError) {
+    return true;
+  }
+  if (typeof err !== 'object' || err === null) {
+    return false;
+  }
+  return hasAxiosErrorMarker(err);
+};
+
+/** The parsed JSON body of an error, when it is a non-null object. */
+const errorBody = (err: ApiError): object | undefined => {
+  const data = err.response?.data;
+  return typeof data === 'object' && data !== null ? data : undefined;
+};
+
+/**
+ * The server-provided `message` from an API error body, when present and a
+ * non-empty string. Mirrors how the Neon console reports errors as
+ * `{ "message": "..." }`.
+ */
+export const apiErrorMessage = (err: ApiError): string | undefined => {
+  const body = errorBody(err);
+  if (body && 'message' in body) {
+    const message = body.message;
+    if (typeof message === 'string' && message !== '') {
+      return message;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The server-provided `code` from an API error body, when present and a string
+ * (e.g. `INVALID_SHARED_OAUTH_PROVIDER`).
+ */
+export const apiErrorBodyCode = (err: ApiError): string | undefined => {
+  const body = errorBody(err);
+  if (body && 'code' in body) {
+    const code = body.code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+  return undefined;
+};
+
+/** The Neon request-id response header, used to correlate failed requests. */
+export const apiErrorRequestId = (err: ApiError): string | undefined => {
+  const value = err.response?.headers['x-neon-ret-request-id'];
+  return typeof value === 'string' ? value : undefined;
+};
+
+// Mirrors axios' timeout error code so existing timeout handling (which keys off
+// `err.code === 'ECONNABORTED'`) keeps working for both api-client and direct
+// requests.
+const TIMEOUT_CODE = 'ECONNABORTED';
+
+export type HttpFetchOptions = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: BodyInit;
+  /** Required by the runtime when streaming a request body. */
+  duplex?: 'half';
+  /** Redirect handling. Defaults to the platform default ('follow'). */
+  redirect?: RequestRedirect;
+  /** Abort the request after this many milliseconds (axios `timeout`). */
+  timeoutMs?: number;
+};
+
+/**
+ * Adapt a Node `Readable` into a web `ReadableStream` usable as a `fetch`
+ * request body. We construct the global `ReadableStream` directly (rather than
+ * `Readable.toWeb`, whose `node:stream/web` return type is not assignable to the
+ * `BodyInit` `fetch` expects) so no cross-stream-type cast is needed and it
+ * works on Node 18+. Pull-based, so it preserves streaming/backpressure and
+ * never buffers the whole source in memory.
+ */
+export const streamToWeb = (readable: Readable): ReadableStream<Uint8Array> => {
+  const iterator = readable[Symbol.asyncIterator]();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { value, done } = await iterator.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        const chunk: unknown = value;
+        if (chunk instanceof Uint8Array) {
+          controller.enqueue(chunk);
+        } else if (typeof chunk === 'string') {
+          controller.enqueue(new TextEncoder().encode(chunk));
+        } else {
+          controller.error(
+            new Error(
+              'Unexpected non-binary chunk while streaming request body',
+            ),
+          );
+        }
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    async cancel(reason) {
+      // Propagate consumer cancellation upstream so the file handle is released.
+      if (typeof iterator.return === 'function') {
+        await iterator.return(reason);
+      }
+    },
+  });
+};
+
+const collectHeaders = (headers: Headers): Record<string, string> => {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+};
+
+const toHttpError = async (res: Response, url: string): Promise<HttpError> => {
+  let data: unknown;
+  try {
+    const text = await res.text();
+    if (text !== '') {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
+  } catch {
+    // Body already consumed or unreadable; status alone is enough to branch on.
+  }
+  return new HttpError(`Request failed with status code ${res.status}`, {
+    response: {
+      status: res.status,
+      statusText: res.statusText,
+      data,
+      headers: collectHeaders(res.headers),
+    },
+    request: { path: url },
+  });
+};
+
+/**
+ * `fetch` with axios-like ergonomics for neonctl's direct requests. Resolves to
+ * the `Response` (the caller reads `.text()` / `.arrayBuffer()` / `.body`) and
+ * throws {@link HttpError} on a non-2xx response or a timeout.
+ */
+export const httpFetch = async (
+  url: string,
+  options: HttpFetchOptions = {},
+): Promise<Response> => {
+  const { timeoutMs, method, headers, body, duplex, redirect } = options;
+
+  const controller =
+    timeoutMs !== undefined ? new AbortController() : undefined;
+  const timer =
+    controller !== undefined && timeoutMs !== undefined
+      ? setTimeout(() => {
+          controller.abort();
+        }, timeoutMs)
+      : undefined;
+
+  log.debug('%s %s', (method ?? 'GET').toUpperCase(), url);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...(method !== undefined ? { method } : {}),
+      ...(headers !== undefined ? { headers } : {}),
+      ...(body !== undefined ? { body } : {}),
+      ...(duplex !== undefined ? { duplex } : {}),
+      ...(redirect !== undefined ? { redirect } : {}),
+      ...(controller !== undefined ? { signal: controller.signal } : {}),
+    });
+  } catch (err) {
+    if (controller?.signal.aborted) {
+      throw new HttpError(`timeout of ${timeoutMs}ms exceeded`, {
+        code: TIMEOUT_CODE,
+        request: { path: url },
+      });
+    }
+    throw err;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+
+  log.debug('%d %s', res.status, res.statusText);
+
+  if (!res.ok) {
+    throw await toHttpError(res, url);
+  }
+  return res;
+};


### PR DESCRIPTION
## Summary

Drops the direct `axios` and `axios-debug-log` dependencies in favor of the global `fetch`, with **no user-facing behavior change**.

`axios` was used in neonctl for two things:
1. **Two direct HTTP calls** — GitHub template downloads (`bootstrap`) and the presigned object-storage upload (`bucket object put`). These talk to GitHub/S3, not the Neon API.
2. **`isAxiosError` / error-shape handling** across ~10 call sites. These actually inspect errors thrown by `@neondatabase/api-client`, which bundles its *own* axios copy and rejects with `AxiosError` on non-2xx. (Confirmed: neonctl resolved `axios@1.7.2` while the api-client resolves its own `axios@1.16.1`; `isAxiosError` worked cross-instance because it only checks the `isAxiosError` marker.)

### Approach: a single normalization seam (`src/utils/http.ts`)

- **`isApiError(err)`** — detects API/HTTP errors *structurally* via the `isAxiosError` marker the client sets, with no axios import. A faithful drop-in for `isAxiosError` that still detects the api-client's errors, and also matches our own `HttpError`.
- **`ApiError` type + typed accessors** (`apiErrorMessage`, `apiErrorBodyCode`, `apiErrorRequestId`) replace ad-hoc `(err.response?.data as { ... })` casts with proper narrowing (no `as`).
- **`httpFetch`** — wraps `fetch` with the axios behaviors the direct calls relied on:
  - throws on non-2xx with the parsed body attached; the message mirrors axios (`Request failed with status code N`) so interpolated user-facing strings are unchanged,
  - `AbortController` timeout surfaced with axios' `ECONNABORTED` code,
  - request/response `DEBUG` logging (replacing `axios-debug-log`, which only ever instrumented these direct calls — the api-client's bundled axios was never patched by it).
- **`streamToWeb`** — adapts a Node `Readable` to a web `ReadableStream` so the upload stays **streamed** (never buffered) with an explicit `Content-Length`. Built on the global `ReadableStream` (not `Readable.toWeb`) so it needs no cross-stream-type cast and works on Node 18+.

`bootstrap.ts` and `bucket.ts` use `httpFetch`; every `isAxiosError` site moves to the seam. **If the api-client ever drops axios, only `http.ts` changes** instead of 8+ call sites.

### Why neonctl first (not api-client)

The api-client is a generated (`swagger-typescript-api`, axios template), published, multi-consumer package; moving it to fetch is a breaking major release. neonctl's direct calls are independent of it, and the seam above makes a future api-client migration a one-file change here. So this PR is self-contained and ships now.

## Test plan

- [x] `pnpm lint` (typecheck + eslint + prettier) clean
- [x] Full suite green: **2984 passed / 7 skipped / 0 failed** (105 files)
- [x] New `src/utils/http.test.ts` — 18 **mock-free** tests against a real local HTTP server: `isApiError` detection, typed accessors, non-2xx → `HttpError` (status/message/JSON + raw-string bodies), `ECONNABORTED` timeout, `redirect: 'error'` refusal, and streamed upload with a manual `Content-Length` (asserts not chunked)
- [x] Existing `bucket`/`bootstrap` e2e tests still pass, including the exact `Request failed with status code 403` message on the upload-failure paths
- [x] **Live e2e against neon.com** (throwaway projects, cleaned up):
  - `bootstrap --list` + real scaffold (fetch GET text from neon.com, gzip arraybuffer from codeload.github.com)
  - `bucket object put/get/list/delete` against **real S3** via the streamed `fetch` PUT and the presigned URL
  - error-translation paths: object/bucket 404, presign 404, `neon-auth status` 404, `functions delete` 404, generic project 404