### PR TITLE
chore(deps): bump @neondatabase/env to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neondatabase/api-client": "2.7.1",
-    "@neondatabase/config": "0.7.2",
-    "@neondatabase/config-runtime": "0.7.2",
-    "@neondatabase/env": "0.5.2",
+    "@neondatabase/config": "0.8.0",
+    "@neondatabase/config-runtime": "0.8.0",
+    "@neondatabase/env": "0.7.0",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       '@neondatabase/config':
-        specifier: 0.7.2
-        version: 0.7.2
+        specifier: 0.8.0
+        version: 0.8.0
       '@neondatabase/config-runtime':
-        specifier: 0.7.2
-        version: 0.7.2
+        specifier: 0.8.0
+        version: 0.8.0
       '@neondatabase/env':
-        specifier: 0.5.2
-        version: 0.5.2
+        specifier: 0.7.0
+        version: 0.7.0
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -884,16 +884,16 @@ packages:
   '@neondatabase/api-client@2.7.1':
     resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
 
-  '@neondatabase/config-runtime@0.7.2':
-    resolution: {integrity: sha512-m8iXgR9SxqMDtIseKqdVeeNCNDhMtOBYZhoX17rSkXzPs9tTgTOwDoqBdmYxzGiYaO9zqr+aq9Wy8/Ize+nxcw==}
+  '@neondatabase/config-runtime@0.8.0':
+    resolution: {integrity: sha512-SVQ4t3UUuSs+SGqBPf8tXoCJHVx2nttCicH5UchYTdrTvaPKEczBWmw1hKYr4sTCbd04AwL6KK42VH9tbOkgMQ==}
     engines: {node: '>=22'}
 
-  '@neondatabase/config@0.7.2':
-    resolution: {integrity: sha512-K9E+/Ah7X9kvoEJlJ0sTOT5UPUPozrtnTSxCs6m3BCycahmhV9eMIuE/e+Pttac97OBpPrMb3dTHANguaow5xw==}
+  '@neondatabase/config@0.8.0':
+    resolution: {integrity: sha512-ReOBVC+9j7X81C6DKtT94wimyHHjPv/LRpGPI2VAcSWSHyT/yGrNSwvT9WwNW1GsUXQNYBJh/3gzUCGhQrTazg==}
     engines: {node: '>=22'}
 
-  '@neondatabase/env@0.5.2':
-    resolution: {integrity: sha512-wvhe5VwrVa8vhlGu4tg4gxv5npUbAo+2U675+cAXMNM6z9Tb9kcxfae7Ke/MnCrZ3+HACviowVFbaCPlOVl0QQ==}
+  '@neondatabase/env@0.7.0':
+    resolution: {integrity: sha512-A5GsnHZm0e6mf9MTB3+Q1TWuNhiAsluOqCsG2M/u9WKMvk9pzRMzN38kZMQ1EKh05UJa7CNNA7bXTr9wtEWwog==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4316,16 +4316,16 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/config-runtime@0.7.2':
+  '@neondatabase/config-runtime@0.8.0':
     dependencies:
-      '@neondatabase/config': 0.7.2
+      '@neondatabase/config': 0.8.0
       esbuild: 0.25.12
       fflate: 0.8.3
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  '@neondatabase/config@0.7.2':
+  '@neondatabase/config@0.8.0':
     dependencies:
       '@neondatabase/api-client': 2.7.1
       jiti: 2.7.0
@@ -4334,9 +4334,9 @@ snapshots:
       - debug
       - supports-color
 
-  '@neondatabase/env@0.5.2':
+  '@neondatabase/env@0.7.0':
     dependencies:
-      '@neondatabase/config': 0.7.2
+      '@neondatabase/config': 0.8.0
       yargs: 18.0.0
       zod: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Why?

Keep `@neondatabase/env` current with the latest published version in the registry. `@neondatabase/env@0.7.0` requires `@neondatabase/config@0.8.0`, which already landed on `main` via #571 — so this PR's net change (after merging `main`) is just the `env` bump.

## What?

- `package.json`: `@neondatabase/env` `0.6.0` -> `0.7.0`
- `pnpm-lock.yaml`: regenerated for the bump (env version + integrity, plus a benign `cosmiconfig-typescript-loader` peer-resolution normalization)

The full test suite passes; `pnpm install --frozen-lockfile` is clean.
