### PR TITLE
chore: bump version to 2.26.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git+ssh://git@github.com/neondatabase/neonctl.git"
   },
   "type": "module",
-  "version": "2.26.6",
+  "version": "2.26.7",
   "description": "CLI tool for NeonDB Cloud management",
   "main": "index.js",
   "author": "NeonDB",


### PR DESCRIPTION
## Why?

#579 bumped `@neondatabase/env` to `0.7.0` but merged without the accompanying patch version bump that change PRs in this repo carry inline (#571 → `2.26.4`, #572 → `2.26.5`, #573 → `2.26.6`). `main` is currently at `2.26.6` despite the merged `env` change, so this brings it up to `2.26.7`.

## What?

- `package.json`: `version` `2.26.6` → `2.26.7`
