### PR TITLE
docs: add "Neon CLI moved" banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> **The Neon CLI has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo (under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli)), and the CLI is being published as the [`neon`](https://www.npmjs.com/package/neon) package.
+>
+> ```shell
+> npm i -g neon
+> ```
+>
+> The `neonctl` package continues to work as an alias. Please open new issues and pull requests in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs).
+
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 
 ## Install the Neon CLI

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-> [!IMPORTANT]
 > **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 > [!IMPORTANT]
-> **The Neon CLI has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo (under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli)), and the CLI is being published as the [`neon`](https://www.npmjs.com/package/neon) package.
->
-> ```shell
-> npm i -g neon
-> ```
->
-> The `neonctl` package continues to work as an alias. Please open new issues and pull requests in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs).
+> **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
+> **The Neon CLI has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 


### PR DESCRIPTION
## Summary

**Layer 1 of the rebrand.** Adds a banner to the top of the README announcing that the Neon CLI has moved to the neondatabase/neon-pkgs monorepo (`packages/cli`), and directs new issues/PRs there.

Scoped to the move only — no mention of the `neon` package yet (that comes in a stacked follow-up once the CLI is republished as `neon`).

Related: neondatabase/neon-pkgs#237.

## Test plan

- [ ] Banner renders correctly on the GitHub repo homepage