### PR TITLE
docs: point banner to the `neon` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!IMPORTANT]
+> **The Neon CLI has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo (under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli)), and the CLI is being published as the [`neon`](https://www.npmjs.com/package/neon) package.
+>
+> ```shell
+> npm i -g neon
+> ```
+>
+> The `neonctl` package continues to work as an alias. Please open new issues and pull requests in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs).
+
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 
 ## Install the Neon CLI

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-> [!IMPORTANT]
 > **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 > [!IMPORTANT]
-> **The Neon CLI has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo (under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli)), and the CLI is being published as the [`neon`](https://www.npmjs.com/package/neon) package.
->
-> ```shell
-> npm i -g neon
-> ```
->
-> The `neonctl` package continues to work as an alias. Please open new issues and pull requests in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs).
+> **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 > [!IMPORTANT]
-> **The Neon CLI source has moved.** Development now happens in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli). Please open new issues and pull requests there.
+> **The Neon CLI is now `neon`.** It is published as the [`neon`](https://www.npmjs.com/package/neon) package and developed in the [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs) monorepo, under [`packages/cli`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/cli).
+>
+> ```shell
+> npm i -g neon
+> ```
+>
+> The `neonctl` package keeps working and forwards to `neon`. Please open new issues and pull requests in [`neondatabase/neon-pkgs`](https://github.com/neondatabase/neon-pkgs).
 
 The Neon CLI is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 


### PR DESCRIPTION
> **Layer 2 — stacked on #585** (base branch `docs/cli-has-moved-banner`). Merge #585 first.

## Summary

Updates the README banner to announce the CLI is now published as **`neon`** (`npm i -g neon`), with `neonctl` continuing to work as a forwarding alias.

Pairs with the npm-side rename in neondatabase/neon-pkgs#238.

## Test plan

- [ ] Banner renders correctly on the GitHub repo homepage